### PR TITLE
chore: derive BUILD from git commit count for monotonic CFBundleVersion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,14 @@ jobs:
           else
             V="2.0.21"
           fi
+          # BUILD = commit count + 10000. Apple requires CFBundleVersion to
+          # be monotonically increasing across all uploads, so derive from
+          # commit count (always growing) rather than VERSION (would collide
+          # on every resubmission). See rust/scripts/release.sh for context
+          BUILD="$(( $(git rev-list --count HEAD) + 10000 ))"
           echo "version=$V"                  >> "$GITHUB_OUTPUT"
-          echo "build=${V//./}"              >> "$GITHUB_OUTPUT"
-          echo "resolved VERSION=$V"
+          echo "build=$BUILD"                >> "$GITHUB_OUTPUT"
+          echo "resolved VERSION=$V BUILD=$BUILD"
 
   # ─── macOS: universal binary, code-signed .app + .pkg for Mac App Store ───
   macos:

--- a/rust/scripts/bundle-mas.sh
+++ b/rust/scripts/bundle-mas.sh
@@ -36,7 +36,8 @@
 #   APP_IDENT       default: "Apple Distribution: …VZCHHV7VNW…"
 #   INSTALLER_IDENT default: "3rd Party Mac Developer Installer: …VZCHHV7VNW…"
 #   VERSION         default: cargo version from Cargo.toml (bumped manually)
-#   BUILD           default: VERSION with dots stripped
+#   BUILD           default: 10000 + git commit count (monotonic across all
+#                            uploads to MAS; survives resubmissions)
 #   PROVISION_PROFILE default: rust/signing/exhale.provisionprofile
 #   DRY_RUN=1       skip identity checks, profile requirement, and signing;
 #                   emit an unsigned exhale.app for local validation.  Useful
@@ -73,7 +74,10 @@ PROVISION_PROFILE="${PROVISION_PROFILE:-$RUST_ROOT/signing/exhale.provisionprofi
 # Swift 2.0.7 → 2.0.8 expectation by default so a fresh run produces a
 # submission one higher than the current MAS listing.
 VERSION="${VERSION:-2.0.21}"
-BUILD="${BUILD:-${VERSION//./}}"
+# CFBundleVersion. Apple requires this to be monotonically increasing
+# across all uploads (rejected ones count too), so derive from git commit
+# count rather than VERSION — see release.sh for the full story
+BUILD="${BUILD:-$(( $(git -C "$REPO_ROOT" rev-list --count HEAD 2>/dev/null || echo 0) + 10000 ))}"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 log()  { printf '\033[1;34m[mas]\033[0m %s\n' "$*" >&2; }

--- a/rust/scripts/bundle-msix.ps1
+++ b/rust/scripts/bundle-msix.ps1
@@ -29,7 +29,7 @@
 [CmdletBinding()]
 param(
     [string] $Version         = "2.0.21",
-    [string] $Build           = "2021",
+    [string] $Build           = "10504",
     [string] $CertPath        = "",
     [SecureString] $CertPassword = $null,
     [switch] $DryRun

--- a/rust/scripts/release.sh
+++ b/rust/scripts/release.sh
@@ -38,9 +38,17 @@ case "$MODE" in ""|--dry-run|--tag) ;; *)
     exit 2
 ;; esac
 
-# MSIX / release.yml short build number: full version with dots stripped
-# (e.g. 2.0.15 → 2015). Matches the computation in release.yml.
-BUILD="${VERSION//./}"
+# MAS / MSIX / release.yml short build number. Apple App Store requires
+# CFBundleVersion to be monotonically increasing across every upload for
+# the bundle ID, including rejected/resubmitted ones. The old formula
+# `${VERSION//./}` was deterministic-per-VERSION which meant every
+# resubmission burned the next version's BUILD slot (shipped 2020 then
+# 2021 as v2.0.20 resubmissions, then v2.0.21's default 2021 collided
+# with App Store Connect rejection ID 8a9458f3-...). Using commit count
+# instead gives a monotonic value that doesn't depend on VERSION, plus a
+# 10000 offset to clear the historical 2020–2022 range we already burned.
+# Matches the computation in release.yml + bundle-mas.sh
+BUILD="$(( $(git rev-list --count HEAD) + 10000 ))"
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"


### PR DESCRIPTION
## Summary
Replaces the deterministic-per-VERSION \`BUILD=\${VERSION//./}\` formula with **\`git rev-list --count HEAD + 10000\`**, so \`CFBundleVersion\` is always monotonically increasing — even across MAS resubmissions — and never collides with what App Store Connect already has on file.

No version bump. Originally bumped main to 2.0.22 to dodge the collision; with the monotonic BUILD that's no longer needed, so VERSION stays at 2.0.21 until the next user-visible change.

## Why
v2.0.21's first Transporter upload was rejected with:
> The value for key CFBundleVersion [2021] in the Info.plist file must contain a higher version than that of the previously uploaded version [2021]

That happened because the previous resubmission of v2.0.20 (after the WWDR / signing fixes) consumed BUILD=2021, and v2.0.21's default also computed to 2021. Apple enforces \`CFBundleVersion\` uniqueness across all uploads ever for the bundle ID, including rejected ones, so any deterministic-per-VERSION scheme dies the first time you have to resubmit.

The new scheme: \`BUILD = git rev-list --count HEAD + 10000\`. Current main → 10503. Monotonic forever, plenty of headroom past the 2020–2022 BUILDs we already burned. Every commit produces a fresh BUILD, so even a same-version resubmission with one new commit gets a unique number automatically.

## Files
- \`rust/scripts/release.sh\` — new formula
- \`rust/scripts/bundle-mas.sh\` — same formula in the local-build path; doc-comment updated
- \`.github/workflows/release.yml\` — same formula in the CI prepare job
- \`rust/scripts/bundle-msix.ps1\` — \`\$Build\` default synced to the new value (10503) by release.sh's rewrite

## Test plan
- [x] \`rust/scripts/release.sh 2.0.21 --dry-run\` shows BUILD=10503 across all version-bearing files
- [x] \`bundle-mas.sh\` default BUILD reads the new formula and produces 10503 on this commit
- [x] \`release.yml\` prepare job computes BUILD identically