### PR TITLE
fix(mac): disable overlay NSWindow shadow to remove gray line on Tahoe

### DIFF
--- a/rust/crates/exhale-app/src/platform/mac.rs
+++ b/rust/crates/exhale-app/src/platform/mac.rs
@@ -98,6 +98,16 @@ use super::*;
         ns_win.setIgnoresMouseEvents(true);
         ns_win.setCollectionBehavior(behavior);
         ns_win.setLevel(NS_WINDOW_LEVEL_SCREEN_SAVER);
+        // Suppress NSWindow's default drop shadow. On macOS Tahoe the new
+        // compositor renders the shadow along the visible-alpha boundaries
+        // of our transparent overlay (i.e. wherever the breathing shape
+        // fades into transparency), which shows up as a thin grey line at
+        // the top + bottom of the rectangle / outer edge of the circle.
+        // Pre-Tahoe this default shadow was effectively invisible on a
+        // borderless transparent window; the new compositor is more
+        // aggressive about painting it. Same fix as the settings backdrop
+        // window uses (`install_settings_vibrancy`)
+        ns_win.setHasShadow(false);
     }
 
     pub fn setup_settings_window(window: &Window) {


### PR DESCRIPTION
## Summary
On macOS Tahoe, a thin gray line appeared at the top and bottom of the rectangle (and at the outer edge of the circle) regardless of which gradient mode was selected.

Root cause: \`NSWindow\`'s default \`hasShadow = true\`. Pre-Tahoe, the system-drawn shadow on a borderless transparent overlay window was effectively invisible. Tahoe's new compositor renders that shadow along the **visible-alpha boundaries** of the window's content, so wherever the breathing shape fades into transparency, you get a thin gray line.

Fix: call \`setHasShadow(false)\` on the overlay NSWindow in \`setup_overlay_window\`. Same pattern already used at [mac.rs:456](rust/crates/exhale-app/src/platform/mac.rs#L456) for the settings backdrop window for the same architectural reason (borderless transparent NSWindow with alpha-fading content).

## Why this is the right layer
The previous PR (#107) addressed a related issue at the shader level (RGB double-darkening through bg.rgb in the partial-alpha zone) and was a real fix on its own. But the gray line on Tahoe wasn't a shader artifact — the shader's edge pixels are mathematically \`(0,0,0,0)\` fully transparent. The line is system-rendered chrome that the new compositor is more aggressive about painting.

## Test plan
This needs to be verified on Tahoe hardware before release. Options:
- [ ] TestFlight pass on a Tahoe Mac (upload via Transporter, install via TestFlight before submitting for review)
- [ ] Direct \`cargo run --release\` sideload on a Tahoe Mac
- [x] No regression on pre-Tahoe macOS: builds clean, no API changes

## API correctness
\`setHasShadow:\` is documented on NSWindow since macOS 10.0. We're already using it successfully on the settings backdrop window. The same call on the overlay window cannot fail.