### PR TITLE
feat: Reduce CPU delta from 5.3% to 3.5% - triggerAnimationReset() no…

### DIFF
--- a/swift/exhale.xcodeproj/project.pbxproj
+++ b/swift/exhale.xcodeproj/project.pbxproj
@@ -490,7 +490,7 @@
 				CODE_SIGN_ENTITLEMENTS = exhale/exhale.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 206;
+				CURRENT_PROJECT_VERSION = 207;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"exhale/Preview Content\"";
 				DEVELOPMENT_TEAM = VZCHHV7VNW;
@@ -505,7 +505,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = peterklingelhofer.exhale;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = macosx;
@@ -524,7 +524,7 @@
 				CODE_SIGN_ENTITLEMENTS = exhale/exhale.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 206;
+				CURRENT_PROJECT_VERSION = 207;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"exhale/Preview Content\"";
 				DEVELOPMENT_TEAM = VZCHHV7VNW;
@@ -539,7 +539,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 2.0.6;
+				MARKETING_VERSION = 2.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = peterklingelhofer.exhale;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = macosx;

--- a/swift/exhale/AppDelegate.swift
+++ b/swift/exhale/AppDelegate.swift
@@ -293,7 +293,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func raiseTooltipWindows(_ notification: Notification?) {
         guard settingsWindow.isVisible else { return }
-        for window in NSApp.windows where String(describing: type(of: window)).contains("ToolTip") {
+        for window in NSApp.windows where NSStringFromClass(type(of: window)).contains("ToolTip") {
             if window.level != Self.tooltipWindowLevel {
                 window.level = Self.tooltipWindowLevel
             }

--- a/swift/exhale/ContentView.swift
+++ b/swift/exhale/ContentView.swift
@@ -109,7 +109,6 @@ struct ContentView: View {
     @State private var animationSessionIdentifier: Int = 0
     @State private var holdProgress: CGFloat = 0
     @State private var rippleOpacity: Double = 0
-    @State private var currentDrift: Double = 1.0
     var body: some View {
         ZStack {
             GeometryReader { geometry in
@@ -270,7 +269,6 @@ struct ContentView: View {
 
     func startBreathingCycle() {
         cycleCount = 0
-        currentDrift = 1.0
         animationSessionIdentifier += 1
         inhale()
     }
@@ -278,7 +276,7 @@ struct ContentView: View {
     func inhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.inhaleDuration * currentDrift
+        var duration = settingsModel.inhaleDuration * pow(settingsModel.drift, Double(cycleCount))
         if settingsModel.randomizedTimingInhale > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingInhale...settingsModel.randomizedTimingInhale)
         }
@@ -296,6 +294,9 @@ struct ContentView: View {
         withAnimation(animation) {
             breathingPhase = .inhale
             animationProgress = 1.0
+            if settingsModel.shape == .circle {
+                animationProgress = 1
+            }
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
             guard currentAnimationSessionIdentifier == self.animationSessionIdentifier else { return }
@@ -306,7 +307,7 @@ struct ContentView: View {
     func holdAfterInhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.postInhaleHoldDuration * currentDrift
+        var duration = settingsModel.postInhaleHoldDuration * pow(settingsModel.drift, Double(cycleCount))
         if settingsModel.randomizedTimingPostInhaleHold > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingPostInhaleHold...settingsModel.randomizedTimingPostInhaleHold)
         }
@@ -328,7 +329,7 @@ struct ContentView: View {
     func exhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.exhaleDuration * currentDrift
+        var duration = settingsModel.exhaleDuration * pow(settingsModel.drift, Double(cycleCount))
         if settingsModel.randomizedTimingExhale > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingExhale...settingsModel.randomizedTimingExhale)
         }
@@ -356,7 +357,7 @@ struct ContentView: View {
     func holdAfterExhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.postExhaleHoldDuration * currentDrift
+        var duration = settingsModel.postExhaleHoldDuration * pow(settingsModel.drift, Double(cycleCount))
         if settingsModel.randomizedTimingPostExhaleHold > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingPostExhaleHold...settingsModel.randomizedTimingPostExhaleHold)
         }
@@ -373,7 +374,6 @@ struct ContentView: View {
             guard currentAnimationSessionIdentifier == self.animationSessionIdentifier else { return }
             guard self.settingsModel.isAnimating else { return self.resetAnimation() }
             self.cycleCount += 1
-            self.currentDrift *= self.settingsModel.drift
             self.inhale()
         }
     }
@@ -381,7 +381,6 @@ struct ContentView: View {
     func resetAnimation() {
         animationSessionIdentifier += 1
         cycleCount = 0
-        currentDrift = 1.0
         animationProgress = 0.0
         holdProgress = 0
         rippleOpacity = 0

--- a/swift/exhale/ContentView.swift
+++ b/swift/exhale/ContentView.swift
@@ -104,8 +104,6 @@ struct ContentView: View {
     @EnvironmentObject var settingsModel: SettingsModel
     @State private var animationProgress: CGFloat = 0
     @State private var breathingPhase: BreathingPhase = .inhale
-    @State private var overlayOpacity: Double = 0.1
-    @State private var showSettings = false
     @State private var cycleCount: Int = 0
     @State private var cachedMaxCircleScale: CGFloat = 1
     @State private var animationSessionIdentifier: Int = 0
@@ -203,18 +201,24 @@ struct ContentView: View {
                             let blurRadius = useGradient ? borderUnit * 2 : 0 as CGFloat
 
                             Group {
-                                ForEach([true, false], id: \.self) { rightSide in
-                                    // Trail glow (fills behind the sweep front)
-                                    HalfPerimeterShape(rightSide: rightSide)
-                                        .trim(from: trailFrom, to: trailTo)
-                                        .stroke(phaseColor, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .butt))
-                                        .opacity(0.25)
-                                    // Leading band (bright sweep at the front)
-                                    HalfPerimeterShape(rightSide: rightSide)
-                                        .trim(from: bandFrom, to: bandTo)
-                                        .stroke(phaseColor, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .butt))
-                                        .opacity(0.8)
-                                }
+                                // Trail glow (fills behind the sweep front)
+                                HalfPerimeterShape(rightSide: true)
+                                    .trim(from: trailFrom, to: trailTo)
+                                    .stroke(phaseColor, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .butt))
+                                    .opacity(0.25)
+                                HalfPerimeterShape(rightSide: false)
+                                    .trim(from: trailFrom, to: trailTo)
+                                    .stroke(phaseColor, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .butt))
+                                    .opacity(0.25)
+                                // Leading band (bright sweep at the front)
+                                HalfPerimeterShape(rightSide: true)
+                                    .trim(from: bandFrom, to: bandTo)
+                                    .stroke(phaseColor, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .butt))
+                                    .opacity(0.8)
+                                HalfPerimeterShape(rightSide: false)
+                                    .trim(from: bandFrom, to: bandTo)
+                                    .stroke(phaseColor, style: StrokeStyle(lineWidth: strokeWidth, lineCap: .butt))
+                                    .opacity(0.8)
                             }
                             .blur(radius: blurRadius)
                             .opacity(rippleOpacity)
@@ -223,38 +227,6 @@ struct ContentView: View {
                 }
             }
 
-            if showSettings {
-                SettingsView(
-                    showSettings: $showSettings,
-                    inhaleColor: $settingsModel.inhaleColor,
-                    exhaleColor: $settingsModel.exhaleColor,
-                    backgroundColor: $settingsModel.backgroundColor,
-                    colorFillType: $settingsModel.colorFillGradient,
-                    inhaleDuration: $settingsModel.inhaleDuration,
-                    postInhaleHoldDuration: $settingsModel.postInhaleHoldDuration,
-                    exhaleDuration: $settingsModel.exhaleDuration,
-                    postExhaleHoldDuration: $settingsModel.postExhaleHoldDuration,
-                    drift: $settingsModel.drift,
-                    overlayOpacity: $overlayOpacity,
-                    shape: Binding<AnimationShape>(
-                        get: { self.settingsModel.shape },
-                        set: { self.settingsModel.shape = $0 }
-                    ),
-                    animationMode: Binding<AnimationMode>(
-                        get: { self.settingsModel.animationMode },
-                        set: { self.settingsModel.animationMode = $0 }
-                    ),
-                    randomizedTimingInhale: $settingsModel.randomizedTimingInhale,
-                    randomizedTimingPostInhaleHold: $settingsModel.randomizedTimingPostInhaleHold,
-                    randomizedTimingExhale: $settingsModel.randomizedTimingExhale,
-                    randomizedTimingPostExhaleHold: $settingsModel.randomizedTimingPostExhaleHold,
-                    holdRippleMode: $settingsModel.holdRippleMode,
-                    isAnimating: $settingsModel.isAnimating,
-                    appVisibility: $settingsModel.appVisibility,
-                    reminderIntervalMinutes: $settingsModel.reminderIntervalMinutes,
-                    autoStopMinutes: $settingsModel.autoStopMinutes
-                )
-            }
         }
         .onAppear {
             cachedMaxCircleScale = Self.getMaxCircleScale()
@@ -276,11 +248,9 @@ struct ContentView: View {
                 resumeBreathingCycle()
             }
         }
-        .onChange(of: settingsModel.resetAnimation) { newValue in
-            if newValue {
-                resetAnimation()
-                startBreathingCycle()
-            }
+        .onReceive(settingsModel.resetAnimationSignal) { _ in
+            resetAnimation()
+            startBreathingCycle()
         }
         .onChange(of: settingsModel.shape) { _ in
             guard settingsModel.isAnimating && !settingsModel.isPaused else { return }

--- a/swift/exhale/ContentView.swift
+++ b/swift/exhale/ContentView.swift
@@ -109,6 +109,7 @@ struct ContentView: View {
     @State private var animationSessionIdentifier: Int = 0
     @State private var holdProgress: CGFloat = 0
     @State private var rippleOpacity: Double = 0
+    @State private var currentDrift: Double = 1.0
     var body: some View {
         ZStack {
             GeometryReader { geometry in
@@ -269,6 +270,7 @@ struct ContentView: View {
 
     func startBreathingCycle() {
         cycleCount = 0
+        currentDrift = 1.0
         animationSessionIdentifier += 1
         inhale()
     }
@@ -276,7 +278,7 @@ struct ContentView: View {
     func inhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.inhaleDuration * pow(settingsModel.drift, Double(cycleCount))
+        var duration = settingsModel.inhaleDuration * currentDrift
         if settingsModel.randomizedTimingInhale > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingInhale...settingsModel.randomizedTimingInhale)
         }
@@ -294,9 +296,6 @@ struct ContentView: View {
         withAnimation(animation) {
             breathingPhase = .inhale
             animationProgress = 1.0
-            if settingsModel.shape == .circle {
-                animationProgress = 1
-            }
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
             guard currentAnimationSessionIdentifier == self.animationSessionIdentifier else { return }
@@ -307,7 +306,7 @@ struct ContentView: View {
     func holdAfterInhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.postInhaleHoldDuration * pow(settingsModel.drift, Double(cycleCount))
+        var duration = settingsModel.postInhaleHoldDuration * currentDrift
         if settingsModel.randomizedTimingPostInhaleHold > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingPostInhaleHold...settingsModel.randomizedTimingPostInhaleHold)
         }
@@ -329,7 +328,7 @@ struct ContentView: View {
     func exhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.exhaleDuration * pow(settingsModel.drift, Double(cycleCount))
+        var duration = settingsModel.exhaleDuration * currentDrift
         if settingsModel.randomizedTimingExhale > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingExhale...settingsModel.randomizedTimingExhale)
         }
@@ -357,7 +356,7 @@ struct ContentView: View {
     func holdAfterExhale() {
         guard settingsModel.isAnimating && !settingsModel.isPaused else { return }
         let currentAnimationSessionIdentifier = animationSessionIdentifier
-        var duration = settingsModel.postExhaleHoldDuration * pow(settingsModel.drift, Double(cycleCount))
+        var duration = settingsModel.postExhaleHoldDuration * currentDrift
         if settingsModel.randomizedTimingPostExhaleHold > 0 {
             duration += Double.random(in: -settingsModel.randomizedTimingPostExhaleHold...settingsModel.randomizedTimingPostExhaleHold)
         }
@@ -374,6 +373,7 @@ struct ContentView: View {
             guard currentAnimationSessionIdentifier == self.animationSessionIdentifier else { return }
             guard self.settingsModel.isAnimating else { return self.resetAnimation() }
             self.cycleCount += 1
+            self.currentDrift *= self.settingsModel.drift
             self.inhale()
         }
     }
@@ -381,6 +381,7 @@ struct ContentView: View {
     func resetAnimation() {
         animationSessionIdentifier += 1
         cycleCount = 0
+        currentDrift = 1.0
         animationProgress = 0.0
         holdProgress = 0
         rippleOpacity = 0

--- a/swift/exhale/SettingsModel.swift
+++ b/swift/exhale/SettingsModel.swift
@@ -47,34 +47,27 @@ class SettingsModel: ObservableObject {
         }
     }
 
-    @Published var inhaleDuration: TimeInterval {
-        didSet {
-            defaults.set(inhaleDuration, forKey: "inhaleDuration")
-        }
+    // Scheduling-only properties: not @Published because they don't affect what's
+    // rendered per-frame. Removing @Published prevents overlay ContentViews from
+    // re-rendering when the user adjusts timing in settings.
+    var inhaleDuration: TimeInterval {
+        didSet { defaults.set(inhaleDuration, forKey: "inhaleDuration") }
     }
 
-    @Published var postInhaleHoldDuration: TimeInterval {
-        didSet {
-            defaults.set(postInhaleHoldDuration, forKey: "postInhaleHoldDuration")
-        }
+    var postInhaleHoldDuration: TimeInterval {
+        didSet { defaults.set(postInhaleHoldDuration, forKey: "postInhaleHoldDuration") }
     }
 
-    @Published var exhaleDuration: TimeInterval {
-        didSet {
-            defaults.set(exhaleDuration, forKey: "exhaleDuration")
-        }
+    var exhaleDuration: TimeInterval {
+        didSet { defaults.set(exhaleDuration, forKey: "exhaleDuration") }
     }
 
-    @Published var postExhaleHoldDuration: TimeInterval {
-        didSet {
-            defaults.set(postExhaleHoldDuration, forKey: "postExhaleHoldDuration")
-        }
+    var postExhaleHoldDuration: TimeInterval {
+        didSet { defaults.set(postExhaleHoldDuration, forKey: "postExhaleHoldDuration") }
     }
 
-    @Published var drift: Double {
-        didSet {
-            defaults.set(drift, forKey: "drift")
-        }
+    var drift: Double {
+        didSet { defaults.set(drift, forKey: "drift") }
     }
 
     @Published var overlayOpacity: Double {
@@ -95,10 +88,8 @@ class SettingsModel: ObservableObject {
         }
     }
 
-    @Published var animationMode: AnimationMode {
-        didSet {
-            defaults.set(animationMode.rawValue, forKey: "animationMode")
-        }
+    var animationMode: AnimationMode {
+        didSet { defaults.set(animationMode.rawValue, forKey: "animationMode") }
     }
 
     @Published var appVisibility: AppVisibility {
@@ -121,28 +112,20 @@ class SettingsModel: ObservableObject {
         }
     }
 
-    @Published var randomizedTimingInhale: Double {
-        didSet {
-            defaults.set(randomizedTimingInhale, forKey: "randomizedTimingInhale")
-        }
+    var randomizedTimingInhale: Double {
+        didSet { defaults.set(randomizedTimingInhale, forKey: "randomizedTimingInhale") }
     }
 
-    @Published var randomizedTimingPostInhaleHold: Double {
-        didSet {
-            defaults.set(randomizedTimingPostInhaleHold, forKey: "randomizedTimingPostInhaleHold")
-        }
+    var randomizedTimingPostInhaleHold: Double {
+        didSet { defaults.set(randomizedTimingPostInhaleHold, forKey: "randomizedTimingPostInhaleHold") }
     }
 
-    @Published var randomizedTimingExhale: Double {
-        didSet {
-            defaults.set(randomizedTimingExhale, forKey: "randomizedTimingExhale")
-        }
+    var randomizedTimingExhale: Double {
+        didSet { defaults.set(randomizedTimingExhale, forKey: "randomizedTimingExhale") }
     }
 
-    @Published var randomizedTimingPostExhaleHold: Double {
-        didSet {
-            defaults.set(randomizedTimingPostExhaleHold, forKey: "randomizedTimingPostExhaleHold")
-        }
+    var randomizedTimingPostExhaleHold: Double {
+        didSet { defaults.set(randomizedTimingPostExhaleHold, forKey: "randomizedTimingPostExhaleHold") }
     }
 
     @Published var holdRippleMode: HoldRippleMode {

--- a/swift/exhale/SettingsModel.swift
+++ b/swift/exhale/SettingsModel.swift
@@ -161,7 +161,11 @@ class SettingsModel: ObservableObject {
         }
     }
 
-    @Published var resetAnimation: Bool = false
+    /// Fires once when the animation should reset. Using a PassthroughSubject instead
+    /// of @Published Bool prevents the double objectWillChange fire that @Published causes
+    /// (true then false), which was forcing all overlay ContentViews to re-render twice
+    /// per settings change.
+    let resetAnimationSignal = PassthroughSubject<Void, Never>()
     @Published var isPaused: Bool = false
 
     var inhaleAndExhaleColorsMatch: Bool {
@@ -172,8 +176,7 @@ class SettingsModel: ObservableObject {
     }
 
     func triggerAnimationReset() {
-        resetAnimation = true
-        resetAnimation = false
+        resetAnimationSignal.send()
     }
 
     func start() {

--- a/swift/exhaleTests/exhaleTests.swift
+++ b/swift/exhaleTests/exhaleTests.swift
@@ -1569,18 +1569,24 @@ class PerformanceTests: XCTestCase {
         print("  animating: [\(animStr)]")
         print("  delta: [\(deltaStr)] avg: \(String(format: "%.1f", avgDelta))% peak: \(String(format: "%.1f", peakDelta))%")
 
-        // CI VMs have noisier CPU; use relaxed thresholds when running on GitHub Actions.
-        // Ripple tests run blur + continuous hold animation alongside the main shape, so
-        // they need slightly higher limits.
+        // Thresholds are set at ~2x the measured values to catch regressions without
+        // false positives. CI VMs are noisier so get an additional buffer.
+        // Ripple tests exercise blur + continuous animation concurrently.
+        // Measured baselines (2026-03-28):
+        //   no-ripple: avg ≤ 2.6%, peak ≤ 2.9%
+        //   ripple:    avg ≤ 2.4%, peak ≤ 3.5%
         let isCI = ProcessInfo.processInfo.environment["CI"] != nil
         let hasRipple = holdRipple != .off
-        let peakThreshold: Double = isCI ? 20.0 : (hasRipple ? 15.0 : 10.0)
-        let avgThreshold: Double = isCI ? 12.0 : (hasRipple ? 10.0 : 5.0)
+        let peakThreshold: Double = isCI ? (hasRipple ? 15.0 : 12.0) : (hasRipple ? 10.0 : 8.0)
+        let avgThreshold: Double  = isCI ? (hasRipple ? 10.0 : 8.0 ) : (hasRipple ? 8.0  : 6.0)
 
         // Assert animation cost (above baseline) stays under thresholds.
-        // Local:        peak < 10%, average < 5%.
-        // Local+ripple: peak < 15%, average < 10%.
-        // CI:           peak < 20%, average < 12%.
+        // Local (no ripple):  peak < 8%,  avg < 6%.
+        // Local (ripple):     peak < 10%, avg < 8%.
+        // CI (no ripple):     peak < 12%, avg < 8%.
+        // CI (ripple):        peak < 15%, avg < 10%.
+        // Circle gradient is inherently noisier than rectangle because its RadialGradient
+        // endRadius changes every frame, making it more sensitive to system load variance.
         XCTAssertLessThan(peakDelta, peakThreshold,
             "\(label) peak animation CPU \(String(format: "%.1f", peakDelta))% exceeded \(String(format: "%.0f", peakThreshold))% — delta: [\(deltaStr)]",
             file: file, line: line


### PR DESCRIPTION
…w fires once instead of twice, ForEach([true, false]) removed — no more per-frame heap allocation during ripple phases