### PR TITLE
fix(render): kill dark band at rectangle/circle gradient edges on Tahoe

### DIFF
--- a/rust/crates/exhale-render/src/shaders/overlay.wgsl
+++ b/rust/crates/exhale-render/src/shaders/overlay.wgsl
@@ -123,38 +123,50 @@ fn ripple_color() -> vec4<f32> {
 
 /// Gradient mode: Off=0, Inner=1, On=2
 
-fn gradient_circle(base: vec4<f32>, pixel: vec2<f32>, bg: vec4<f32>) -> vec4<f32> {
+fn gradient_circle(base: vec4<f32>, pixel: vec2<f32>, _bg: vec4<f32>) -> vec4<f32> {
     let center   = u.viewport_size * 0.5;
     let min_dim  = min(u.viewport_size.x, u.viewport_size.y);
     let prog_sq  = u.progress * u.progress;
     let radius   = max((min_dim * prog_sq * u.max_circle_scale) * 0.5, 0.001);
     let dist    = length(pixel - center);
 
-    if u.gradient_mode == 1u { // Inner
-        return lerp_color(bg, base, clamp01(dist / radius));
+    // Same wallpaper-bleed fix as `gradient_rectangle`: hold base.rgb
+    // constant and fade only alpha so transparent zones at the gradient's
+    // endpoints don't reveal a dark wallpaper as a perceived "ring."
+    // Smoothstep softens the visual falloff
+    if u.gradient_mode == 1u { // Inner: center invisible → outer edge fully base
+        let t = smoothstep(0.0, 1.0, clamp01(dist / radius));
+        return vec4<f32>(base.rgb, base.a * t);
     }
 
-    // On: radial from center, peaks at midpoint
+    // On: radial bell, peaks at the half-radius mark, falls off symmetrically
     let ext_r = radius * max(u.circle_gradient_scale, 1.0);
-    let t     = clamp01(dist / ext_r);
-    if t <= 0.5 {
-        return lerp_color(bg, base, t * 2.0);
-    }
-    return lerp_color(base, bg, (t - 0.5) * 2.0);
+    let r01   = clamp01(dist / ext_r);
+    let dist_from_mid = abs(r01 - 0.5) * 2.0;
+    let t     = smoothstep(0.0, 1.0, 1.0 - dist_from_mid);
+    return vec4<f32>(base.rgb, base.a * t);
 }
 
-fn gradient_rectangle(base: vec4<f32>, pixel: vec2<f32>, rect_h: f32, bg: vec4<f32>) -> vec4<f32> {
+fn gradient_rectangle(base: vec4<f32>, pixel: vec2<f32>, rect_h: f32, _bg: vec4<f32>) -> vec4<f32> {
     let y01 = clamp01(pixel.y / max(rect_h, 1.0));
 
-    if u.gradient_mode == 1u { // Inner: bottom=bg → top=base
-        return lerp_color(bg, base, y01);
+    // Both modes fade the BASE color's alpha rather than lerping toward bg's
+    // RGB. With the default `background_color = [0,0,0,0]`, lerping toward bg
+    // produces (rgb=0, low alpha) at the rectangle's edges, which composites
+    // over dark wallpapers (notably Tahoe's new desktop visuals) as visible
+    // black bands at the top + bottom of the shape. Holding base.rgb constant
+    // and fading only alpha keeps any wallpaper bleed-through harmonious
+    // with the base hue. Smoothstep softens the falloff so the transition
+    // isn't a perceptual band even on darker wallpapers
+    if u.gradient_mode == 1u { // Inner: bottom invisible → top fully base
+        let t = smoothstep(0.0, 1.0, y01);
+        return vec4<f32>(base.rgb, base.a * t);
     }
 
-    // On: bottom=bg, middle=base, top=bg
-    if y01 <= 0.5 {
-        return lerp_color(bg, base, y01 * 2.0);
-    }
-    return lerp_color(base, bg, (y01 - 0.5) * 2.0);
+    // On: bell-shaped alpha, peaks in the middle, falls off symmetrically
+    let dist = abs(y01 - 0.5) * 2.0;   // 0 at middle, 1 at top/bottom edges
+    let t    = smoothstep(0.0, 1.0, 1.0 - dist);
+    return vec4<f32>(base.rgb, base.a * t);
 }
 
 // ─── Screen-edge ripple ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- On macOS Tahoe (and any setup with a dark wallpaper), the rectangle and circle gradients showed a perceptible dark band at their fade-out edges
- Root cause: the shader was lerping toward \`bg.rgb\` (default black, opacity 0) as alpha dropped, so partial-alpha pixels near the edges were double-dimmed (alpha decay + RGB darkening toward black). Composited over a dark wallpaper, that read as a visible dark line
- Fix: hold \`base.rgb\` constant across the gradient and fade only alpha, with a smoothstep curve for a softer perceptual falloff. The fully-transparent edge itself is unchanged (still shows wallpaper); the partial-alpha zone leading up to it no longer darkens through black
- Applied to both \`gradient_rectangle\` and \`gradient_circle\` for consistency (Circle had the same latent bug)

## Test plan
- [ ] Open Preferences → Shape = Rectangle → Gradient = On → confirm no dark band at top/bottom edges
- [ ] Same with Gradient = Inner
- [ ] Switch to Shape = Circle, repeat both gradient modes, confirm no dark ring at the outer edge
- [ ] Verify default Off gradient is visually unchanged