### PR TITLE
docs: add Crossref-verified citation corpus and gaps ledger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,21 @@ jobs:
         with:
           name: TestResults
           path: TestResults.xcresult
+
+  # docs/CITATIONS.md is generated from the CSL-JSON corpus plus the
+  # hand-written notes, so it can silently fall behind either one.  This
+  # job also validates citekey format, the group / verification / access /
+  # tier enums, and every anchor link the gaps ledger makes into the
+  # corpus, so a renamed entry fails here rather than rotting in the docs.
+  # Stdlib only and no Rust toolchain, so it costs seconds
+  citations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check generated citations are current
+        run: python3 scripts/generate-citations.py --check

--- a/README.md
+++ b/README.md
@@ -1,12 +1,111 @@
 # exhale
 
-A minimal cross-platform breathing overlay - a friendly indicator and reminder to take full, deep breaths while looking at screens. Research indicates we blink less and breathe more shallowly when staring at displays, and this is intended as a small tool to help counter that.
+A minimal cross-platform breathing overlay - a friendly indicator and reminder to take full, deep breaths while looking at screens.
 
-The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable. A good starting point is `4` seconds in and `4` seconds out; eventually `6` and `8` with the out twice as long as the in (to engage the parasympathetic nervous system). Box breathing is `4` / `4` / `4` / `4`. Take breaks if intense feelings arise — it's important not to overdo it.
+Screen work measurably changes how you breathe. Data-entry operators monitored across full working days ran significantly *lower* end-tidal CO2 and *faster* respiration at the keyboard than at rest ([Schleifer & Ley 1994](docs/CITATIONS.md#schleifer1994-vdt-petco2), [Schleifer et al. 2008](docs/CITATIONS.md#schleifer2008-emg-gaps-computer-work)), and that over-breathing pattern is characterised by a shift from diaphragmatic to thoracic breathing ([Schleifer, Ley & Spalding 2002](docs/CITATIONS.md#schleifer2002-hyperventilation-job-stress)): chest, not belly. Under cognitive load generally, breathing gets faster while depth stays roughly stable ([Grassmann et al. 2016](docs/CITATIONS.md#grassmann2016-cognitive-load-respiration), 54 experiments). Screen posture compounds it: heavy smartphone use tracks with worse head posture and lower peak expiratory flow ([Jung et al. 2016](docs/CITATIONS.md#jung2016-smartphone-posture-respiration)), and forward head posture is associated with FVC reductions of 0.25 to 0.81 L ([Deniz et al. 2024](docs/CITATIONS.md#deniz2024-forward-head-lung-volumes)).
+
+Slow paced breathing is the countermeasure with the most evidence behind it ([Laborde et al. 2022](docs/CITATIONS.md#laborde2022-vsb-meta), 223 studies; [Fincham et al. 2023](docs/CITATIONS.md#fincham2023-breathwork-meta), g = -0.35 for stress; [Zaccaro et al. 2018](docs/CITATIONS.md#zaccaro2018-slow-breathing-review)), and exhale is a way to run one with no sensor, no account and no telemetry. A plain expanding shape at 6 breaths per minute matches sensor-driven HRV biofeedback on the physiological outcome ([Tabor et al. 2022](docs/CITATIONS.md#tabor2022-guided-breathing-design), [Laborde et al. 2021](docs/CITATIONS.md#laborde2021-spb-6cpm-biofeedback)), so the hardware buys nothing.
+
+Blink rate also falls sharply at a display ([Tsubota & Nakamori 1993](docs/CITATIONS.md#tsubota1993-vdt-blink), [Rosenfield 2011](docs/CITATIONS.md#rosenfield2011-computer-vision-syndrome), [Sheppard & Wolffsohn 2018](docs/CITATIONS.md#sheppard2018-digital-eye-strain)). exhale does nothing about that; it paces breathing only.
+
+Every claim above and below is sourced in **[docs/CITATIONS.md](docs/CITATIONS.md)**, 42 verified references. Each link lands on that source's corpus entry, which carries its DOI, its access level, its evidence tier and its caveats, rather than on the paper directly, because several of these findings are weaker than a bare citation would suggest. The [gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices) collects fourteen places where exhale ships something the literature does not back.
+
+The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable.
+
+**Where to start: `5` / `0` / `5` / `0`.** Five seconds in, five out, no holds. That is 6 breaths per minute, which is the rate with the best direct evidence. The band tested head-on runs 5 to 7 breaths per minute, and every rate in it beat spontaneous breathing ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)); average individual resonance frequency sits near 5.5 ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). In a four-way head-to-head (n = 84), 6 breaths per minute raised heart rate variability more than either box breathing or 4-7-8 ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)). Holding the breath is the hard part for a beginner, not the slow part, so this is also the gentlest place to start.
+
+Box breathing is `4` / `4` / `4` / `4` and exhale supports it, but note it is a 16-second cycle, or 3.75 breaths per minute: the holds hide the fact that it is *slower* than it looks. It lost that head-to-head ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six), whose authors note square and 4-7-8 breathing "have little empirical support"), and lost again on mood in a month-long randomised trial ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). The same applies to 4-7-8.
+
+**On making the exhale longer than the inhale:** worth doing, but not for the usual reason. Whether a 1:2 ratio raises heart rate variability more than 1:1 is genuinely split: two studies found an effect ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)), one found the *equal* ratio better ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)), and one found no difference across an original experiment and its own replication ([Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). exhale therefore no longer claims a longer exhale "engages the parasympathetic nervous system."
+
+What the evidence does support is subjective. In the one study that measured how people *felt* across ratios, the longer exhale produced more reported relaxation, stress reduction, mindfulness and positive energy, while slowing the rate alone moved only one of those four ([Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)); a month-long trial points the same way on mood ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). Prefer a longer exhale because it feels better, which is the outcome that matters here anyway. Worth knowing that *every* slow pattern tested beat baseline on relaxation ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)): rate does most of the work, and ratio is a preference with a modest, contested edge.
+
+exhale's shipped default is `5` in / `10` out, or 4 breaths per minute, below the band anyone has tested ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)). It is kept for continuity with existing installs rather than because it is known to be better. All of this, including the arithmetic, is laid out in [the gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices).
+
+Take breaks if intense feelings arise; it's important not to overdo it. Few adverse effects are expected from *slow* breathing specifically ([Laborde et al. 2022](docs/CITATIONS.md#laborde2022-vsb-meta)), but exhale's sliders can also be set to fast, hold-heavy patterns that leave that evidence base for the high-ventilation literature, where transient tetany and light-headedness are documented ([Fincham et al. 2024](docs/CITATIONS.md#fincham2024-high-ventilation-rct)).
 
 ## Disclaimer
 
 The information and guidance provided by this app are intended for general informational purposes only and are not medical advice. The creator is not a medical professional. Always seek the advice of a qualified healthcare provider with any questions about your health, and do not disregard or delay professional medical advice because of this app. Use is at your own risk.
+
+## What to expect
+
+**How long before it does anything.** In a lab comparison, HRV changes appeared roughly two minutes
+into a paced session ([Tabor et al. 2022](docs/CITATIONS.md#tabor2022-guided-breathing-design)). Expect the effect
+to last about as long as the pacer runs: the one study of an ambient on-screen pacer during real
+information work found breathing rate dropped while pacing was active and did not persist as a
+lasting change ([Moraveji et al. 2011](docs/CITATIONS.md#moraveji2011-peripheral-paced-respiration)). The trial that
+showed a month-long mood benefit used five minutes a day
+([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). Running exhale all day is fine; just do not
+expect all-day carryover from it.
+
+**If you use the reminder timer instead of the always-on overlay.** Breaks of ten minutes or less
+reduce fatigue and increase vigor ([Albulescu et al. 2022](docs/CITATIONS.md#albulescu2022-micro-breaks), 22
+studies), and self-reported relief is higher after a single instructed deep breath than before it
+([Vlemincx et al. 2016](docs/CITATIONS.md#vlemincx2016-sigh-relief)). That is the closest published support for
+exhale's smallest gesture, which is being told to take one breath.
+
+**Breathe through your nose.** exhale cannot show you this and does not try, but it is free. Nasal
+respiration entrains oscillations in human piriform cortex, amygdala and hippocampus, and the effect
+is specific to the nasal route rather than to breathing as such
+([Zelano et al. 2016](docs/CITATIONS.md#zelano2016-nasal-respiration-limbic)).
+
+**Tune the numbers to yourself.** Resonance frequency is individual, and taller people and men tend
+to have lower ones ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)). That is the honest
+reason exhale's timings are sliders rather than a hardcoded rate: there is no single correct number
+to ship.
+
+**Why breathing reaches how you feel at all.** Heart rate rises on inhalation and falls on
+exhalation ([Yasuma & Hayano 2004](docs/CITATIONS.md#yasuma2004-rsa)), which is the coupling every HRV claim here
+rests on. Separately, a small population of neurons in the mouse breathing rhythm generator projects
+onto the locus coeruleus, and ablating them left breathing intact while increasing calm behaviour
+([Yackle et al. 2017](docs/CITATIONS.md#yackle2017-breathing-arousal-neurons)). That is a plausible route from
+breathing pattern to arousal state. It is mice, and it is a reason rather than a result.
+
+## Research and evidence
+
+exhale's premise, its defaults and its interface choices are traced to the literature in
+**[docs/CITATIONS.md](docs/CITATIONS.md)**: 42 sources, 40 verified against the Crossref REST API and
+2 against Open Library, each carrying an access level, an evidence tier and the specific claims it is
+allowed to back.
+
+The corpus is deliberately not a sales pitch. Alongside the meta-analyses that support slow paced
+breathing it carries the published dissent: a meta-analysis finds sustained slow breathing lowers
+systolic pressure by about 5.6 mmHg ([Chaddha et al. 2019](docs/CITATIONS.md#chaddha2019-slow-breathing-bp)), and an
+editorial in a hypertension journal argues that case should be considered closed
+([van Dijk et al. 2018](docs/CITATIONS.md#vandijk2018-close-the-book)). It also carries the failed replications, a null result
+against exhale's own genre ([Johnson & Rosenfield 2023](docs/CITATIONS.md#johnson2023-20-20-20), where scheduled
+on-screen breaks did nothing), a correction to this repo's own earlier claims, and a
+[ledger of fourteen places](docs/CITATIONS.md#gaps-and-unsupported-choices) where exhale ships
+something the literature does not back. Four highlights:
+
+- exhale's **default pace is 4 breaths per minute**, below the 5 to 7 range that has been tested directly ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)). So is box breathing, at 3.75.
+- Whether a **longer exhale** beats an equal one on heart rate variability is split four ways ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv), [Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). It holds up on how people report *feeling*, which is why the recommendation survived and the mechanism claim did not.
+- The closest published analogue to exhale, an ambient on-screen pacer running during real information work, lowered breathing rate **only while it was running** ([Moraveji et al. 2011](docs/CITATIONS.md#moraveji2011-peripheral-paced-respiration)). Treat an always-on overlay as an effect that lasts as long as it is on. Visual pacing also changes breathing more than audio while feeling *less* calming ([Wongsuphasawat et al. 2012](docs/CITATIONS.md#wongsuphasawat2012-cant-force-calm)), which is a trade exhale makes deliberately.
+- Slow pacing itself mildly increases over-breathing ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)), and screen workers are already mildly hypocapnic ([Schleifer & Ley 1994](docs/CITATIONS.md#schleifer1994-vdt-petco2), [Schleifer et al. 2008](docs/CITATIONS.md#schleifer2008-emg-gaps-computer-work)). Nobody has tested a slow pacer on that population, which is exactly exhale's user.
+
+The tradition exhale actually descends from is named rather than airbrushed. The four-phase
+inhale / hold / exhale / hold structure is pranayama ([Saraswati 2008](docs/CITATIONS.md#satyananda2008-apmb),
+[Muktibodhananda 1998](docs/CITATIONS.md#muktibodhananda1998-hatha-yoga-pradipika)), and both references are carried
+at evidence tier **E**: citable for lineage, never for whether anything works. They are marked
+`NOT READ`, their catalogue records checked rather than their contents. Retrofitting a 2020s HRV
+citation onto an instruction that is centuries older would be revisionist about the app's own design
+history, and knowing the longer-exhale idea reached breathing apps through this tradition rather than
+through a laboratory is worth weighing when reading the studies that later tested it.
+
+The corpus is generated, not hand-maintained. [`docs/CITATIONS.csl.json`](docs/CITATIONS.csl.json) holds
+the records, [`docs/citations-notes.md`](docs/citations-notes.md) holds the prose, and
+[`scripts/generate-citations.py`](scripts/generate-citations.py) renders the two into `CITATIONS.md`:
+
+```sh
+uv run --no-project scripts/generate-citations.py           # regenerate
+uv run --no-project scripts/generate-citations.py --check   # fail if stale
+```
+
+`--check` also validates citekey format, enum values and every anchor link the gaps ledger makes into
+the corpus, so a renamed entry breaks the build rather than rotting silently.
+
+Nothing in this section is medical advice; see the [disclaimer](#disclaimer) above.
 
 ## Download
 
@@ -16,9 +115,9 @@ Pre-built binaries for each OS are on the [Releases](https://github.com/peterkli
 
 [<img src="https://user-images.githubusercontent.com/60944077/232312847-df673556-fb5e-49b4-8037-4d38267e6e18.png"  width="157" height="63"></img>](https://apps.apple.com/us/app/exhale-breath/id6447758995?mt=12)
 
-**Windows** — install the MSIX from the Microsoft Store, or grab the standalone `.exe` from Releases.
+**Windows**: install the MSIX from the Microsoft Store, or grab the standalone `.exe` from Releases.
 
-**Linux** — install the Snap from the Snap Store, or build from source.
+**Linux**: install the Snap from the Snap Store, or build from source.
 
 ## Usage
 
@@ -57,17 +156,17 @@ Single Rust workspace (`rust/`) producing one cross-platform binary.
 - **Settings UI**: `egui` (hand-rolled stepper, segmented picker, control buttons painted directly via `egui::Painter` to match `NSSegmentedControl` / `NSStepper` look)
 - **AppKit interop**: typed FFI via `objc2` for the menu-bar, status-bar level, and `NSApplicationActivationPolicy` paths. `platform/mac.rs` and `timers.rs` still use raw `msg_send!` where typed bindings don't exist yet (window-level juggling, NSUserNotification plumbing)
 - **Threading model**: per-overlay-window render thread + per-window `wgpu::Device` so overlay frame delivery isn't gated by the main thread's message queue or the settings window's GPU submissions
-- **Animation cadence**: 24 fps while the breath animation is running (matches the legacy Swift `MetalBreathingController`); drops to 1 fps when the controller has nothing dynamic to draw (paused, fullscreen-with-matching-colors tint, or all-zero durations). Hardcoded — per-frame CPU runs ≤ 2 % on every scene tested, so the earlier user-tunable preset was removed
+- **Animation cadence**: 24 fps while the breath animation is running (matches the legacy Swift `MetalBreathingController`); drops to 1 fps when the controller has nothing dynamic to draw (paused, fullscreen-with-matching-colors tint, or all-zero durations). Hardcoded; per-frame CPU runs ≤ 2 % on every scene tested, so the earlier user-tunable preset was removed
 
 ### Crates
 
-- `exhale-core` — settings + `SettingsDiff`, breathing controller (deadline-scheduled background thread), poison-tolerant lock helpers, easing tables. Zero GUI deps.
-- `exhale-render` — `wgpu` renderer + WGSL fragment shader, headless benchmarking harness (`cargo run --example cpu_bench`).
-- `exhale-app` — winit event loop, split egui settings panel (`settings_window.rs` + `widgets.rs` + `theme.rs`), per-overlay render thread, tray, hotkeys, platform glue (`objc2` / `windows-sys` / `x11-dl`).
+- `exhale-core`: settings + `SettingsDiff`, breathing controller (deadline-scheduled background thread), poison-tolerant lock helpers, easing tables. Zero GUI deps.
+- `exhale-render`: `wgpu` renderer + WGSL fragment shader, headless benchmarking harness (`cargo run --example cpu_bench`).
+- `exhale-app`: winit event loop, split egui settings panel (`settings_window.rs` + `widgets.rs` + `theme.rs`), per-overlay render thread, tray, hotkeys, platform glue (`objc2` / `windows-sys` / `x11-dl`).
 
 ## Build & run
 
-The `cargo run` family builds and then launches the binary in one step. The `cargo build` family only compiles — you have to invoke the binary yourself afterwards.
+The `cargo run` family builds and then launches the binary in one step. The `cargo build` family only compiles; you have to invoke the binary yourself afterwards.
 
 | Command                  | Builds | Runs | Build profile               |
 |--------------------------|:------:|:----:|-----------------------------|
@@ -109,11 +208,11 @@ After `cargo build`, run the binary directly without going through cargo:
 
 ### Platform prerequisites
 
-**macOS** — no extra prerequisites beyond Rust.
+**macOS**: no extra prerequisites beyond Rust.
 
-**Windows** — no extra prerequisites. Works with both the MSVC and GNU toolchains.
+**Windows**: no extra prerequisites. Works with both the MSVC and GNU toolchains.
 
-**Linux** — exhale dynamically loads several system libraries at run time. To build AND run on Debian/Ubuntu:
+**Linux**: exhale dynamically loads several system libraries at run time. To build AND run on Debian/Ubuntu:
 
 ```sh
 sudo apt install \
@@ -131,7 +230,7 @@ sudo dnf install \
     openssl-devel pkgconf-pkg-config
 ```
 
-If you're **running** a pre-built binary (not compiling from source), the bare runtime packages are enough — drop the `-dev` suffixes:
+If you're **running** a pre-built binary (not compiling from source), the bare runtime packages are enough; drop the `-dev` suffixes:
 
 ```sh
 sudo apt install libgtk-3-0 libayatana-appindicator3-1 libwayland-client0 libxkbcommon0 libxdo3 libssl3
@@ -168,7 +267,7 @@ The MAS path differs because the App Store build runs sandboxed; the sandbox red
    - **Compositor supports alpha** (rare on current Mutter/GNOME, supported by some KWin setups): the overlay is placed at `AlwaysOnBottom` because Wayland's security model doesn't surface a portable click-through / always-on-top protocol to winit (`wp_input_region` isn't exposed). Your app windows cover the overlay by default; to see the breath animation, **narrow your foreground windows so they don't fill the whole screen** and the animation shows through the gap.
    - **Compositor only exposes Opaque alpha** (typical real-hardware Wayland session on Ubuntu / Fedora GNOME): exhale falls back to the **windowed mode** described below.
    For full topmost + click-through overlay behavior on Linux, log out and pick an X11 session at the login screen.
-- **Windowed-mode fallback** (Wayland sessions without alpha, some Windows 10 + Vulkan combinations, WARP / Microsoft Basic Render Driver, remote-desktop sessions): the breath animation runs in a **480×360 movable, resizable "exhale" window** with normal decorations and full window-manager participation (Alt-Tab, taskbar, native close button). You can use it two ways: (1) **as a foreground window**, watching the breath animation directly the same way you'd watch any other app, or (2) **as an edge-strip overlay**, by sending the window behind your other apps (Alt-Tab past it / click on the window manager to lower it), switching exhale to **Rectangle mode**, and narrowing the windows in front so the animation shows through the side / bottom strips you've left open. The Stop button (and the global Stop hotkey, if bound) hides this window; clicking the window's native close X does the same thing — both halt the animation but leave the tray icon and settings panel running, so Start brings the animation window back. The settings panel is still the way to fully quit (Quit button, or close the settings window on Linux).
+- **Windowed-mode fallback** (Wayland sessions without alpha, some Windows 10 + Vulkan combinations, WARP / Microsoft Basic Render Driver, remote-desktop sessions): the breath animation runs in a **480×360 movable, resizable "exhale" window** with normal decorations and full window-manager participation (Alt-Tab, taskbar, native close button). You can use it two ways: (1) **as a foreground window**, watching the breath animation directly the same way you'd watch any other app, or (2) **as an edge-strip overlay**, by sending the window behind your other apps (Alt-Tab past it / click on the window manager to lower it), switching exhale to **Rectangle mode**, and narrowing the windows in front so the animation shows through the side / bottom strips you've left open. The Stop button (and the global Stop hotkey, if bound) hides this window; clicking the window's native close X does the same thing; both halt the animation but leave the tray icon and settings panel running, so Start brings the animation window back. The settings panel is still the way to fully quit (Quit button, or close the settings window on Linux).
 
 ## Performance vs the legacy Swift build
 
@@ -211,7 +310,7 @@ python main.py
 
 Modify the constants at the top of [`python/main.py`](python/main.py) for inhale/exhale duration in seconds, shape mode, and full-screen toggle.
 
-**The Rust binary is the recommended path on every supported OS, including Wayland.** On a typical Wayland desktop the compositor doesn't expose alpha-capable swap chains, so the Rust binary opens as a regular movable window — you can either watch the animation directly in that window OR send it behind your other apps and narrow them so the animation peeks through the edges, exactly the same "make room for the overlay" trick this Python script uses in its bars mode (see the [Linux (Wayland) platform note](#platform-notes) above for details). The Python script is a hackable single-file alternative, not a performance recommendation.
+**The Rust binary is the recommended path on every supported OS, including Wayland.** On a typical Wayland desktop the compositor doesn't expose alpha-capable swap chains, so the Rust binary opens as a regular movable window; you can either watch the animation directly in that window OR send it behind your other apps and narrow them so the animation peeks through the edges, exactly the same "make room for the overlay" trick this Python script uses in its bars mode (see the [Linux (Wayland) platform note](#platform-notes) above for details). The Python script is a hackable single-file alternative, not a performance recommendation.
 
 ## Companion repository
 

--- a/docs/CITATIONS.csl.json
+++ b/docs/CITATIONS.csl.json
@@ -1,0 +1,2011 @@
+[
+  {
+    "id": "albulescu2022-micro-breaks",
+    "type": "article-journal",
+    "title": "\"Give me a break!\" A systematic review and meta-analysis on the efficacy of micro-breaks for increasing well-being and performance",
+    "author": [
+      {
+        "family": "Albulescu",
+        "given": "Patricia"
+      },
+      {
+        "family": "Macsinga",
+        "given": "Irina"
+      },
+      {
+        "family": "Rusu",
+        "given": "Andrei"
+      },
+      {
+        "family": "Sulea",
+        "given": "Coralia"
+      },
+      {
+        "family": "Bodnaru",
+        "given": "Alexandra"
+      },
+      {
+        "family": "Tulbure",
+        "given": "Bogdan Tudor"
+      }
+    ],
+    "container-title": "PLOS ONE",
+    "volume": "17",
+    "issue": "8",
+    "page": "e0272460",
+    "issued": {
+      "date-parts": [
+        [
+          2022
+        ]
+      ]
+    },
+    "DOI": "10.1371/journal.pone.0272460",
+    "URL": "https://doi.org/10.1371/journal.pone.0272460",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "short breaks of ten minutes or less from a work task reduce fatigue and increase vigor",
+        "an interruption long enough to run one breath cycle is a plausible unit of recovery"
+      ],
+      "caveat": "22 studies, 19 manuscripts. The performance effect was smaller and less consistent than the well-being effect, and the authors report it depended on task type. None of the included studies used a breathing exercise as the break activity, so this supports the general shape of exhale's reminder timer, not its specific content."
+    }
+  },
+  {
+    "id": "bae2021-exhalation-inhalation-ratio",
+    "type": "article-journal",
+    "title": "Increased exhalation to inhalation ratio during breathing enhances high-frequency heart rate variability in healthy adults",
+    "author": [
+      {
+        "family": "Bae",
+        "given": "Dalbyeol"
+      },
+      {
+        "family": "Matthews",
+        "given": "Jacob J. L."
+      },
+      {
+        "family": "Chen",
+        "given": "J. Jean"
+      },
+      {
+        "family": "Mah",
+        "given": "Linda"
+      }
+    ],
+    "container-title": "Psychophysiology",
+    "volume": "58",
+    "issue": "11",
+    "page": "e13905",
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "DOI": "10.1111/psyp.13905",
+    "URL": "https://doi.org/10.1111/psyp.13905",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "a 2:1 exhale-to-inhale cue raised RMSSD and HF-HRV relative to a 1:1 cue at the participant's own breathing rate",
+        "the HF-HRV elevation persisted about four minutes after the 2:1 block ended"
+      ],
+      "caveat": "n = 28 (16 young, 12 older). Note the manipulation check: the achieved ratios were 1.08 and 1.33, nowhere near the instructed 1:1 and 2:1, and pacing was at each participant's spontaneous rate rather than in the resonance range. One of four studies that disagree about the ratio; see vandiest2014-ie-ratio-relaxation (also positive), lin2014-equal-ratio-hrv (favours the equal ratio) and meehan2024-longer-exhalations (null). Gap 4 in the ledger tabulates all four."
+    }
+  },
+  {
+    "id": "balban2023-cyclic-sighing",
+    "type": "article-journal",
+    "title": "Brief structured respiration practices enhance mood and reduce physiological arousal",
+    "author": [
+      {
+        "family": "Balban",
+        "given": "Melis Yilmaz"
+      },
+      {
+        "family": "Neri",
+        "given": "Eric"
+      },
+      {
+        "family": "Kogon",
+        "given": "Manuela M."
+      },
+      {
+        "family": "Weed",
+        "given": "Lara"
+      },
+      {
+        "family": "Nouriani",
+        "given": "Bita"
+      },
+      {
+        "family": "Jo",
+        "given": "Booil"
+      },
+      {
+        "family": "Holl",
+        "given": "Gary"
+      },
+      {
+        "family": "Zeitzer",
+        "given": "Jamie M."
+      },
+      {
+        "family": "Spiegel",
+        "given": "David"
+      },
+      {
+        "family": "Huberman",
+        "given": "Andrew D."
+      }
+    ],
+    "container-title": "Cell Reports Medicine",
+    "volume": "4",
+    "issue": "1",
+    "page": "100895",
+    "issued": {
+      "date-parts": [
+        [
+          2023
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.xcrm.2022.100895",
+    "URL": "https://doi.org/10.1016/j.xcrm.2022.100895",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "five minutes a day of exhale-emphasising cyclic sighing improved mood and lowered respiratory rate more than an equal period of mindfulness meditation over one month",
+        "box breathing, equal inhale / hold / exhale, was tested head-to-head and was not the best-performing arm"
+      ],
+      "caveat": "Remote randomised controlled study, pre-registered as NCT05304000. The primary comparator is mindfulness meditation, not a sham, so the arms differ in more than breath ratio. The mood difference reached p < 0.05 in a mixed-effects model; this is a real but modest separation. Directly relevant to exhale twice over: it is the best evidence that a longer exhale is the right emphasis, and it is the reason the README should stop presenting box breathing as equivalent."
+    }
+  },
+  {
+    "id": "chaddha2019-slow-breathing-bp",
+    "type": "article-journal",
+    "title": "Device and non-device-guided slow breathing to reduce blood pressure: A systematic review and meta-analysis",
+    "author": [
+      {
+        "family": "Chaddha",
+        "given": "Ashish"
+      },
+      {
+        "family": "Modaff",
+        "given": "Daniel"
+      },
+      {
+        "family": "Hooper-Lane",
+        "given": "Christopher"
+      },
+      {
+        "family": "Feldstein",
+        "given": "David A."
+      }
+    ],
+    "container-title": "Complementary Therapies in Medicine",
+    "volume": "45",
+    "page": "179-184",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.ctim.2019.03.005",
+    "URL": "https://doi.org/10.1016/j.ctim.2019.03.005",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "sustained slow breathing programmes lower systolic blood pressure by about 5.6 mmHg and diastolic by about 3.0 mmHg in hypertensive and prehypertensive adults"
+      ],
+      "caveat": "17 RCTs. Heterogeneity was high for every analysis, and the authors say so. Inclusion required at least 5 minutes of breathing at 10 breaths/min or slower, on at least 3 days a week, for at least 4 weeks. exhale asks for none of that and measures none of it, so this describes a dose exhale does not deliver. Read alongside vandijk2018-close-the-book."
+    }
+  },
+  {
+    "id": "deniz2024-forward-head-lung-volumes",
+    "type": "article-journal",
+    "title": "The effect of forward head posture on dynamic lung volumes in young adults: a systematic review",
+    "author": [
+      {
+        "family": "Deniz",
+        "given": "Yasemin"
+      },
+      {
+        "family": "Ertekın",
+        "given": "Damla"
+      },
+      {
+        "family": "Cokar",
+        "given": "Dılek"
+      }
+    ],
+    "container-title": "Bulletin of Faculty of Physical Therapy",
+    "volume": "29",
+    "issue": "1",
+    "page": "15",
+    "issued": {
+      "date-parts": [
+        [
+          2024
+        ]
+      ]
+    },
+    "DOI": "10.1186/s43161-024-00186-7",
+    "URL": "https://doi.org/10.1186/s43161-024-00186-7",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "across four comparison studies totalling 115 participants, forward head posture was associated with FVC reductions of 0.25 to 0.81 L and FEV1 reductions of 0.16 to 0.93 L",
+        "craniovertebral angle correlates positively with dynamic pulmonary volumes"
+      ],
+      "caveat": "Systematic review without meta-analysis; the authors phrase the conclusion as FHP 'can potentially cause' pulmonary abnormalities. Searched ResearchGate alongside PubMed and Google Scholar, which is an unusual database choice. This is the posture half of the screen-breathing argument: it is about head position, not about screens, and the link to screens comes from jung2016-smartphone-posture-respiration."
+    }
+  },
+  {
+    "id": "fincham2023-breathwork-meta",
+    "type": "article-journal",
+    "title": "Effect of breathwork on stress and mental health: A meta-analysis of randomised-controlled trials",
+    "author": [
+      {
+        "family": "Fincham",
+        "given": "Guy William"
+      },
+      {
+        "family": "Strauss",
+        "given": "Clara"
+      },
+      {
+        "family": "Montero-Marin",
+        "given": "Jesus"
+      },
+      {
+        "family": "Cavanagh",
+        "given": "Kate"
+      }
+    ],
+    "container-title": "Scientific Reports",
+    "volume": "13",
+    "issue": "1",
+    "page": "432",
+    "issued": {
+      "date-parts": [
+        [
+          2023
+        ]
+      ]
+    },
+    "DOI": "10.1038/s41598-022-27247-y",
+    "URL": "https://doi.org/10.1038/s41598-022-27247-y",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "breathwork lowers self-reported stress against control conditions, g = -0.35 (95% CI -0.55 to -0.14), 12 RCTs, 785 adults",
+        "comparable small-to-medium effects for anxiety (g = -0.32, k = 20) and depressive symptoms (g = -0.40, k = 18)"
+      ],
+      "caveat": "Most included studies were rated at moderate risk of bias. Effects are small-to-medium and self-reported. This is the strongest single warrant for the claim that a breathing practice does something, and it is still a g of about a third of a standard deviation."
+    }
+  },
+  {
+    "id": "fincham2024-high-ventilation-rct",
+    "type": "article-journal",
+    "title": "Effects of brief remote high ventilation breathwork with retention on mental health and wellbeing: a randomised placebo-controlled trial",
+    "author": [
+      {
+        "family": "Fincham",
+        "given": "Guy W."
+      },
+      {
+        "family": "Epel",
+        "given": "Elissa"
+      },
+      {
+        "family": "Colasanti",
+        "given": "Alessandro"
+      },
+      {
+        "family": "Strauss",
+        "given": "Clara"
+      },
+      {
+        "family": "Cavanagh",
+        "given": "Kate"
+      }
+    ],
+    "container-title": "Scientific Reports",
+    "volume": "14",
+    "issue": "1",
+    "page": "16893",
+    "issued": {
+      "date-parts": [
+        [
+          2024
+        ]
+      ]
+    },
+    "DOI": "10.1038/s41598-024-64254-7",
+    "URL": "https://doi.org/10.1038/s41598-024-64254-7",
+    "custom": {
+      "group": "safety",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "high-ventilation breathwork with retention is a distinct practice from slow-paced breathing and warrants a placebo-controlled evaluation of its own"
+      ],
+      "caveat": "NUMBERS NOT READ 2026-08-28; carried for the distinction it draws rather than for its effect estimate. It matters to exhale because exhale's sliders can be set to fast, hold-heavy patterns that leave the slow-breathing evidence base entirely. Adverse-event reporting across this field is sparse: reviews note that only a minority of breathwork trials report on adverse events at all, which is the honest basis for the README's advice to stop if intense feelings arise."
+    }
+  },
+  {
+    "id": "grassmann2016-cognitive-load-respiration",
+    "type": "article-journal",
+    "title": "Respiratory Changes in Response to Cognitive Load: A Systematic Review",
+    "author": [
+      {
+        "family": "Grassmann",
+        "given": "Mariel"
+      },
+      {
+        "family": "Vlemincx",
+        "given": "Elke"
+      },
+      {
+        "family": "von Leupoldt",
+        "given": "Andreas"
+      },
+      {
+        "family": "Mittelstädt",
+        "given": "Justin M."
+      },
+      {
+        "family": "Van den Bergh",
+        "given": "Omer"
+      }
+    ],
+    "container-title": "Neural Plasticity",
+    "volume": "2016",
+    "page": "8146809",
+    "issued": {
+      "date-parts": [
+        [
+          2016
+        ]
+      ]
+    },
+    "DOI": "10.1155/2016/8146809",
+    "URL": "https://doi.org/10.1155/2016/8146809",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "mentally demanding work is reliably marked by faster breathing, with medium to large effects",
+        "respiratory amplitude stays roughly stable under cognitive load rather than shrinking",
+        "cognitive load lowers end-tidal CO2, meaning ventilation runs ahead of metabolic need"
+      ],
+      "caveat": "54 experiments across 53 articles. Careful with this one: it establishes that cognitive load raises rate while leaving amplitude roughly stable, so it does NOT support 'shallow' if shallow means less air moved. Minute ventilation goes up. For the diaphragmatic-to-thoracic shift that 'shallow' actually names, cite schleifer2002-hyperventilation-job-stress; for the same effect measured at a real keyboard, cite schleifer1994-vdt-petco2 and schleifer2008-emg-gaps-computer-work. This entry is the general cognitive-load backdrop."
+    }
+  },
+  {
+    "id": "johnson2023-20-20-20",
+    "type": "article-journal",
+    "title": "20-20-20 Rule: Are These Numbers Justified?",
+    "author": [
+      {
+        "family": "Johnson",
+        "given": "Sophia"
+      },
+      {
+        "family": "Rosenfield",
+        "given": "Mark"
+      }
+    ],
+    "container-title": "Optometry and Vision Science",
+    "volume": "100",
+    "issue": "1",
+    "page": "52-56",
+    "issued": {
+      "date-parts": [
+        [
+          2023
+        ]
+      ]
+    },
+    "DOI": "10.1097/OPX.0000000000001971",
+    "URL": "https://doi.org/10.1097/OPX.0000000000001971",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "the widely repeated 20-20-20 rule has little peer-reviewed support",
+        "scheduled 20-second breaks every 5, 10 or 20 minutes produced no significant effect on ocular symptoms, reading speed or task accuracy"
+      ],
+      "caveat": "n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge is not self-evidently effective just because it is popular and plausible."
+    }
+  },
+  {
+    "id": "jung2016-smartphone-posture-respiration",
+    "type": "article-journal",
+    "title": "The effect of smartphone usage time on posture and respiratory function",
+    "author": [
+      {
+        "family": "Jung",
+        "given": "Sang In"
+      },
+      {
+        "family": "Lee",
+        "given": "Na Kyung"
+      },
+      {
+        "family": "Kang",
+        "given": "Kyung Woo"
+      },
+      {
+        "family": "Kim",
+        "given": "Kyoung"
+      },
+      {
+        "family": "Lee",
+        "given": "Do Youn"
+      }
+    ],
+    "container-title": "Journal of Physical Therapy Science",
+    "volume": "28",
+    "issue": "1",
+    "page": "186-189",
+    "issued": {
+      "date-parts": [
+        [
+          2016
+        ]
+      ]
+    },
+    "DOI": "10.1589/jpts.28.186",
+    "URL": "https://doi.org/10.1589/jpts.28.186",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "people using smartphones more than four hours a day had significantly worse craniovertebral angle, worse scapular index and lower peak expiratory flow than people using them less than four hours a day"
+      ],
+      "caveat": "n = 50, cross-sectional, two groups split on self-reported usage. Correlational: heavy users may differ in many ways besides screen time, and peak expiratory flow was the only respiratory measure that separated (FVC and FEV1 did not). Crossref carries no license; access level taken from J Phys Ther Sci being fully open access."
+    }
+  },
+  {
+    "id": "laborde2021-ie-ratio-pauses",
+    "type": "article-journal",
+    "title": "Slow-Paced Breathing: Influence of Inhalation/Exhalation Ratio and of Respiratory Pauses on Cardiac Vagal Activity",
+    "author": [
+      {
+        "family": "Laborde",
+        "given": "Sylvain"
+      },
+      {
+        "family": "Iskra",
+        "given": "Maša"
+      },
+      {
+        "family": "Zammit",
+        "given": "Nina"
+      },
+      {
+        "family": "Borges",
+        "given": "Uirassu"
+      },
+      {
+        "family": "You",
+        "given": "Min"
+      },
+      {
+        "family": "Sevoz-Couche",
+        "given": "Caroline"
+      },
+      {
+        "family": "Dosseville",
+        "given": "Fabrice"
+      }
+    ],
+    "container-title": "Sustainability",
+    "volume": "13",
+    "issue": "14",
+    "page": "7775",
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "DOI": "10.3390/su13147775",
+    "URL": "https://doi.org/10.3390/su13147775",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "inhalation/exhalation ratio and the presence of respiratory pauses were manipulated directly against cardiac vagal activity as the outcome"
+      ],
+      "caveat": "NUMBERS NOT READ 2026-08-28. Carried for the design question it asks, which is exactly the question exhale's four sliders pose. It is the fifth study bearing on the ratio disagreement tabulated in gap 4, and the only one that also manipulates respiratory pauses, which makes it the highest-value full text still unread in this corpus: it bears on both gap 4 and gap 11. Read it before quoting any effect from it."
+    }
+  },
+  {
+    "id": "laborde2021-spb-6cpm-biofeedback",
+    "type": "article-journal",
+    "title": "Psychophysiological effects of slow-paced breathing at six cycles per minute with or without heart rate variability biofeedback",
+    "author": [
+      {
+        "family": "Laborde",
+        "given": "Sylvain"
+      },
+      {
+        "family": "Allen",
+        "given": "Mark S."
+      },
+      {
+        "family": "Borges",
+        "given": "Uirassu"
+      },
+      {
+        "family": "Iskra",
+        "given": "Maša"
+      },
+      {
+        "family": "Zammit",
+        "given": "Nina"
+      },
+      {
+        "family": "You",
+        "given": "Min"
+      },
+      {
+        "family": "Hosang",
+        "given": "Thomas"
+      },
+      {
+        "family": "Mosley",
+        "given": "Emma"
+      },
+      {
+        "family": "Dosseville",
+        "given": "Fabrice"
+      }
+    ],
+    "container-title": "Psychophysiology",
+    "volume": "59",
+    "issue": "1",
+    "page": "e13952",
+    "issued": {
+      "date-parts": [
+        [
+          2021
+        ]
+      ]
+    },
+    "DOI": "10.1111/psyp.13952",
+    "URL": "https://doi.org/10.1111/psyp.13952",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "slow-paced breathing at six cycles per minute raised RMSSD relative to control in every condition tested",
+        "adding heart-rate-variability biofeedback on top of the six-per-minute pace did not add a further benefit"
+      ],
+      "caveat": "Crossref records this as issued 2021, appearing in the January 2022 issue (59:1). Together with tabor2022-guided-breathing-design this is why exhale needs no sensor: the pace is doing the work, not the feedback loop."
+    }
+  },
+  {
+    "id": "laborde2022-vsb-meta",
+    "type": "article-journal",
+    "title": "Effects of voluntary slow breathing on heart rate and heart rate variability: A systematic review and a meta-analysis",
+    "author": [
+      {
+        "family": "Laborde",
+        "given": "S."
+      },
+      {
+        "family": "Allen",
+        "given": "M. S."
+      },
+      {
+        "family": "Borges",
+        "given": "U."
+      },
+      {
+        "family": "Dosseville",
+        "given": "F."
+      },
+      {
+        "family": "Hosang",
+        "given": "T. J."
+      },
+      {
+        "family": "Iskra",
+        "given": "M."
+      },
+      {
+        "family": "Mosley",
+        "given": "E."
+      },
+      {
+        "family": "Salvotti",
+        "given": "C."
+      },
+      {
+        "family": "Spolverato",
+        "given": "L."
+      },
+      {
+        "family": "Zammit",
+        "given": "N."
+      },
+      {
+        "family": "Javelle",
+        "given": "F."
+      }
+    ],
+    "container-title": "Neuroscience & Biobehavioral Reviews",
+    "volume": "138",
+    "page": "104711",
+    "issued": {
+      "date-parts": [
+        [
+          2022
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.neubiorev.2022.104711",
+    "URL": "https://doi.org/10.1016/j.neubiorev.2022.104711",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "voluntary slow breathing raises vagally-mediated HRV during the session, immediately after a single session, and after a multi-session intervention",
+        "few adverse effects are expected from slow breathing practice"
+      ],
+      "caveat": "223 studies from 1842 screened abstracts (172 during, 16 immediately-after, 49 after-intervention). This is the central warrant for exhale's whole premise. Note what it establishes: an effect on a cardiac index of parasympathetic activity, not an effect on how anyone feels or works."
+    }
+  },
+  {
+    "id": "lehrer2014-hrv-biofeedback",
+    "type": "article-journal",
+    "title": "Heart rate variability biofeedback: how and why does it work?",
+    "author": [
+      {
+        "family": "Lehrer",
+        "given": "Paul M."
+      },
+      {
+        "family": "Gevirtz",
+        "given": "Richard"
+      }
+    ],
+    "container-title": "Frontiers in Psychology",
+    "volume": "5",
+    "page": "756",
+    "issued": {
+      "date-parts": [
+        [
+          2014
+        ]
+      ]
+    },
+    "DOI": "10.3389/fpsyg.2014.00756",
+    "URL": "https://doi.org/10.3389/fpsyg.2014.00756",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "maximum heart-rate oscillation is usually reached breathing at approximately 0.1 Hz, six breaths per minute",
+        "refined measurement puts the average resonance frequency nearer 0.09 Hz, about 5.5 breaths per minute, a breath lasting roughly 11 seconds",
+        "resonance frequency is individual: taller people and men tend to have lower resonance frequencies",
+        "baroreflex gain increases substantially during HRV biofeedback"
+      ],
+      "caveat": "Narrative mechanistic review by the technique's principal developers. Read as the mechanism argument, not as independent evidence. The individual-variation point is the honest reason exhale's timing sliders are user-editable at all: there is no single correct number to hardcode."
+    }
+  },
+  {
+    "id": "li2016-sigh-circuit",
+    "type": "article-journal",
+    "title": "The peptidergic control circuit for sighing",
+    "author": [
+      {
+        "family": "Li",
+        "given": "Peng"
+      },
+      {
+        "family": "Janczewski",
+        "given": "Wiktor A."
+      },
+      {
+        "family": "Yackle",
+        "given": "Kevin"
+      },
+      {
+        "family": "Kam",
+        "given": "Kaiwen"
+      },
+      {
+        "family": "Pagliardini",
+        "given": "Silvia"
+      },
+      {
+        "family": "Krasnow",
+        "given": "Mark A."
+      },
+      {
+        "family": "Feldman",
+        "given": "Jack L."
+      }
+    ],
+    "container-title": "Nature",
+    "volume": "530",
+    "issue": "7590",
+    "page": "293-297",
+    "issued": {
+      "date-parts": [
+        [
+          2016
+        ]
+      ]
+    },
+    "DOI": "10.1038/nature16964",
+    "URL": "https://doi.org/10.1038/nature16964",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "sighing is generated by a dedicated peptidergic circuit projecting onto the preBotzinger complex, not as a byproduct of ordinary breathing rhythm"
+      ],
+      "caveat": "Mouse work. It establishes that the sigh is a distinct, hardwired respiratory behaviour, which is the mechanistic backdrop for the cyclic-sighing result in balban2023-cyclic-sighing. It says nothing about humans deliberately performing sighs, and must not be cited as if it did."
+    }
+  },
+  {
+    "id": "lin2014-equal-ratio-hrv",
+    "type": "article-journal",
+    "title": "Breathing at a rate of 5.5 breaths per minute with equal inhalation-to-exhalation ratio increases heart rate variability",
+    "author": [
+      {
+        "family": "Lin",
+        "given": "I. M."
+      },
+      {
+        "family": "Tai",
+        "given": "L. Y."
+      },
+      {
+        "family": "Fan",
+        "given": "S. Y."
+      }
+    ],
+    "container-title": "International Journal of Psychophysiology",
+    "volume": "91",
+    "issue": "3",
+    "page": "206-211",
+    "issued": {
+      "date-parts": [
+        [
+          2014
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.ijpsycho.2013.12.006",
+    "URL": "https://doi.org/10.1016/j.ijpsycho.2013.12.006",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "5.5 breaths per minute with an equal 5:5 inhale-to-exhale ratio produced higher SDNN and LF power than 6 bpm or than a 4:6 ratio",
+        "all four slow-breathing patterns increased self-reported relaxation relative to spontaneous breathing"
+      ],
+      "caveat": "n = 47, Latin-square counterbalanced. The clearest published result AGAINST a longer exhale on HRV grounds, and it is why exhale's README no longer asserts the 1:2 mechanism. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works."
+    }
+  },
+  {
+    "id": "linardon2020-app-attrition",
+    "type": "article-journal",
+    "title": "Attrition and adherence in smartphone-delivered interventions for mental health problems: A systematic and meta-analytic review",
+    "author": [
+      {
+        "family": "Linardon",
+        "given": "Jake"
+      },
+      {
+        "family": "Fuller-Tyszkiewicz",
+        "given": "Matthew"
+      }
+    ],
+    "container-title": "Journal of Consulting and Clinical Psychology",
+    "volume": "88",
+    "issue": "1",
+    "page": "1-13",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "DOI": "10.1037/ccp0000459",
+    "URL": "https://doi.org/10.1037/ccp0000459",
+    "custom": {
+      "group": "safety",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "A",
+      "backsClaims": [
+        "dropout and non-adherence are the dominant practical failure mode of smartphone-delivered mental health interventions, even where efficacy trials are positive"
+      ],
+      "caveat": "NUMBERS NOT READ 2026-08-28. Carried as the reality check on every other entry in this corpus: an effect measured in a supervised session says little about a tool someone installs and forgets. exhale has no telemetry and therefore no idea whether anyone keeps it running, which is stated plainly in the gaps ledger rather than hidden."
+    }
+  },
+  {
+    "id": "little2025-a52-breath-method",
+    "type": "article-journal",
+    "title": "The A52 Breath Method: A Narrative Review of Breathwork for Mental Health and Stress Resilience",
+    "author": [
+      {
+        "family": "Little",
+        "given": "Abbie L."
+      }
+    ],
+    "container-title": "Stress and Health",
+    "volume": "41",
+    "issue": "4",
+    "page": "e70098",
+    "issued": {
+      "date-parts": [
+        [
+          2025
+        ]
+      ]
+    },
+    "DOI": "10.1002/smi.70098",
+    "URL": "https://doi.org/10.1002/smi.70098",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "a 5 s inhale, 5 s exhale, 2 s post-exhale hold at five breaths per minute is a protocol a recent review argues is representative of the effective literature",
+        "23 of 30 reviewed studies reported significant HRV improvement; 10 reported anxiety reduction and 9 reported reduced perceived stress",
+        "benefits appear larger in people with elevated baseline distress"
+      ],
+      "caveat": "Narrative review, single author, 465 abstracts screened and 30 full texts analysed, with no meta-analysis and no risk-of-bias assessment. It proposes the protocol it reviews, which is a conflict of framing worth naming. Its A52 shape maps onto exhale's four sliders as 5 / 0 / 5 / 2, which is 5 breaths per minute and inside the tested band, unlike exhale's shipped default. Note that marchant2025-square-478-six found no-hold 6 bpm outperformed both hold-bearing patterns it tested, so the 2 s retention here is the least supported part of the protocol."
+    }
+  },
+  {
+    "id": "marchant2025-square-478-six",
+    "type": "article-journal",
+    "title": "Comparing the Effects of Square, 4-7-8, and 6 Breaths-per-Minute Breathing Conditions on Heart Rate Variability, CO2 Levels, and Mood",
+    "author": [
+      {
+        "family": "Marchant",
+        "given": "Joshua"
+      },
+      {
+        "family": "Khazan",
+        "given": "Inna"
+      },
+      {
+        "family": "Cressman",
+        "given": "Mikel"
+      },
+      {
+        "family": "Steffen",
+        "given": "Patrick"
+      }
+    ],
+    "container-title": "Applied Psychophysiology and Biofeedback",
+    "volume": "50",
+    "issue": "2",
+    "page": "261-276",
+    "issued": {
+      "date-parts": [
+        [
+          2025
+        ]
+      ]
+    },
+    "DOI": "10.1007/s10484-025-09688-z",
+    "URL": "https://doi.org/10.1007/s10484-025-09688-z",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "breathing at 6 breaths per minute raised HRV more than either square (box) breathing or 4-7-8 breathing, with small to medium effects",
+        "square and 4-7-8 breathing are popularly promoted but have little empirical support",
+        "none of the four conditions produced meaningful changes in blood pressure or mood",
+        "breathing at 6 breaths per minute unexpectedly produced mild over-breathing"
+      ],
+      "caveat": "n = 84 college students, within-subjects, four conditions: square, 4-7-8, 6 bpm at 4:6, and 6 bpm at 5:5. Single session, so it speaks to acute effect only. This is the head-to-head that answers exhale's default-preset question directly, and it answers against box breathing and against 4-7-8. The over-breathing finding is the uncomfortable one: see gap 5 in the ledger."
+    }
+  },
+  {
+    "id": "meehan2024-longer-exhalations",
+    "type": "article-journal",
+    "title": "Do Longer Exhalations Increase HRV During Slow-Paced Breathing?",
+    "author": [
+      {
+        "family": "Meehan",
+        "given": "Zachary M."
+      },
+      {
+        "family": "Shaffer",
+        "given": "Fred"
+      }
+    ],
+    "container-title": "Applied Psychophysiology and Biofeedback",
+    "volume": "49",
+    "issue": "3",
+    "page": "407-417",
+    "issued": {
+      "date-parts": [
+        [
+          2024
+        ]
+      ]
+    },
+    "DOI": "10.1007/s10484-024-09637-2",
+    "URL": "https://doi.org/10.1007/s10484-024-09637-2",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "at 6 breaths per minute, a 1:2 inhale-to-exhale ratio produced no HRV advantage over 1:1 in either an original experiment or its replication",
+        "the finding held across time-domain, frequency-domain and nonlinear HRV metrics"
+      ],
+      "caveat": "Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of four disagreeing studies; see also vandiest2014-ie-ratio-relaxation and lin2014-equal-ratio-hrv. Critically, all four measured HRV; none of them measured how participants felt except vandiest2014-ie-ratio-relaxation, which is why exhale's recommendation now rests on the subjective outcome rather than on this dispute."
+    }
+  },
+  {
+    "id": "moraveji2011-peripheral-paced-respiration",
+    "type": "paper-conference",
+    "title": "Peripheral paced respiration: influencing user physiology during information work",
+    "author": [
+      {
+        "family": "Moraveji",
+        "given": "Neema"
+      },
+      {
+        "family": "Olson",
+        "given": "Ben"
+      },
+      {
+        "family": "Nguyen",
+        "given": "Truc"
+      },
+      {
+        "family": "Saadat",
+        "given": "Mahmoud"
+      },
+      {
+        "family": "Khalighi",
+        "given": "Yaser"
+      },
+      {
+        "family": "Pea",
+        "given": "Roy"
+      },
+      {
+        "family": "Heer",
+        "given": "Jeffrey"
+      }
+    ],
+    "container-title": "Proceedings of the 24th Annual ACM Symposium on User Interface Software and Technology (UIST '11)",
+    "page": "423-428",
+    "issued": {
+      "date-parts": [
+        [
+          2011
+        ]
+      ]
+    },
+    "DOI": "10.1145/2047196.2047250",
+    "URL": "https://doi.org/10.1145/2047196.2047250",
+    "custom": {
+      "group": "interface",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "a translucent animated bar spanning the screen, running in the periphery of attention during normal information work, significantly lowered participants' breathing rate",
+        "peripheral pacing does not require the user's full attention to change breathing"
+      ],
+      "caveat": "This is the closest published analogue to exhale that exists, and its limitation is the important part: the reduction occurred while the pacing feedback was active and did not persist as a lasting change in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as it is on. A free author copy is posted at vis.stanford.edu; the ACM Digital Library version is paywalled."
+    }
+  },
+  {
+    "id": "muktibodhananda1998-hatha-yoga-pradipika",
+    "type": "book",
+    "title": "Hatha Yoga Pradipika",
+    "author": [
+      {
+        "family": "Muktibodhananda",
+        "given": "Swami"
+      }
+    ],
+    "publisher": "Bihar School of Yoga",
+    "publisher-place": "Munger, Bihar, India",
+    "ISBN": "9788185787381",
+    "issued": {
+      "date-parts": [
+        [
+          1998
+        ]
+      ]
+    },
+    "URL": "https://openlibrary.org/search?q=hatha+yoga+pradipika+muktibodhananda",
+    "custom": {
+      "group": "tradition",
+      "verification": "openlibrary-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "E",
+      "backsClaims": [
+        "the classical hatha text and commentary in which timed inhale, retention and exhale ratios are set out is the historical origin of the ratio instructions modern breathing apps repeat"
+      ],
+      "caveat": "NOT READ 2026-08-28. Bibliographic record checked against Open Library (Bihar School of Yoga, 1998 record). Not peer reviewed, and a commentary on a fifteenth-century text rather than a primary source in any modern sense. Carried because the 'longer exhale' instruction exhale ships did not come from a laboratory: it came from here, centuries before anyone measured HRV. Naming that is more honest than retrofitting a citation to psychophysiology. It must never back a physiological claim."
+    }
+  },
+  {
+    "id": "rosenfield2011-computer-vision-syndrome",
+    "type": "article-journal",
+    "title": "Computer vision syndrome: a review of ocular causes and potential treatments",
+    "author": [
+      {
+        "family": "Rosenfield",
+        "given": "Mark"
+      }
+    ],
+    "container-title": "Ophthalmic and Physiological Optics",
+    "volume": "31",
+    "issue": "5",
+    "page": "502-515",
+    "issued": {
+      "date-parts": [
+        [
+          2011
+        ]
+      ]
+    },
+    "DOI": "10.1111/j.1475-1313.2011.00834.x",
+    "URL": "https://doi.org/10.1111/j.1475-1313.2011.00834.x",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "blink rate falls substantially during display work relative to other tasks",
+        "reduced and incomplete blinking is a principal mechanism of computer vision syndrome"
+      ],
+      "caveat": "Narrative review of the ocular literature. Load-bearing for the blink half of exhale's opening claim only. exhale does nothing about blinking; see the gaps ledger."
+    }
+  },
+  {
+    "id": "russo2017-slow-breathing-physiology",
+    "type": "article-journal",
+    "title": "The physiological effects of slow breathing in the healthy human",
+    "author": [
+      {
+        "family": "Russo",
+        "given": "Marc A."
+      },
+      {
+        "family": "Santarelli",
+        "given": "Danielle M."
+      },
+      {
+        "family": "O'Rourke",
+        "given": "Dean"
+      }
+    ],
+    "container-title": "Breathe",
+    "volume": "13",
+    "issue": "4",
+    "page": "298-309",
+    "issued": {
+      "date-parts": [
+        [
+          2017
+        ]
+      ]
+    },
+    "DOI": "10.1183/20734735.009817",
+    "URL": "https://doi.org/10.1183/20734735.009817",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "slow breathing improves ventilation efficiency and alters cardiorespiratory coupling, respiratory sinus arrhythmia and sympathovagal balance"
+      ],
+      "caveat": "Narrative review. The authors close by calling explicitly for further research, and describe the health claims as potential rather than demonstrated. Use it to explain a mechanism, not to assert an outcome."
+    }
+  },
+  {
+    "id": "satyananda2008-apmb",
+    "type": "book",
+    "title": "Asana Pranayama Mudra Bandha",
+    "author": [
+      {
+        "family": "Saraswati",
+        "given": "Swami Satyananda"
+      }
+    ],
+    "publisher": "Yoga Publications Trust",
+    "publisher-place": "Munger, Bihar, India",
+    "number-of-pages": "553",
+    "ISBN": "9788186336144",
+    "issued": {
+      "date-parts": [
+        [
+          2008
+        ]
+      ]
+    },
+    "URL": "https://openlibrary.org/books/OL22138410M/Asana_pranayama_mudra_bandha",
+    "custom": {
+      "group": "tradition",
+      "verification": "openlibrary-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "E",
+      "backsClaims": [
+        "the systematic pranayama tradition from which exhale's controllable inhale / retention / exhale / retention structure descends is documented in a standard modern reference manual"
+      ],
+      "caveat": "NOT READ 2026-08-28. Bibliographic record checked against Open Library, which returns the Yoga Publications Trust edition at 553 pages under this ISBN but dates its record 1999, while the printing in question is described as the 2008 Fourth Revised Edition revised under Swami Niranjanananda Saraswati; the edition history of this title is genuinely tangled and this entry does not resolve it. Not peer reviewed. Cited ONLY for lineage: it is where exhale's four-phase structure comes from, and pretending the design was derived from 2020s psychophysiology would be revisionist. It must never back a physiological claim."
+    }
+  },
+  {
+    "id": "schleifer1994-vdt-petco2",
+    "type": "article-journal",
+    "title": "End-tidal PCO2 as an index of psychophysiological activity during VDT data-entry work and relaxation",
+    "author": [
+      {
+        "family": "Schleifer",
+        "given": "Lawrence M."
+      },
+      {
+        "family": "Ley",
+        "given": "Ronald"
+      }
+    ],
+    "container-title": "Ergonomics",
+    "volume": "37",
+    "issue": "2",
+    "page": "245-254",
+    "issued": {
+      "date-parts": [
+        [
+          1994
+        ]
+      ]
+    },
+    "DOI": "10.1080/00140139408963642",
+    "URL": "https://doi.org/10.1080/00140139408963642",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "during computer data-entry work, end-tidal CO2 was significantly lower and respiration frequency significantly higher than during either baseline relaxation or progressive muscle relaxation",
+        "breathing changes measurably at a screen, and end-tidal CO2 discriminates the state"
+      ],
+      "caveat": "n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real screen work over real working days, not a lab proxy. This entry retracts an earlier claim in this repo that no peer-reviewed study had measured respiration during ordinary screen use. It had; this is it, from 1994."
+    }
+  },
+  {
+    "id": "schleifer2002-hyperventilation-job-stress",
+    "type": "article-journal",
+    "title": "A hyperventilation theory of job stress and musculoskeletal disorders",
+    "author": [
+      {
+        "family": "Schleifer",
+        "given": "Lawrence M."
+      },
+      {
+        "family": "Ley",
+        "given": "Ronald"
+      },
+      {
+        "family": "Spalding",
+        "given": "Thomas W."
+      }
+    ],
+    "container-title": "American Journal of Industrial Medicine",
+    "volume": "41",
+    "issue": "5",
+    "page": "420-432",
+    "issued": {
+      "date-parts": [
+        [
+          2002
+        ]
+      ]
+    },
+    "DOI": "10.1002/ajim.10061",
+    "URL": "https://doi.org/10.1002/ajim.10061",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "hyperventilation is often characterised by a shift from a diaphragmatic to a thoracic breathing pattern",
+        "thoracic breathing recruits sternocleidomastoid, scalene and trapezius muscles, imposing biomechanical stress on the neck and shoulder region",
+        "breathing training and rest breaks are a rationale-backed response to this pattern at work"
+      ],
+      "caveat": "Theory paper, not an experiment, hence tier D. It is nonetheless the closest thing in the peer-reviewed literature to the folk claim about 'shallow' breathing at a screen: the diaphragmatic-to-thoracic shift IS what people mean by shallow. Cite it for the pattern, never for a measured tidal volume, and note it theorises the shift rather than demonstrating it in screen users."
+    }
+  },
+  {
+    "id": "schleifer2008-emg-gaps-computer-work",
+    "type": "article-journal",
+    "title": "Mental stress and trapezius muscle activation under psychomotor challenge: A focus on EMG gaps during computer work",
+    "author": [
+      {
+        "family": "Schleifer",
+        "given": "Lawrence M."
+      },
+      {
+        "family": "Spalding",
+        "given": "Thomas W."
+      },
+      {
+        "family": "Kerick",
+        "given": "Scott E."
+      },
+      {
+        "family": "Cram",
+        "given": "Jeffrey R."
+      },
+      {
+        "family": "Ley",
+        "given": "Ronald"
+      },
+      {
+        "family": "Hatfield",
+        "given": "Bradley D."
+      }
+    ],
+    "container-title": "Psychophysiology",
+    "volume": "45",
+    "issue": "3",
+    "page": "356-365",
+    "issued": {
+      "date-parts": [
+        [
+          2008
+        ]
+      ]
+    },
+    "DOI": "10.1111/j.1469-8986.2008.00645.x",
+    "URL": "https://doi.org/10.1111/j.1469-8986.2008.00645.x",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "end-tidal CO2 was lower under high mental workload than low during computer data entry, replicating the over-breathing finding in a second sample",
+        "lower end-tidal CO2 tracked reduced trapezius EMG-gap frequency, suggesting over-breathing mediates muscle tension at the keyboard"
+      ],
+      "caveat": "n = 23. The second independent measurement by this group of the same effect, fourteen years after schleifer1994-vdt-petco2. Two small samples pointing the same way is what the screen-breathing claim actually rests on."
+    }
+  },
+  {
+    "id": "sevozcouche2022-coherence-resonance",
+    "type": "article-journal",
+    "title": "Heart rate variability and slow-paced breathing: when coherence meets resonance",
+    "author": [
+      {
+        "family": "Sevoz-Couche",
+        "given": "Caroline"
+      },
+      {
+        "family": "Laborde",
+        "given": "Sylvain"
+      }
+    ],
+    "container-title": "Neuroscience & Biobehavioral Reviews",
+    "volume": "135",
+    "page": "104576",
+    "issued": {
+      "date-parts": [
+        [
+          2022
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.neubiorev.2022.104576",
+    "URL": "https://doi.org/10.1016/j.neubiorev.2022.104576",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "coherence and resonance are distinct phenomena that are frequently conflated in the slow-breathing literature"
+      ],
+      "caveat": "Narrative review. Carried as a terminology guard: much of the popular writing exhale competes with uses 'coherence' loosely, and this is the paper to check before adopting that vocabulary in the app or the README."
+    }
+  },
+  {
+    "id": "sheppard2018-digital-eye-strain",
+    "type": "article-journal",
+    "title": "Digital eye strain: prevalence, measurement and amelioration",
+    "author": [
+      {
+        "family": "Sheppard",
+        "given": "Amy L."
+      },
+      {
+        "family": "Wolffsohn",
+        "given": "James S."
+      }
+    ],
+    "container-title": "BMJ Open Ophthalmology",
+    "volume": "3",
+    "issue": "1",
+    "page": "e000146",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "DOI": "10.1136/bmjophth-2018-000146",
+    "URL": "https://doi.org/10.1136/bmjophth-2018-000146",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "digital eye strain is common among heavy display users",
+        "reduced blink rate and incomplete blinks during screen work are among its established contributors"
+      ],
+      "caveat": "Crossref carries no license field for this record; access level is taken from BMJ Open Ophthalmology being a fully open-access title."
+    }
+  },
+  {
+    "id": "tabor2022-guided-breathing-design",
+    "type": "article-journal",
+    "title": "Comparing heart rate variability biofeedback and simple paced breathing to inform the design of guided breathing technologies",
+    "author": [
+      {
+        "family": "Tabor",
+        "given": "Aaron"
+      },
+      {
+        "family": "Bateman",
+        "given": "Scott"
+      },
+      {
+        "family": "Scheme",
+        "given": "Erik J."
+      },
+      {
+        "family": "schraefel",
+        "given": "m.c."
+      }
+    ],
+    "container-title": "Frontiers in Computer Science",
+    "volume": "4",
+    "page": "926649",
+    "issued": {
+      "date-parts": [
+        [
+          2022
+        ]
+      ]
+    },
+    "DOI": "10.3389/fcomp.2022.926649",
+    "URL": "https://doi.org/10.3389/fcomp.2022.926649",
+    "custom": {
+      "group": "interface",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "an expanding and contracting circle pacing 6 breaths per minute produced HRV amplitude gains statistically indistinguishable from sensor-driven HRV biofeedback",
+        "both conditions took roughly two minutes for effects to appear",
+        "paced breathing needs no sensor, no real-time processing and no sustained attention, which suits it to use as a secondary task"
+      ],
+      "caveat": "Between-subjects, n = 28 (14 per group), single 10-minute session. This is the strongest published warrant for exhale's specific design choices: an expanding/contracting shape, no hardware, no account, watchable while doing something else."
+    }
+  },
+  {
+    "id": "tsubota1993-vdt-blink",
+    "type": "article-journal",
+    "title": "Dry Eyes and Video Display Terminals",
+    "author": [
+      {
+        "family": "Tsubota",
+        "given": "Kazuo"
+      },
+      {
+        "family": "Nakamori",
+        "given": "Katsu"
+      }
+    ],
+    "container-title": "New England Journal of Medicine",
+    "volume": "328",
+    "issue": "8",
+    "page": "584",
+    "issued": {
+      "date-parts": [
+        [
+          1993
+        ]
+      ]
+    },
+    "DOI": "10.1056/NEJM199302253280817",
+    "URL": "https://doi.org/10.1056/NEJM199302253280817",
+    "custom": {
+      "group": "premise",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "blink rate during display work is far below blink rate at rest"
+      ],
+      "caveat": "NUMBERS NOT READ 2026-08-28. This is a one-page correspondence item, not a full paper, and it is paywalled to automated fetch. It is the origin of the widely quoted '22 blinks/min at rest, 7 during screen work' figures, which circulate almost entirely by secondary citation. Cite it for the direction of the effect. For a magnitude you can defend, use rosenfield2011-computer-vision-syndrome or sheppard2018-digital-eye-strain instead."
+    }
+  },
+  {
+    "id": "vandiest2014-ie-ratio-relaxation",
+    "type": "article-journal",
+    "title": "Inhalation/Exhalation Ratio Modulates the Effect of Slow Breathing on Heart Rate Variability and Relaxation",
+    "author": [
+      {
+        "family": "Van Diest",
+        "given": "Ilse"
+      },
+      {
+        "family": "Verstappen",
+        "given": "Karen"
+      },
+      {
+        "family": "Aubert",
+        "given": "André E."
+      },
+      {
+        "family": "Widjaja",
+        "given": "Devy"
+      },
+      {
+        "family": "Vansteenwegen",
+        "given": "Debora"
+      },
+      {
+        "family": "Vlemincx",
+        "given": "Elke"
+      }
+    ],
+    "container-title": "Applied Psychophysiology and Biofeedback",
+    "volume": "39",
+    "issue": "3-4",
+    "page": "171-180",
+    "issued": {
+      "date-parts": [
+        [
+          2014
+        ]
+      ]
+    },
+    "DOI": "10.1007/s10484-014-9253-x",
+    "URL": "https://doi.org/10.1007/s10484-014-9253-x",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "participants reported more relaxation, more stress reduction, more mindfulness and more positive energy breathing with a low inhale/exhale ratio (longer exhale) than a high one",
+        "a low inhale/exhale ratio also produced more HF-HRV power, but only in the slow breathing condition",
+        "slowing the rate on its own improved only self-reported positive energy"
+      ],
+      "caveat": "n = 30, four patterns crossing rate (6 or 12 breaths/min) with i/e ratio (0.42 or 2.33). This is the single most important entry for exhale's longer-exhale recommendation, and for a reason easy to miss: it is the only study in this corpus that measured how people FELT across ratios, and on that outcome the longer exhale clearly won. The HRV studies that disagree about ratio were measuring something else."
+    }
+  },
+  {
+    "id": "vandijk2018-close-the-book",
+    "type": "article-journal",
+    "title": "It is time to close the book on device-guided slow breathing",
+    "author": [
+      {
+        "family": "van Dijk",
+        "given": "Peter R."
+      },
+      {
+        "family": "van Hateren",
+        "given": "Kornelis J. J."
+      },
+      {
+        "family": "Kleefstra",
+        "given": "Nanne"
+      },
+      {
+        "family": "Landman",
+        "given": "Gijs W. D."
+      }
+    ],
+    "container-title": "Blood Pressure",
+    "volume": "27",
+    "issue": "3",
+    "page": "181-182",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "DOI": "10.1080/08037051.2018.1435260",
+    "URL": "https://doi.org/10.1080/08037051.2018.1435260",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": null,
+      "backsClaims": [
+        "a body of specialist opinion holds that the blood-pressure case for device-guided slow breathing is weak and should be considered closed"
+      ],
+      "caveat": "Editorial, two pages, not a study, hence no evidence tier. Carried deliberately: it is the strongest published dissent against the cardiovascular claims exhale sits next to, and a corpus that omitted it would be advocacy rather than provenance."
+    }
+  },
+  {
+    "id": "vlemincx2013-sigh-reset-model",
+    "type": "article-journal",
+    "title": "Respiratory variability and sighing: A psychophysiological reset model",
+    "author": [
+      {
+        "family": "Vlemincx",
+        "given": "Elke"
+      },
+      {
+        "family": "Abelson",
+        "given": "James L."
+      },
+      {
+        "family": "Lehrer",
+        "given": "Paul M."
+      },
+      {
+        "family": "Davenport",
+        "given": "Paul W."
+      },
+      {
+        "family": "Van Diest",
+        "given": "Ilse"
+      },
+      {
+        "family": "Van den Bergh",
+        "given": "Omer"
+      }
+    ],
+    "container-title": "Biological Psychology",
+    "volume": "93",
+    "issue": "1",
+    "page": "24-32",
+    "issued": {
+      "date-parts": [
+        [
+          2013
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.biopsycho.2012.12.001",
+    "URL": "https://doi.org/10.1016/j.biopsycho.2012.12.001",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "sighs act as resetters of respiratory variability: random variability is elevated before a sigh and correlated variability increases after one"
+      ],
+      "caveat": "Theoretical model paper with supporting data. Carried because it is the honest place to point when someone asks why a deliberately irregular breath might be useful, which is the only literature adjacent to exhale's randomised-timing sliders. It is not evidence that those sliders help; see the gaps ledger."
+    }
+  },
+  {
+    "id": "vlemincx2016-sigh-relief",
+    "type": "article-journal",
+    "title": "A sigh of relief or a sigh to relieve: The psychological and physiological relief effect of deep breaths",
+    "author": [
+      {
+        "family": "Vlemincx",
+        "given": "Elke"
+      },
+      {
+        "family": "Van Diest",
+        "given": "Ilse"
+      },
+      {
+        "family": "Van den Bergh",
+        "given": "Omer"
+      }
+    ],
+    "container-title": "Physiology & Behavior",
+    "volume": "165",
+    "page": "127-135",
+    "issued": {
+      "date-parts": [
+        [
+          2016
+        ]
+      ]
+    },
+    "DOI": "10.1016/j.physbeh.2016.07.004",
+    "URL": "https://doi.org/10.1016/j.physbeh.2016.07.004",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "self-reported relief was higher after an instructed deep breath than before it",
+        "spontaneous sighs were followed by a gradual fall in muscle tension, most clearly in people high in anxiety sensitivity"
+      ],
+      "caveat": "NUMBERS NOT READ 2026-08-28; paywalled to automated fetch, findings taken from the abstract. The instructed-breath result is the closest thing in this corpus to evidence that being told to take one deliberate breath, which is precisely what exhale's reminder does, changes how a person feels."
+    }
+  },
+  {
+    "id": "wongsuphasawat2012-cant-force-calm",
+    "type": "paper-conference",
+    "title": "You can't force calm: designing and evaluating respiratory regulating interfaces for calming technology",
+    "author": [
+      {
+        "family": "Wongsuphasawat",
+        "given": "Kanit"
+      },
+      {
+        "family": "Gamburg",
+        "given": "Alex"
+      },
+      {
+        "family": "Moraveji",
+        "given": "Neema"
+      }
+    ],
+    "container-title": "Adjunct Proceedings of the 25th Annual ACM Symposium on User Interface Software and Technology (UIST '12 Adjunct)",
+    "page": "69-70",
+    "issued": {
+      "date-parts": [
+        [
+          2012
+        ]
+      ]
+    },
+    "DOI": "10.1145/2380296.2380326",
+    "URL": "https://doi.org/10.1145/2380296.2380326",
+    "custom": {
+      "group": "interface",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "visual pacing produced more measured respiratory change than auditory pacing, but auditory pacing was rated as subjectively more calming"
+      ],
+      "caveat": "Two-page adjunct paper, effectively a poster; treat the finding as a design signal, not a result. It is carried anyway because it is the one published comparison that puts exhale's visual-only design at a disadvantage on the outcome most users actually care about, which is whether they feel calmer."
+    }
+  },
+  {
+    "id": "yackle2017-breathing-arousal-neurons",
+    "type": "article-journal",
+    "title": "Breathing control center neurons that promote arousal in mice",
+    "author": [
+      {
+        "family": "Yackle",
+        "given": "Kevin"
+      },
+      {
+        "family": "Schwarz",
+        "given": "Lindsay A."
+      },
+      {
+        "family": "Kam",
+        "given": "Kaiwen"
+      },
+      {
+        "family": "Sorokin",
+        "given": "Jordan M."
+      },
+      {
+        "family": "Huguenard",
+        "given": "John R."
+      },
+      {
+        "family": "Feldman",
+        "given": "Jack L."
+      },
+      {
+        "family": "Luo",
+        "given": "Liqun"
+      },
+      {
+        "family": "Krasnow",
+        "given": "Mark A."
+      }
+    ],
+    "container-title": "Science",
+    "volume": "355",
+    "issue": "6332",
+    "page": "1411-1415",
+    "issued": {
+      "date-parts": [
+        [
+          2017
+        ]
+      ]
+    },
+    "DOI": "10.1126/science.aai7984",
+    "URL": "https://doi.org/10.1126/science.aai7984",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "a small preBotzinger subpopulation projects to and positively regulates noradrenergic locus coeruleus neurons, giving breathing a direct anatomical route to arousal state",
+        "ablating those roughly 175 neurons left breathing intact but increased calm behaviours"
+      ],
+      "caveat": "Mouse work, and the direction is breathing pattern to arousal rather than voluntarily slow breathing to calm. It is the single best answer to 'why would breathing slowly change how I feel at all', and it is still an inference from mice. Do not cite it for a human effect."
+    }
+  },
+  {
+    "id": "yasuma2004-rsa",
+    "type": "article-journal",
+    "title": "Respiratory Sinus Arrhythmia: Why Does the Heartbeat Synchronize With Respiratory Rhythm?",
+    "author": [
+      {
+        "family": "Yasuma",
+        "given": "Fumihiko"
+      },
+      {
+        "family": "Hayano",
+        "given": "Jun-ichiro"
+      }
+    ],
+    "container-title": "Chest",
+    "volume": "125",
+    "issue": "2",
+    "page": "683-690",
+    "issued": {
+      "date-parts": [
+        [
+          2004
+        ]
+      ]
+    },
+    "DOI": "10.1378/chest.125.2.683",
+    "URL": "https://doi.org/10.1378/chest.125.2.683",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "heart rate rises on inhalation and falls on exhalation, and this respiratory sinus arrhythmia is the coupling that HRV-based breathing claims rest on"
+      ],
+      "caveat": "Review. This is the physiological fact underneath every 'longer exhale calms you' claim in this corpus, which is why the claim is so intuitive and why meehan2024-longer-exhalations failing to find a ratio effect is worth taking seriously: a real beat-to-beat mechanism does not guarantee a measurable session-level outcome."
+    }
+  },
+  {
+    "id": "you2023-respiratory-frequency",
+    "type": "article-journal",
+    "title": "Influence of Respiratory Frequency of Slow-Paced Breathing on Vagally-Mediated Heart Rate Variability",
+    "author": [
+      {
+        "family": "You",
+        "given": "Min"
+      },
+      {
+        "family": "Laborde",
+        "given": "Sylvain"
+      },
+      {
+        "family": "Ackermann",
+        "given": "Stefan"
+      },
+      {
+        "family": "Borges",
+        "given": "Uirassu"
+      },
+      {
+        "family": "Dosseville",
+        "given": "Fabrice"
+      },
+      {
+        "family": "Mosley",
+        "given": "Emma"
+      }
+    ],
+    "container-title": "Applied Psychophysiology and Biofeedback",
+    "volume": "49",
+    "issue": "1",
+    "page": "133-143",
+    "issued": {
+      "date-parts": [
+        [
+          2023
+        ]
+      ]
+    },
+    "DOI": "10.1007/s10484-023-09605-2",
+    "URL": "https://doi.org/10.1007/s10484-023-09605-2",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "five minutes of slow-paced breathing at 5, 5.5, 6, 6.5 and 7 cycles per minute all raised cardiac vagal activity above spontaneous breathing",
+        "LF-HRV discriminated between the tested frequencies more sensitively than RMSSD",
+        "the band actually tested and supported is 5 to 7 cycles per minute"
+      ],
+      "caveat": "Crossref records this as issued 2023 (online 8 December); it appears in the March 2024 issue, 49(1), which is how it is usually cited. The citekey follows the Crossref issued year, as everywhere else in this corpus. n = 75, all athletes aged 19-31, single lab session. Generalisation to a desk worker is an assumption, not a finding. This is the source that puts a number on exhale's default: 5 s in and 10 s out is 4.0 cycles per minute, below the bottom of the band this study tested."
+    }
+  },
+  {
+    "id": "zaccaro2018-slow-breathing-review",
+    "type": "article-journal",
+    "title": "How Breath-Control Can Change Your Life: A Systematic Review on Psycho-Physiological Correlates of Slow Breathing",
+    "author": [
+      {
+        "family": "Zaccaro",
+        "given": "Andrea"
+      },
+      {
+        "family": "Piarulli",
+        "given": "Andrea"
+      },
+      {
+        "family": "Laurino",
+        "given": "Marco"
+      },
+      {
+        "family": "Garbella",
+        "given": "Erika"
+      },
+      {
+        "family": "Menicucci",
+        "given": "Danilo"
+      },
+      {
+        "family": "Neri",
+        "given": "Bruno"
+      },
+      {
+        "family": "Gemignani",
+        "given": "Angelo"
+      }
+    ],
+    "container-title": "Frontiers in Human Neuroscience",
+    "volume": "12",
+    "page": "353",
+    "issued": {
+      "date-parts": [
+        [
+          2018
+        ]
+      ]
+    },
+    "DOI": "10.3389/fnhum.2018.00353",
+    "URL": "https://doi.org/10.3389/fnhum.2018.00353",
+    "custom": {
+      "group": "slow-breathing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "slow breathing, conventionally defined as under 10 breaths per minute, is associated with increased HRV and shifts in central and autonomic measures",
+        "reported psychological correlates include increased comfort and relaxation and reduced anxiety and arousal"
+      ],
+      "caveat": "Systematic review without meta-analysis. The included studies vary widely in technique, rate and duration, so the pooled picture is directional rather than dose-specific."
+    }
+  },
+  {
+    "id": "zelano2016-nasal-respiration-limbic",
+    "type": "article-journal",
+    "title": "Nasal Respiration Entrains Human Limbic Oscillations and Modulates Cognitive Function",
+    "author": [
+      {
+        "family": "Zelano",
+        "given": "Christina"
+      },
+      {
+        "family": "Jiang",
+        "given": "Heidi"
+      },
+      {
+        "family": "Zhou",
+        "given": "Guangyu"
+      },
+      {
+        "family": "Arora",
+        "given": "Nikita"
+      },
+      {
+        "family": "Schuele",
+        "given": "Stephan"
+      },
+      {
+        "family": "Rosenow",
+        "given": "Joshua"
+      },
+      {
+        "family": "Gottfried",
+        "given": "Jay A."
+      }
+    ],
+    "container-title": "The Journal of Neuroscience",
+    "volume": "36",
+    "issue": "49",
+    "page": "12448-12467",
+    "issued": {
+      "date-parts": [
+        [
+          2016
+        ]
+      ]
+    },
+    "DOI": "10.1523/JNEUROSCI.2586-16.2016",
+    "URL": "https://doi.org/10.1523/JNEUROSCI.2586-16.2016",
+    "custom": {
+      "group": "mechanism",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "nasal breathing entrains oscillations in human piriform cortex, amygdala and hippocampus, and the effect is specific to the nasal route rather than to breathing as such"
+      ],
+      "caveat": "Human intracranial recordings in a small epilepsy-surgery cohort plus behavioural experiments. Carried because it is the reason nose-versus-mouth is a real variable and not folklore. exhale gives no nasal-breathing guidance at all, which is a defensible omission for a wordless overlay but should be a conscious one."
+    }
+  }
+]

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -1,0 +1,857 @@
+# Citation corpus
+
+42 sources: 40 Crossref-verified, 2 verified against Open Library. 5 are cited from their abstract only and say so, and 2 are not peer-reviewed and are tiered E so they can back lineage but never a claim.
+
+Machine-readable companion: [`CITATIONS.csl.json`](./CITATIONS.csl.json) (CSL-JSON).
+Verification pass completed 2026-08-28 against the Crossref REST API.
+
+> **This file is generated.** Edit [`CITATIONS.csl.json`](./CITATIONS.csl.json) for records and
+> [`citations-notes.md`](./citations-notes.md) for the prose, then run
+> `uv run --no-project scripts/generate-citations.py`. Editing `CITATIONS.md` directly will be
+> overwritten. `--check` fails if the two drift apart.
+
+exhale is a breathing overlay, not a medical device, and nothing here is medical advice. See the
+[disclaimer](../README.md#disclaimer). This corpus exists so that anyone, including the author, can
+check which of exhale's claims and defaults rest on published evidence and which do not. The
+[gaps ledger](#gaps-and-unsupported-choices) at the end is the more useful half.
+
+## How to read this
+
+### Verification status
+
+This says how the *bibliographic record* was checked. It says nothing about whether the finding is
+true, and nothing about whether the full text was read.
+
+| Status | Meaning |
+|---|---|
+| `crossref-verified` | The DOI resolves in Crossref, and the title, authors, year, journal, volume and pages printed here are the ones Crossref returned, not the ones a search result claimed. |
+| `openlibrary-verified` | No DOI exists because the source is a book. The title, author, publisher and page count printed here were checked against the Open Library record for the stated ISBN. Edition ambiguities are written into the caveat. |
+| `unverified` | No resolvable DOI and no catalogue record. Bibliographic details are inherited from secondary citation and may be wrong. |
+
+A `crossref-verified` record can still carry a loud caveat. Several entries here are Crossref-verified
+but were paywalled to full-text fetch, meaning we confirmed the paper exists and is what we say it is
+but never read its numbers. Those carry `NUMBERS NOT READ` in the caveat. Verification confirms the
+*citation*, not the *claim*.
+
+### Access level
+
+`open-access` (a CC licence is registered with Crossref, or the title is fully open access) |
+`paywalled`. Where a Crossref `license` field was present, the access level is taken from it rather
+than guessed; where it was absent the basis is stated in the entry's caveat.
+
+### Evidence tier
+
+Applied to sources making a claim about what happens to a human being. Physiological and animal
+mechanism papers are tier D by definition: they explain why something might work, they do not
+establish that it does.
+
+| Tier | Definition | How exhale is allowed to use it |
+|---|---|---|
+| A | Systematic review or meta-analysis of controlled trials, or a large pre-registered RCT | May be cited for an outcome claim |
+| B | Controlled experiment with an internal replication, or a systematic review of controlled experiments | May be cited for an outcome claim, with its scope conditions stated |
+| C | Single controlled experiment, small n, or lab-only | Cite as suggestive; never as "research shows" |
+| D | Narrative review, mechanism, or animal work | Cite for *why*, never for *whether* |
+| E | Not peer reviewed, or contradicted by better evidence | May be cited for provenance, meaning where a practice came from. Never for whether it works |
+
+### Counts
+
+| Verification | n |
+|---|---|
+| crossref-verified | 40 |
+| openlibrary-verified | 2 |
+| **total** | **42** |
+
+| Access level | n |
+|---|---|
+| open-access | 17 |
+| paywalled | 25 |
+| **total** | **42** |
+
+| Evidence tier | n |
+|---|---|
+| A | 7 |
+| B | 7 |
+| C | 16 |
+| D | 9 |
+| E | 2 |
+| null (not a study) | 1 |
+| **total** | **42** |
+
+---
+
+## Why a breathing reminder next to a screen
+
+11 sources.
+
+#### `albulescu2022-micro-breaks`
+
+Albulescu, Patricia; Macsinga, Irina; Rusu, Andrei; Sulea, Coralia; Bodnaru, Alexandra; Tulbure, Bogdan Tudor. (2022). *"Give me a break!" A systematic review and meta-analysis on the efficacy of micro-breaks for increasing well-being and performance*. PLOS ONE 17(8): e0272460
+
+- DOI: [10.1371/journal.pone.0272460](https://doi.org/10.1371/journal.pone.0272460)
+- Verification: crossref-verified | Access: open-access | evidence tier **A**
+- Backs:
+  - short breaks of ten minutes or less from a work task reduce fatigue and increase vigor
+  - an interruption long enough to run one breath cycle is a plausible unit of recovery
+- Caveat: 22 studies, 19 manuscripts. The performance effect was smaller and less consistent than the well-being effect, and the authors report it depended on task type. None of the included studies used a breathing exercise as the break activity, so this supports the general shape of exhale's reminder timer, not its specific content.
+
+#### `deniz2024-forward-head-lung-volumes`
+
+Deniz, Yasemin; Ertekın, Damla; Cokar, Dılek. (2024). *The effect of forward head posture on dynamic lung volumes in young adults: a systematic review*. Bulletin of Faculty of Physical Therapy 29(1): 15
+
+- DOI: [10.1186/s43161-024-00186-7](https://doi.org/10.1186/s43161-024-00186-7)
+- Verification: crossref-verified | Access: open-access | evidence tier **B**
+- Backs:
+  - across four comparison studies totalling 115 participants, forward head posture was associated with FVC reductions of 0.25 to 0.81 L and FEV1 reductions of 0.16 to 0.93 L
+  - craniovertebral angle correlates positively with dynamic pulmonary volumes
+- Caveat: Systematic review without meta-analysis; the authors phrase the conclusion as FHP 'can potentially cause' pulmonary abnormalities. Searched ResearchGate alongside PubMed and Google Scholar, which is an unusual database choice. This is the posture half of the screen-breathing argument: it is about head position, not about screens, and the link to screens comes from jung2016-smartphone-posture-respiration.
+
+#### `grassmann2016-cognitive-load-respiration`
+
+Grassmann, Mariel; Vlemincx, Elke; von Leupoldt, Andreas; Mittelstädt, Justin M.; Van den Bergh, Omer. (2016). *Respiratory Changes in Response to Cognitive Load: A Systematic Review*. Neural Plasticity 2016: 8146809
+
+- DOI: [10.1155/2016/8146809](https://doi.org/10.1155/2016/8146809)
+- Verification: crossref-verified | Access: open-access | evidence tier **A**
+- Backs:
+  - mentally demanding work is reliably marked by faster breathing, with medium to large effects
+  - respiratory amplitude stays roughly stable under cognitive load rather than shrinking
+  - cognitive load lowers end-tidal CO2, meaning ventilation runs ahead of metabolic need
+- Caveat: 54 experiments across 53 articles. Careful with this one: it establishes that cognitive load raises rate while leaving amplitude roughly stable, so it does NOT support 'shallow' if shallow means less air moved. Minute ventilation goes up. For the diaphragmatic-to-thoracic shift that 'shallow' actually names, cite schleifer2002-hyperventilation-job-stress; for the same effect measured at a real keyboard, cite schleifer1994-vdt-petco2 and schleifer2008-emg-gaps-computer-work. This entry is the general cognitive-load backdrop.
+
+#### `johnson2023-20-20-20`
+
+Johnson, Sophia; Rosenfield, Mark. (2023). *20-20-20 Rule: Are These Numbers Justified?* Optometry and Vision Science 100(1): 52-56
+
+- DOI: [10.1097/OPX.0000000000001971](https://doi.org/10.1097/OPX.0000000000001971)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - the widely repeated 20-20-20 rule has little peer-reviewed support
+  - scheduled 20-second breaks every 5, 10 or 20 minutes produced no significant effect on ocular symptoms, reading speed or task accuracy
+- Caveat: n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge is not self-evidently effective just because it is popular and plausible.
+
+#### `jung2016-smartphone-posture-respiration`
+
+Jung, Sang In; Lee, Na Kyung; Kang, Kyung Woo; Kim, Kyoung; Lee, Do Youn. (2016). *The effect of smartphone usage time on posture and respiratory function*. Journal of Physical Therapy Science 28(1): 186-189
+
+- DOI: [10.1589/jpts.28.186](https://doi.org/10.1589/jpts.28.186)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - people using smartphones more than four hours a day had significantly worse craniovertebral angle, worse scapular index and lower peak expiratory flow than people using them less than four hours a day
+- Caveat: n = 50, cross-sectional, two groups split on self-reported usage. Correlational: heavy users may differ in many ways besides screen time, and peak expiratory flow was the only respiratory measure that separated (FVC and FEV1 did not). Crossref carries no license; access level taken from J Phys Ther Sci being fully open access.
+
+#### `rosenfield2011-computer-vision-syndrome`
+
+Rosenfield, Mark. (2011). *Computer vision syndrome: a review of ocular causes and potential treatments*. Ophthalmic and Physiological Optics 31(5): 502-515
+
+- DOI: [10.1111/j.1475-1313.2011.00834.x](https://doi.org/10.1111/j.1475-1313.2011.00834.x)
+- Verification: crossref-verified | Access: paywalled | evidence tier **B**
+- Backs:
+  - blink rate falls substantially during display work relative to other tasks
+  - reduced and incomplete blinking is a principal mechanism of computer vision syndrome
+- Caveat: Narrative review of the ocular literature. Load-bearing for the blink half of exhale's opening claim only. exhale does nothing about blinking; see the gaps ledger.
+
+#### `schleifer1994-vdt-petco2`
+
+Schleifer, Lawrence M.; Ley, Ronald. (1994). *End-tidal PCO2 as an index of psychophysiological activity during VDT data-entry work and relaxation*. Ergonomics 37(2): 245-254
+
+- DOI: [10.1080/00140139408963642](https://doi.org/10.1080/00140139408963642)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - during computer data-entry work, end-tidal CO2 was significantly lower and respiration frequency significantly higher than during either baseline relaxation or progressive muscle relaxation
+  - breathing changes measurably at a screen, and end-tidal CO2 discriminates the state
+- Caveat: n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real screen work over real working days, not a lab proxy. This entry retracts an earlier claim in this repo that no peer-reviewed study had measured respiration during ordinary screen use. It had; this is it, from 1994.
+
+#### `schleifer2002-hyperventilation-job-stress`
+
+Schleifer, Lawrence M.; Ley, Ronald; Spalding, Thomas W.. (2002). *A hyperventilation theory of job stress and musculoskeletal disorders*. American Journal of Industrial Medicine 41(5): 420-432
+
+- DOI: [10.1002/ajim.10061](https://doi.org/10.1002/ajim.10061)
+- Verification: crossref-verified | Access: paywalled | evidence tier **D**
+- Backs:
+  - hyperventilation is often characterised by a shift from a diaphragmatic to a thoracic breathing pattern
+  - thoracic breathing recruits sternocleidomastoid, scalene and trapezius muscles, imposing biomechanical stress on the neck and shoulder region
+  - breathing training and rest breaks are a rationale-backed response to this pattern at work
+- Caveat: Theory paper, not an experiment, hence tier D. It is nonetheless the closest thing in the peer-reviewed literature to the folk claim about 'shallow' breathing at a screen: the diaphragmatic-to-thoracic shift IS what people mean by shallow. Cite it for the pattern, never for a measured tidal volume, and note it theorises the shift rather than demonstrating it in screen users.
+
+#### `schleifer2008-emg-gaps-computer-work`
+
+Schleifer, Lawrence M.; Spalding, Thomas W.; Kerick, Scott E.; Cram, Jeffrey R.; Ley, Ronald; Hatfield, Bradley D.. (2008). *Mental stress and trapezius muscle activation under psychomotor challenge: A focus on EMG gaps during computer work*. Psychophysiology 45(3): 356-365
+
+- DOI: [10.1111/j.1469-8986.2008.00645.x](https://doi.org/10.1111/j.1469-8986.2008.00645.x)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - end-tidal CO2 was lower under high mental workload than low during computer data entry, replicating the over-breathing finding in a second sample
+  - lower end-tidal CO2 tracked reduced trapezius EMG-gap frequency, suggesting over-breathing mediates muscle tension at the keyboard
+- Caveat: n = 23. The second independent measurement by this group of the same effect, fourteen years after schleifer1994-vdt-petco2. Two small samples pointing the same way is what the screen-breathing claim actually rests on.
+
+#### `sheppard2018-digital-eye-strain`
+
+Sheppard, Amy L.; Wolffsohn, James S.. (2018). *Digital eye strain: prevalence, measurement and amelioration*. BMJ Open Ophthalmology 3(1): e000146
+
+- DOI: [10.1136/bmjophth-2018-000146](https://doi.org/10.1136/bmjophth-2018-000146)
+- Verification: crossref-verified | Access: open-access | evidence tier **B**
+- Backs:
+  - digital eye strain is common among heavy display users
+  - reduced blink rate and incomplete blinks during screen work are among its established contributors
+- Caveat: Crossref carries no license field for this record; access level is taken from BMJ Open Ophthalmology being a fully open-access title.
+
+#### `tsubota1993-vdt-blink`
+
+Tsubota, Kazuo; Nakamori, Katsu. (1993). *Dry Eyes and Video Display Terminals*. New England Journal of Medicine 328(8): 584
+
+- DOI: [10.1056/NEJM199302253280817](https://doi.org/10.1056/NEJM199302253280817)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - blink rate during display work is far below blink rate at rest
+- Caveat: NUMBERS NOT READ 2026-08-28. This is a one-page correspondence item, not a full paper, and it is paywalled to automated fetch. It is the origin of the widely quoted '22 blinks/min at rest, 7 during screen work' figures, which circulate almost entirely by secondary citation. Cite it for the direction of the effect. For a magnitude you can defend, use rosenfield2011-computer-vision-syndrome or sheppard2018-digital-eye-strain instead.
+
+---
+
+## Whether slow paced breathing does anything
+
+7 sources.
+
+#### `chaddha2019-slow-breathing-bp`
+
+Chaddha, Ashish; Modaff, Daniel; Hooper-Lane, Christopher; Feldstein, David A.. (2019). *Device and non-device-guided slow breathing to reduce blood pressure: A systematic review and meta-analysis*. Complementary Therapies in Medicine 45: 179-184
+
+- DOI: [10.1016/j.ctim.2019.03.005](https://doi.org/10.1016/j.ctim.2019.03.005)
+- Verification: crossref-verified | Access: paywalled | evidence tier **A**
+- Backs:
+  - sustained slow breathing programmes lower systolic blood pressure by about 5.6 mmHg and diastolic by about 3.0 mmHg in hypertensive and prehypertensive adults
+- Caveat: 17 RCTs. Heterogeneity was high for every analysis, and the authors say so. Inclusion required at least 5 minutes of breathing at 10 breaths/min or slower, on at least 3 days a week, for at least 4 weeks. exhale asks for none of that and measures none of it, so this describes a dose exhale does not deliver. Read alongside vandijk2018-close-the-book.
+
+#### `fincham2023-breathwork-meta`
+
+Fincham, Guy William; Strauss, Clara; Montero-Marin, Jesus; Cavanagh, Kate. (2023). *Effect of breathwork on stress and mental health: A meta-analysis of randomised-controlled trials*. Scientific Reports 13(1): 432
+
+- DOI: [10.1038/s41598-022-27247-y](https://doi.org/10.1038/s41598-022-27247-y)
+- Verification: crossref-verified | Access: open-access | evidence tier **A**
+- Backs:
+  - breathwork lowers self-reported stress against control conditions, g = -0.35 (95% CI -0.55 to -0.14), 12 RCTs, 785 adults
+  - comparable small-to-medium effects for anxiety (g = -0.32, k = 20) and depressive symptoms (g = -0.40, k = 18)
+- Caveat: Most included studies were rated at moderate risk of bias. Effects are small-to-medium and self-reported. This is the strongest single warrant for the claim that a breathing practice does something, and it is still a g of about a third of a standard deviation.
+
+#### `laborde2022-vsb-meta`
+
+Laborde, S.; Allen, M. S.; Borges, U.; Dosseville, F.; Hosang, T. J.; Iskra, M.; Mosley, E.; Salvotti, C.; Spolverato, L.; Zammit, N.; Javelle, F.. (2022). *Effects of voluntary slow breathing on heart rate and heart rate variability: A systematic review and a meta-analysis*. Neuroscience & Biobehavioral Reviews 138: 104711
+
+- DOI: [10.1016/j.neubiorev.2022.104711](https://doi.org/10.1016/j.neubiorev.2022.104711)
+- Verification: crossref-verified | Access: paywalled | evidence tier **A**
+- Backs:
+  - voluntary slow breathing raises vagally-mediated HRV during the session, immediately after a single session, and after a multi-session intervention
+  - few adverse effects are expected from slow breathing practice
+- Caveat: 223 studies from 1842 screened abstracts (172 during, 16 immediately-after, 49 after-intervention). This is the central warrant for exhale's whole premise. Note what it establishes: an effect on a cardiac index of parasympathetic activity, not an effect on how anyone feels or works.
+
+#### `little2025-a52-breath-method`
+
+Little, Abbie L.. (2025). *The A52 Breath Method: A Narrative Review of Breathwork for Mental Health and Stress Resilience*. Stress and Health 41(4): e70098
+
+- DOI: [10.1002/smi.70098](https://doi.org/10.1002/smi.70098)
+- Verification: crossref-verified | Access: open-access | evidence tier **D**
+- Backs:
+  - a 5 s inhale, 5 s exhale, 2 s post-exhale hold at five breaths per minute is a protocol a recent review argues is representative of the effective literature
+  - 23 of 30 reviewed studies reported significant HRV improvement; 10 reported anxiety reduction and 9 reported reduced perceived stress
+  - benefits appear larger in people with elevated baseline distress
+- Caveat: Narrative review, single author, 465 abstracts screened and 30 full texts analysed, with no meta-analysis and no risk-of-bias assessment. It proposes the protocol it reviews, which is a conflict of framing worth naming. Its A52 shape maps onto exhale's four sliders as 5 / 0 / 5 / 2, which is 5 breaths per minute and inside the tested band, unlike exhale's shipped default. Note that marchant2025-square-478-six found no-hold 6 bpm outperformed both hold-bearing patterns it tested, so the 2 s retention here is the least supported part of the protocol.
+
+#### `russo2017-slow-breathing-physiology`
+
+Russo, Marc A.; Santarelli, Danielle M.; O'Rourke, Dean. (2017). *The physiological effects of slow breathing in the healthy human*. Breathe 13(4): 298-309
+
+- DOI: [10.1183/20734735.009817](https://doi.org/10.1183/20734735.009817)
+- Verification: crossref-verified | Access: open-access | evidence tier **D**
+- Backs:
+  - slow breathing improves ventilation efficiency and alters cardiorespiratory coupling, respiratory sinus arrhythmia and sympathovagal balance
+- Caveat: Narrative review. The authors close by calling explicitly for further research, and describe the health claims as potential rather than demonstrated. Use it to explain a mechanism, not to assert an outcome.
+
+#### `vandijk2018-close-the-book`
+
+van Dijk, Peter R.; van Hateren, Kornelis J. J.; Kleefstra, Nanne; Landman, Gijs W. D.. (2018). *It is time to close the book on device-guided slow breathing*. Blood Pressure 27(3): 181-182
+
+- DOI: [10.1080/08037051.2018.1435260](https://doi.org/10.1080/08037051.2018.1435260)
+- Verification: crossref-verified | Access: paywalled | no evidence tier (not a study)
+- Backs:
+  - a body of specialist opinion holds that the blood-pressure case for device-guided slow breathing is weak and should be considered closed
+- Caveat: Editorial, two pages, not a study, hence no evidence tier. Carried deliberately: it is the strongest published dissent against the cardiovascular claims exhale sits next to, and a corpus that omitted it would be advocacy rather than provenance.
+
+#### `zaccaro2018-slow-breathing-review`
+
+Zaccaro, Andrea; Piarulli, Andrea; Laurino, Marco; Garbella, Erika; Menicucci, Danilo; Neri, Bruno; Gemignani, Angelo. (2018). *How Breath-Control Can Change Your Life: A Systematic Review on Psycho-Physiological Correlates of Slow Breathing*. Frontiers in Human Neuroscience 12: 353
+
+- DOI: [10.3389/fnhum.2018.00353](https://doi.org/10.3389/fnhum.2018.00353)
+- Verification: crossref-verified | Access: open-access | evidence tier **B**
+- Backs:
+  - slow breathing, conventionally defined as under 10 breaths per minute, is associated with increased HRV and shifts in central and autonomic measures
+  - reported psychological correlates include increased comfort and relaxation and reduced anxiety and arousal
+- Caveat: Systematic review without meta-analysis. The included studies vary widely in technique, rate and duration, so the pooled picture is directional rather than dose-specific.
+
+---
+
+## What the numbers should be
+
+10 sources.
+
+#### `bae2021-exhalation-inhalation-ratio`
+
+Bae, Dalbyeol; Matthews, Jacob J. L.; Chen, J. Jean; Mah, Linda. (2021). *Increased exhalation to inhalation ratio during breathing enhances high-frequency heart rate variability in healthy adults*. Psychophysiology 58(11): e13905
+
+- DOI: [10.1111/psyp.13905](https://doi.org/10.1111/psyp.13905)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - a 2:1 exhale-to-inhale cue raised RMSSD and HF-HRV relative to a 1:1 cue at the participant's own breathing rate
+  - the HF-HRV elevation persisted about four minutes after the 2:1 block ended
+- Caveat: n = 28 (16 young, 12 older). Note the manipulation check: the achieved ratios were 1.08 and 1.33, nowhere near the instructed 1:1 and 2:1, and pacing was at each participant's spontaneous rate rather than in the resonance range. One of four studies that disagree about the ratio; see vandiest2014-ie-ratio-relaxation (also positive), lin2014-equal-ratio-hrv (favours the equal ratio) and meehan2024-longer-exhalations (null). Gap 4 in the ledger tabulates all four.
+
+#### `balban2023-cyclic-sighing`
+
+Balban, Melis Yilmaz; Neri, Eric; Kogon, Manuela M.; Weed, Lara; Nouriani, Bita; Jo, Booil; Holl, Gary; Zeitzer, Jamie M.; Spiegel, David; Huberman, Andrew D.. (2023). *Brief structured respiration practices enhance mood and reduce physiological arousal*. Cell Reports Medicine 4(1): 100895
+
+- DOI: [10.1016/j.xcrm.2022.100895](https://doi.org/10.1016/j.xcrm.2022.100895)
+- Verification: crossref-verified | Access: open-access | evidence tier **A**
+- Backs:
+  - five minutes a day of exhale-emphasising cyclic sighing improved mood and lowered respiratory rate more than an equal period of mindfulness meditation over one month
+  - box breathing, equal inhale / hold / exhale, was tested head-to-head and was not the best-performing arm
+- Caveat: Remote randomised controlled study, pre-registered as NCT05304000. The primary comparator is mindfulness meditation, not a sham, so the arms differ in more than breath ratio. The mood difference reached p < 0.05 in a mixed-effects model; this is a real but modest separation. Directly relevant to exhale twice over: it is the best evidence that a longer exhale is the right emphasis, and it is the reason the README should stop presenting box breathing as equivalent.
+
+#### `laborde2021-ie-ratio-pauses`
+
+Laborde, Sylvain; Iskra, Maša; Zammit, Nina; Borges, Uirassu; You, Min; Sevoz-Couche, Caroline; Dosseville, Fabrice. (2021). *Slow-Paced Breathing: Influence of Inhalation/Exhalation Ratio and of Respiratory Pauses on Cardiac Vagal Activity*. Sustainability 13(14): 7775
+
+- DOI: [10.3390/su13147775](https://doi.org/10.3390/su13147775)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - inhalation/exhalation ratio and the presence of respiratory pauses were manipulated directly against cardiac vagal activity as the outcome
+- Caveat: NUMBERS NOT READ 2026-08-28. Carried for the design question it asks, which is exactly the question exhale's four sliders pose. It is the fifth study bearing on the ratio disagreement tabulated in gap 4, and the only one that also manipulates respiratory pauses, which makes it the highest-value full text still unread in this corpus: it bears on both gap 4 and gap 11. Read it before quoting any effect from it.
+
+#### `laborde2021-spb-6cpm-biofeedback`
+
+Laborde, Sylvain; Allen, Mark S.; Borges, Uirassu; Iskra, Maša; Zammit, Nina; You, Min; Hosang, Thomas; Mosley, Emma; Dosseville, Fabrice. (2021). *Psychophysiological effects of slow-paced breathing at six cycles per minute with or without heart rate variability biofeedback*. Psychophysiology 59(1): e13952
+
+- DOI: [10.1111/psyp.13952](https://doi.org/10.1111/psyp.13952)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - slow-paced breathing at six cycles per minute raised RMSSD relative to control in every condition tested
+  - adding heart-rate-variability biofeedback on top of the six-per-minute pace did not add a further benefit
+- Caveat: Crossref records this as issued 2021, appearing in the January 2022 issue (59:1). Together with tabor2022-guided-breathing-design this is why exhale needs no sensor: the pace is doing the work, not the feedback loop.
+
+#### `lin2014-equal-ratio-hrv`
+
+Lin, I. M.; Tai, L. Y.; Fan, S. Y.. (2014). *Breathing at a rate of 5.5 breaths per minute with equal inhalation-to-exhalation ratio increases heart rate variability*. International Journal of Psychophysiology 91(3): 206-211
+
+- DOI: [10.1016/j.ijpsycho.2013.12.006](https://doi.org/10.1016/j.ijpsycho.2013.12.006)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - 5.5 breaths per minute with an equal 5:5 inhale-to-exhale ratio produced higher SDNN and LF power than 6 bpm or than a 4:6 ratio
+  - all four slow-breathing patterns increased self-reported relaxation relative to spontaneous breathing
+- Caveat: n = 47, Latin-square counterbalanced. The clearest published result AGAINST a longer exhale on HRV grounds, and it is why exhale's README no longer asserts the 1:2 mechanism. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works.
+
+#### `marchant2025-square-478-six`
+
+Marchant, Joshua; Khazan, Inna; Cressman, Mikel; Steffen, Patrick. (2025). *Comparing the Effects of Square, 4-7-8, and 6 Breaths-per-Minute Breathing Conditions on Heart Rate Variability, CO2 Levels, and Mood*. Applied Psychophysiology and Biofeedback 50(2): 261-276
+
+- DOI: [10.1007/s10484-025-09688-z](https://doi.org/10.1007/s10484-025-09688-z)
+- Verification: crossref-verified | Access: paywalled | evidence tier **B**
+- Backs:
+  - breathing at 6 breaths per minute raised HRV more than either square (box) breathing or 4-7-8 breathing, with small to medium effects
+  - square and 4-7-8 breathing are popularly promoted but have little empirical support
+  - none of the four conditions produced meaningful changes in blood pressure or mood
+  - breathing at 6 breaths per minute unexpectedly produced mild over-breathing
+- Caveat: n = 84 college students, within-subjects, four conditions: square, 4-7-8, 6 bpm at 4:6, and 6 bpm at 5:5. Single session, so it speaks to acute effect only. This is the head-to-head that answers exhale's default-preset question directly, and it answers against box breathing and against 4-7-8. The over-breathing finding is the uncomfortable one: see gap 5 in the ledger.
+
+#### `meehan2024-longer-exhalations`
+
+Meehan, Zachary M.; Shaffer, Fred. (2024). *Do Longer Exhalations Increase HRV During Slow-Paced Breathing?* Applied Psychophysiology and Biofeedback 49(3): 407-417
+
+- DOI: [10.1007/s10484-024-09637-2](https://doi.org/10.1007/s10484-024-09637-2)
+- Verification: crossref-verified | Access: open-access | evidence tier **B**
+- Backs:
+  - at 6 breaths per minute, a 1:2 inhale-to-exhale ratio produced no HRV advantage over 1:1 in either an original experiment or its replication
+  - the finding held across time-domain, frequency-domain and nonlinear HRV metrics
+- Caveat: Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of four disagreeing studies; see also vandiest2014-ie-ratio-relaxation and lin2014-equal-ratio-hrv. Critically, all four measured HRV; none of them measured how participants felt except vandiest2014-ie-ratio-relaxation, which is why exhale's recommendation now rests on the subjective outcome rather than on this dispute.
+
+#### `sevozcouche2022-coherence-resonance`
+
+Sevoz-Couche, Caroline; Laborde, Sylvain. (2022). *Heart rate variability and slow-paced breathing: when coherence meets resonance*. Neuroscience & Biobehavioral Reviews 135: 104576
+
+- DOI: [10.1016/j.neubiorev.2022.104576](https://doi.org/10.1016/j.neubiorev.2022.104576)
+- Verification: crossref-verified | Access: paywalled | evidence tier **D**
+- Backs:
+  - coherence and resonance are distinct phenomena that are frequently conflated in the slow-breathing literature
+- Caveat: Narrative review. Carried as a terminology guard: much of the popular writing exhale competes with uses 'coherence' loosely, and this is the paper to check before adopting that vocabulary in the app or the README.
+
+#### `vandiest2014-ie-ratio-relaxation`
+
+Van Diest, Ilse; Verstappen, Karen; Aubert, André E.; Widjaja, Devy; Vansteenwegen, Debora; Vlemincx, Elke. (2014). *Inhalation/Exhalation Ratio Modulates the Effect of Slow Breathing on Heart Rate Variability and Relaxation*. Applied Psychophysiology and Biofeedback 39(3-4): 171-180
+
+- DOI: [10.1007/s10484-014-9253-x](https://doi.org/10.1007/s10484-014-9253-x)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - participants reported more relaxation, more stress reduction, more mindfulness and more positive energy breathing with a low inhale/exhale ratio (longer exhale) than a high one
+  - a low inhale/exhale ratio also produced more HF-HRV power, but only in the slow breathing condition
+  - slowing the rate on its own improved only self-reported positive energy
+- Caveat: n = 30, four patterns crossing rate (6 or 12 breaths/min) with i/e ratio (0.42 or 2.33). This is the single most important entry for exhale's longer-exhale recommendation, and for a reason easy to miss: it is the only study in this corpus that measured how people FELT across ratios, and on that outcome the longer exhale clearly won. The HRV studies that disagree about ratio were measuring something else.
+
+#### `you2023-respiratory-frequency`
+
+You, Min; Laborde, Sylvain; Ackermann, Stefan; Borges, Uirassu; Dosseville, Fabrice; Mosley, Emma. (2023). *Influence of Respiratory Frequency of Slow-Paced Breathing on Vagally-Mediated Heart Rate Variability*. Applied Psychophysiology and Biofeedback 49(1): 133-143
+
+- DOI: [10.1007/s10484-023-09605-2](https://doi.org/10.1007/s10484-023-09605-2)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - five minutes of slow-paced breathing at 5, 5.5, 6, 6.5 and 7 cycles per minute all raised cardiac vagal activity above spontaneous breathing
+  - LF-HRV discriminated between the tested frequencies more sensitively than RMSSD
+  - the band actually tested and supported is 5 to 7 cycles per minute
+- Caveat: Crossref records this as issued 2023 (online 8 December); it appears in the March 2024 issue, 49(1), which is how it is usually cited. The citekey follows the Crossref issued year, as everywhere else in this corpus. n = 75, all athletes aged 19-31, single lab session. Generalisation to a desk worker is an assumption, not a finding. This is the source that puts a number on exhale's default: 5 s in and 10 s out is 4.0 cycles per minute, below the bottom of the band this study tested.
+
+---
+
+## Where the practice came from
+
+2 sources.
+
+#### `muktibodhananda1998-hatha-yoga-pradipika`
+
+Muktibodhananda, Swami. (1998). *Hatha Yoga Pradipika*. Munger, Bihar, India: Bihar School of Yoga
+
+- ISBN: 9788185787381 | [Open Library record](https://openlibrary.org/search?q=hatha+yoga+pradipika+muktibodhananda)
+- Verification: openlibrary-verified | Access: paywalled | evidence tier **E**
+- Backs:
+  - the classical hatha text and commentary in which timed inhale, retention and exhale ratios are set out is the historical origin of the ratio instructions modern breathing apps repeat
+- Caveat: NOT READ 2026-08-28. Bibliographic record checked against Open Library (Bihar School of Yoga, 1998 record). Not peer reviewed, and a commentary on a fifteenth-century text rather than a primary source in any modern sense. Carried because the 'longer exhale' instruction exhale ships did not come from a laboratory: it came from here, centuries before anyone measured HRV. Naming that is more honest than retrofitting a citation to psychophysiology. It must never back a physiological claim.
+
+#### `satyananda2008-apmb`
+
+Saraswati, Swami Satyananda. (2008). *Asana Pranayama Mudra Bandha*. Munger, Bihar, India: Yoga Publications Trust 553 pp
+
+- ISBN: 9788186336144 | [Open Library record](https://openlibrary.org/books/OL22138410M/Asana_pranayama_mudra_bandha)
+- Verification: openlibrary-verified | Access: paywalled | evidence tier **E**
+- Backs:
+  - the systematic pranayama tradition from which exhale's controllable inhale / retention / exhale / retention structure descends is documented in a standard modern reference manual
+- Caveat: NOT READ 2026-08-28. Bibliographic record checked against Open Library, which returns the Yoga Publications Trust edition at 553 pages under this ISBN but dates its record 1999, while the printing in question is described as the 2008 Fourth Revised Edition revised under Swami Niranjanananda Saraswati; the edition history of this title is genuinely tangled and this entry does not resolve it. Not peer reviewed. Cited ONLY for lineage: it is where exhale's four-phase structure comes from, and pretending the design was derived from 2020s psychophysiology would be revisionist. It must never back a physiological claim.
+
+---
+
+## Whether an on-screen visual pacer works
+
+3 sources.
+
+#### `moraveji2011-peripheral-paced-respiration`
+
+Moraveji, Neema; Olson, Ben; Nguyen, Truc; Saadat, Mahmoud; Khalighi, Yaser; Pea, Roy; Heer, Jeffrey. (2011). *Peripheral paced respiration: influencing user physiology during information work*. Proceedings of the 24th Annual ACM Symposium on User Interface Software and Technology (UIST '11) 423-428
+
+- DOI: [10.1145/2047196.2047250](https://doi.org/10.1145/2047196.2047250)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - a translucent animated bar spanning the screen, running in the periphery of attention during normal information work, significantly lowered participants' breathing rate
+  - peripheral pacing does not require the user's full attention to change breathing
+- Caveat: This is the closest published analogue to exhale that exists, and its limitation is the important part: the reduction occurred while the pacing feedback was active and did not persist as a lasting change in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as it is on. A free author copy is posted at vis.stanford.edu; the ACM Digital Library version is paywalled.
+
+#### `tabor2022-guided-breathing-design`
+
+Tabor, Aaron; Bateman, Scott; Scheme, Erik J.; schraefel, m.c.. (2022). *Comparing heart rate variability biofeedback and simple paced breathing to inform the design of guided breathing technologies*. Frontiers in Computer Science 4: 926649
+
+- DOI: [10.3389/fcomp.2022.926649](https://doi.org/10.3389/fcomp.2022.926649)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - an expanding and contracting circle pacing 6 breaths per minute produced HRV amplitude gains statistically indistinguishable from sensor-driven HRV biofeedback
+  - both conditions took roughly two minutes for effects to appear
+  - paced breathing needs no sensor, no real-time processing and no sustained attention, which suits it to use as a secondary task
+- Caveat: Between-subjects, n = 28 (14 per group), single 10-minute session. This is the strongest published warrant for exhale's specific design choices: an expanding/contracting shape, no hardware, no account, watchable while doing something else.
+
+#### `wongsuphasawat2012-cant-force-calm`
+
+Wongsuphasawat, Kanit; Gamburg, Alex; Moraveji, Neema. (2012). *You can't force calm: designing and evaluating respiratory regulating interfaces for calming technology*. Adjunct Proceedings of the 25th Annual ACM Symposium on User Interface Software and Technology (UIST '12 Adjunct) 69-70
+
+- DOI: [10.1145/2380296.2380326](https://doi.org/10.1145/2380296.2380326)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - visual pacing produced more measured respiratory change than auditory pacing, but auditory pacing was rated as subjectively more calming
+- Caveat: Two-page adjunct paper, effectively a poster; treat the finding as a design signal, not a result. It is carried anyway because it is the one published comparison that puts exhale's visual-only design at a disadvantage on the outcome most users actually care about, which is whether they feel calmer.
+
+---
+
+## Physiology and neuroscience
+
+7 sources.
+
+#### `lehrer2014-hrv-biofeedback`
+
+Lehrer, Paul M.; Gevirtz, Richard. (2014). *Heart rate variability biofeedback: how and why does it work?* Frontiers in Psychology 5: 756
+
+- DOI: [10.3389/fpsyg.2014.00756](https://doi.org/10.3389/fpsyg.2014.00756)
+- Verification: crossref-verified | Access: open-access | evidence tier **D**
+- Backs:
+  - maximum heart-rate oscillation is usually reached breathing at approximately 0.1 Hz, six breaths per minute
+  - refined measurement puts the average resonance frequency nearer 0.09 Hz, about 5.5 breaths per minute, a breath lasting roughly 11 seconds
+  - resonance frequency is individual: taller people and men tend to have lower resonance frequencies
+  - baroreflex gain increases substantially during HRV biofeedback
+- Caveat: Narrative mechanistic review by the technique's principal developers. Read as the mechanism argument, not as independent evidence. The individual-variation point is the honest reason exhale's timing sliders are user-editable at all: there is no single correct number to hardcode.
+
+#### `li2016-sigh-circuit`
+
+Li, Peng; Janczewski, Wiktor A.; Yackle, Kevin; Kam, Kaiwen; Pagliardini, Silvia; Krasnow, Mark A.; Feldman, Jack L.. (2016). *The peptidergic control circuit for sighing*. Nature 530(7590): 293-297
+
+- DOI: [10.1038/nature16964](https://doi.org/10.1038/nature16964)
+- Verification: crossref-verified | Access: paywalled | evidence tier **D**
+- Backs:
+  - sighing is generated by a dedicated peptidergic circuit projecting onto the preBotzinger complex, not as a byproduct of ordinary breathing rhythm
+- Caveat: Mouse work. It establishes that the sigh is a distinct, hardwired respiratory behaviour, which is the mechanistic backdrop for the cyclic-sighing result in balban2023-cyclic-sighing. It says nothing about humans deliberately performing sighs, and must not be cited as if it did.
+
+#### `vlemincx2013-sigh-reset-model`
+
+Vlemincx, Elke; Abelson, James L.; Lehrer, Paul M.; Davenport, Paul W.; Van Diest, Ilse; Van den Bergh, Omer. (2013). *Respiratory variability and sighing: A psychophysiological reset model*. Biological Psychology 93(1): 24-32
+
+- DOI: [10.1016/j.biopsycho.2012.12.001](https://doi.org/10.1016/j.biopsycho.2012.12.001)
+- Verification: crossref-verified | Access: paywalled | evidence tier **D**
+- Backs:
+  - sighs act as resetters of respiratory variability: random variability is elevated before a sigh and correlated variability increases after one
+- Caveat: Theoretical model paper with supporting data. Carried because it is the honest place to point when someone asks why a deliberately irregular breath might be useful, which is the only literature adjacent to exhale's randomised-timing sliders. It is not evidence that those sliders help; see the gaps ledger.
+
+#### `vlemincx2016-sigh-relief`
+
+Vlemincx, Elke; Van Diest, Ilse; Van den Bergh, Omer. (2016). *A sigh of relief or a sigh to relieve: The psychological and physiological relief effect of deep breaths*. Physiology & Behavior 165: 127-135
+
+- DOI: [10.1016/j.physbeh.2016.07.004](https://doi.org/10.1016/j.physbeh.2016.07.004)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - self-reported relief was higher after an instructed deep breath than before it
+  - spontaneous sighs were followed by a gradual fall in muscle tension, most clearly in people high in anxiety sensitivity
+- Caveat: NUMBERS NOT READ 2026-08-28; paywalled to automated fetch, findings taken from the abstract. The instructed-breath result is the closest thing in this corpus to evidence that being told to take one deliberate breath, which is precisely what exhale's reminder does, changes how a person feels.
+
+#### `yackle2017-breathing-arousal-neurons`
+
+Yackle, Kevin; Schwarz, Lindsay A.; Kam, Kaiwen; Sorokin, Jordan M.; Huguenard, John R.; Feldman, Jack L.; Luo, Liqun; Krasnow, Mark A.. (2017). *Breathing control center neurons that promote arousal in mice*. Science 355(6332): 1411-1415
+
+- DOI: [10.1126/science.aai7984](https://doi.org/10.1126/science.aai7984)
+- Verification: crossref-verified | Access: paywalled | evidence tier **D**
+- Backs:
+  - a small preBotzinger subpopulation projects to and positively regulates noradrenergic locus coeruleus neurons, giving breathing a direct anatomical route to arousal state
+  - ablating those roughly 175 neurons left breathing intact but increased calm behaviours
+- Caveat: Mouse work, and the direction is breathing pattern to arousal rather than voluntarily slow breathing to calm. It is the single best answer to 'why would breathing slowly change how I feel at all', and it is still an inference from mice. Do not cite it for a human effect.
+
+#### `yasuma2004-rsa`
+
+Yasuma, Fumihiko; Hayano, Jun-ichiro. (2004). *Respiratory Sinus Arrhythmia: Why Does the Heartbeat Synchronize With Respiratory Rhythm?* Chest 125(2): 683-690
+
+- DOI: [10.1378/chest.125.2.683](https://doi.org/10.1378/chest.125.2.683)
+- Verification: crossref-verified | Access: paywalled | evidence tier **D**
+- Backs:
+  - heart rate rises on inhalation and falls on exhalation, and this respiratory sinus arrhythmia is the coupling that HRV-based breathing claims rest on
+- Caveat: Review. This is the physiological fact underneath every 'longer exhale calms you' claim in this corpus, which is why the claim is so intuitive and why meehan2024-longer-exhalations failing to find a ratio effect is worth taking seriously: a real beat-to-beat mechanism does not guarantee a measurable session-level outcome.
+
+#### `zelano2016-nasal-respiration-limbic`
+
+Zelano, Christina; Jiang, Heidi; Zhou, Guangyu; Arora, Nikita; Schuele, Stephan; Rosenow, Joshua; Gottfried, Jay A.. (2016). *Nasal Respiration Entrains Human Limbic Oscillations and Modulates Cognitive Function*. The Journal of Neuroscience 36(49): 12448-12467
+
+- DOI: [10.1523/JNEUROSCI.2586-16.2016](https://doi.org/10.1523/JNEUROSCI.2586-16.2016)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - nasal breathing entrains oscillations in human piriform cortex, amygdala and hippocampus, and the effect is specific to the nasal route rather than to breathing as such
+- Caveat: Human intracranial recordings in a small epilepsy-surgery cohort plus behavioural experiments. Carried because it is the reason nose-versus-mouth is a real variable and not folklore. exhale gives no nasal-breathing guidance at all, which is a defensible omission for a wordless overlay but should be a conscious one.
+
+---
+
+## Limits, harms and adherence
+
+2 sources.
+
+#### `fincham2024-high-ventilation-rct`
+
+Fincham, Guy W.; Epel, Elissa; Colasanti, Alessandro; Strauss, Clara; Cavanagh, Kate. (2024). *Effects of brief remote high ventilation breathwork with retention on mental health and wellbeing: a randomised placebo-controlled trial*. Scientific Reports 14(1): 16893
+
+- DOI: [10.1038/s41598-024-64254-7](https://doi.org/10.1038/s41598-024-64254-7)
+- Verification: crossref-verified | Access: open-access | evidence tier **B**
+- Backs:
+  - high-ventilation breathwork with retention is a distinct practice from slow-paced breathing and warrants a placebo-controlled evaluation of its own
+- Caveat: NUMBERS NOT READ 2026-08-28; carried for the distinction it draws rather than for its effect estimate. It matters to exhale because exhale's sliders can be set to fast, hold-heavy patterns that leave the slow-breathing evidence base entirely. Adverse-event reporting across this field is sparse: reviews note that only a minority of breathwork trials report on adverse events at all, which is the honest basis for the README's advice to stop if intense feelings arise.
+
+#### `linardon2020-app-attrition`
+
+Linardon, Jake; Fuller-Tyszkiewicz, Matthew. (2020). *Attrition and adherence in smartphone-delivered interventions for mental health problems: A systematic and meta-analytic review*. Journal of Consulting and Clinical Psychology 88(1): 1-13
+
+- DOI: [10.1037/ccp0000459](https://doi.org/10.1037/ccp0000459)
+- Verification: crossref-verified | Access: paywalled | evidence tier **A**
+- Backs:
+  - dropout and non-adherence are the dominant practical failure mode of smartphone-delivered mental health interventions, even where efficacy trials are positive
+- Caveat: NUMBERS NOT READ 2026-08-28. Carried as the reality check on every other entry in this corpus: an effect measured in a supervised session says little about a tool someone installs and forgets. exhale has no telemetry and therefore no idea whether anyone keeps it running, which is stated plainly in the gaps ledger rather than hidden.
+
+---
+
+## Gaps and unsupported choices
+
+Written by hand. This section is the point of the exercise: everything below is a place where exhale
+either claims more than the literature supports, or ships a default that the literature does not
+back. Nothing here is a reason not to use the app. It is a list of things that are currently
+believed rather than known.
+
+### 1. Shallow breathing at screens: a retraction, and what the evidence actually supports
+
+**An earlier revision of this file said no peer-reviewed study had measured respiration during
+ordinary screen use. That was wrong, and it was wrong because the first search was not deep enough.**
+The literature exists, it is just old and small and filed under ergonomics rather than under
+breathwork.
+
+- [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2): eleven data-entry operators, monitored
+  continuously across three consecutive six-hour work days. During computer work, end-tidal CO2 was
+  significantly **lower** and respiration frequency significantly **higher** than during either
+  baseline relaxation or progressive muscle relaxation.
+- [`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work): the same group,
+  fourteen years later, n = 23. Lower end-tidal CO2 under high mental workload during computer data
+  entry, and it tracked reduced trapezius EMG gaps.
+- [`schleifer2002-hyperventilation-job-stress`](#schleifer2002-hyperventilation-job-stress): the
+  theory paper tying it together, which states that hyperventilation "is often characterised by a
+  shift from a **diaphragmatic to a thoracic** breathing pattern," recruiting sternocleidomastoid,
+  scalene and trapezius.
+
+That diaphragmatic-to-thoracic shift is what people mean by "shallow." It is chest breathing instead
+of belly breathing. So the folk claim has a real mechanism in the peer-reviewed record.
+
+There is a second, independent line of support through posture.
+[`jung2016-smartphone-posture-respiration`](#jung2016-smartphone-posture-respiration) found that
+people using smartphones more than four hours a day had significantly worse craniovertebral angle
+and lower peak expiratory flow than lighter users, and
+[`deniz2024-forward-head-lung-volumes`](#deniz2024-forward-head-lung-volumes) found forward head
+posture associated with FVC reductions of 0.25 to 0.81 L across 115 participants.
+
+**What is still not supported** is "shallow" meaning reduced *volume of air moved*.
+[`grassmann2016-cognitive-load-respiration`](#grassmann2016-cognitive-load-respiration), 54
+experiments, finds respiratory amplitude roughly stable and minute ventilation **up** under
+cognitive load. Both things are true at once: more air per minute, moved by the wrong muscles, from
+a slumped posture with less capacity available.
+
+So the precise, defensible statement is: at a screen people breathe **faster, higher in the chest,
+and slightly over-ventilated**, from a posture that reduces how much the diaphragm can do. That is
+the claim the README now makes.
+
+Separately, and still true: the specific popular framing of "screen apnea" or "email apnea," meaning
+outright breath-*holding* at a screen, traces to unpublished observations by Linda Stone from 2007,
+tested informally on acquaintances with no protocol, no published data and no replication. Nothing
+found in this pass measures breath-holding during screen use. The over-breathing finding above is
+close to the opposite of breath-holding, and the two claims should not be run together.
+
+### 2. exhale's default breathing rate is below the band anyone has tested
+
+exhale ships 5 s inhale and 10 s exhale
+([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)). That is a
+15-second cycle, or **4.0 breaths per minute**.
+
+[`you2023-respiratory-frequency`](#you2023-respiratory-frequency) tested 5, 5.5, 6, 6.5 and 7 cycles
+per minute and found all of them raised cardiac vagal activity above spontaneous breathing. It did
+not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts the average resonance
+frequency at about 5.5 breaths per minute and notes it varies by individual.
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 bpm outperformed 6.
+
+So exhale's out-of-the-box default sits below the bottom of the range with direct support. It may be
+fine, or better, for a given person; nobody has measured it.
+
+The shipped default has deliberately **not** been changed. Silently moving the pace under people who
+already have exhale installed is worse than documenting where the number came from. Changing it is a
+decision to make on purpose, in a release note, not as a side effect of writing this file.
+
+### 3. Box breathing is not the beginner-friendly default it looks like
+
+A natural thought is that `4` / `4` / `4` / `4` box breathing would be a gentler default than the
+current 5 / 10. Two problems.
+
+First, arithmetic: 4+4+4+4 is a 16-second cycle, or **3.75 breaths per minute**. That is *slower*
+than the current default and further below the tested band, not closer to it. The holds hide the
+rate.
+
+Second, and more decisively, box breathing has been tested head-to-head and lost twice:
+
+- [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84, compared square breathing,
+  4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 bpm raised HRV **more than
+  either square or 4-7-8**, with small to medium effects. The paper opens by stating flatly that
+  square and 4-7-8 "are popularly promoted by psychotherapists but have little empirical support."
+- [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing), a pre-registered RCT, tested box
+  breathing against cyclic sighing and cyclic hyperventilation over a month. Box breathing was not
+  the best-performing arm; the exhale-emphasising one was.
+
+The same evidence rules out 4-7-8, sometimes attributed to Andrew Weil, for the same reason: it lost
+in Marchant, and at 4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
+
+**The evidence-based beginner default is `5` / `0` / `5` / `0`**: 6 breaths per minute, no holds,
+a 10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and it
+is genuinely easier for a beginner than box breathing, because holding the breath is the hard part,
+not the slow part. Box breathing remains a perfectly reasonable thing to want and exhale still
+supports it. It is just not the choice the evidence points at.
+
+### 4. The 1:2 ratio: what it does and does not support
+
+The README used to say to make the exhale twice as long as the inhale "to engage the parasympathetic
+nervous system." That mechanism claim is not supportable as stated. But the practice is *not*
+unsupported, and the reason is a distinction worth getting right: **the HRV studies and the
+how-do-you-feel studies disagree with each other, and they disagree in a consistent direction.**
+
+On HRV, four results, and they do not line up:
+
+| Source | n | Design | Result on ratio |
+|---|---|---|---|
+| [`bae2021-exhalation-inhalation-ratio`](#bae2021-exhalation-inhalation-ratio) | 28 | 2:1 vs 1:1 cue at spontaneous rate | Longer exhale raised RMSSD and HF-HRV |
+| [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) | 30 | i/e 0.42 vs 2.33, at 6 and 12 bpm | Longer exhale raised HF-HRV, but only at the slow rate |
+| [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) | 47 | 5:5 vs 4:6 at 5.5 and 6 bpm | **Equal** ratio won on SDNN and LF |
+| [`meehan2024-longer-exhalations`](#meehan2024-longer-exhalations) | 26 + 16 replication | 1:1 vs 1:2 at 6 bpm | No difference, in the original *and* the replication |
+
+Two for, one against, one null. Nobody should be asserting a mechanism from that.
+
+On how people actually felt, the picture is cleaner.
+[`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) is the only study here that
+measured subjective state across ratios, and participants reported more relaxation, more stress
+reduction, more mindfulness and more positive energy with the longer exhale. Slowing the rate alone
+moved only one of those four. [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) points the
+same way over a month, on mood.
+
+So: **keep the recommendation, drop the mechanism.** A longer exhale is worth preferring because
+people report feeling better doing it, which is the outcome anyone installing exhale actually cares
+about. It should not be sold as a way to "engage the parasympathetic nervous system," because the
+cardiac measures that would show that are split. Note also
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv)'s second finding: *every* slow pattern it
+tested increased relaxation over baseline. Rate is doing most of the work. Ratio is a preference
+with a modest, contested edge.
+
+### 5. Pacing someone slowly at a screen may push them further into over-breathing
+
+This one is a genuine tension between two entries and nobody has looked at it.
+
+[`marchant2025-square-478-six`](#marchant2025-square-478-six) reports, as an unexpected finding, that
+breathing at 6 breaths per minute produced **mild over-breathing**: HRV went up and end-tidal CO2
+went down. Meanwhile [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2) and
+[`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work) show that a person
+at a keyboard is *already* mildly hypocapnic.
+
+exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while
+taking large breaths moves more air per minute, not less. The whole benefit of slow breathing is
+usually framed as calming, and the CO2 direction here runs the other way. No study in this corpus
+tests a slow pacer on an already-hypocapnic screen worker, which is exactly exhale's user.
+
+Nothing actionable follows yet, and this is not a safety warning: the effect Marchant reports is
+mild and was measured in a single session. It is recorded because it is the most interesting
+unanswered question this corpus turned up, and because an app that paces breathing should know that
+pacing rate is not the same as pacing volume.
+
+### 6. `drift` has no literature behind it at all
+
+exhale defaults `drift` to `1.01`, making each cycle 1% longer than the last. Over 30 cycles that is
+a 1.35x stretch, taking a 4.0 breaths/min pace down to roughly 3.0 and further outside any tested
+range. No study in this corpus examines a progressively lengthening pace. It is an invented feature.
+It may be a pleasant one. It is not evidence-based, and the default is not zero.
+
+### 7. Randomised timing has no literature behind it either
+
+The four randomisation sliders inject per-phase jitter. Every pacing study in this corpus uses a
+fixed rate; that is what "paced" means. The nearest adjacent literature is
+[`vlemincx2013-sigh-reset-model`](#vlemincx2013-sigh-reset-model), on natural respiratory
+variability and sighs, which is about spontaneous breathing rather than about deliberately
+destabilising a pacer. Defaults are 0, which is the right default. Treat the sliders as an
+aesthetic option.
+
+### 8. Nothing about exhale itself has ever been measured
+
+No study in this corpus is about exhale. The closest published analogue is
+[`moraveji2011-peripheral-paced-respiration`](#moraveji2011-peripheral-paced-respiration): a
+translucent animated bar across the screen, running in the periphery during real information work,
+which significantly lowered participants' breathing rate. Its limitation is the one that matters
+here. The reduction happened **while the pacing was active** and did not persist as a lasting change
+in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as
+it is on.
+
+The strongest design warrant is [`tabor2022-guided-breathing-design`](#tabor2022-guided-breathing-design):
+an expanding and contracting circle at 6 breaths/min matched sensor-driven HRV biofeedback on HRV
+amplitude, with effects appearing in about two minutes and no hardware needed. That is exhale's
+Circle mode, and it is why exhale needs no sensor, no account and no telemetry. It is still n = 28
+in one session.
+
+### 9. Visual-only guidance is the weaker modality for the outcome users care about
+
+[`wongsuphasawat2012-cant-force-calm`](#wongsuphasawat2012-cant-force-calm) found visual pacing
+produced more measured respiratory change than auditory pacing, but auditory was rated more calming.
+exhale is visual-only by design, because it is meant to sit silently in the corner of a working
+screen. That is a real trade-off against felt calm, made deliberately. The source is a two-page
+adjunct paper, so it is a signal rather than a result.
+
+### 10. exhale cites blink research and does nothing about blinking
+
+The blink-rate literature is well supported, and exhale does not act on it. The overlay paces
+breathing; it does not prompt a blink, does not detect blinks, and does not implement anything from
+the digital eye strain literature. The blink finding is context for why screens deserve a nudge, not
+a description of what this app does.
+
+Also relevant to exhale's whole genre: [`johnson2023-20-20-20`](#johnson2023-20-20-20) found that
+scheduled 20-second breaks at any of three intervals produced no significant effect on symptoms,
+reading speed or accuracy. A periodic on-screen nudge is not effective merely because it is popular.
+
+### 11. Both hold sliders default to 0, with no cited basis either way
+
+`post_inhale_hold_duration` and `post_exhale_hold_duration` both default to 0.
+[`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the study that manipulates
+respiratory pauses directly, and it was paywalled to full-text fetch in this pass, so its numbers
+have not been read. [`little2025-a52-breath-method`](#little2025-a52-breath-method) argues for a 2 s
+post-exhale hold, while [`marchant2025-square-478-six`](#marchant2025-square-478-six) found the two
+hold-heavy patterns it tested underperformed a no-hold 6 bpm pace. On current evidence, 0 is a
+defensible default.
+
+### 12. Nobody knows whether anyone keeps using it
+
+exhale has no telemetry, by design and stated in [PRIVACY.md](../PRIVACY.md). The consequence is
+that the single biggest determinant of whether a tool like this does anything, namely whether people
+keep it running, is unmeasured and unmeasurable here.
+[`linardon2020-app-attrition`](#linardon2020-app-attrition) is the reality check: dropout and
+non-adherence dominate outcomes for app-delivered interventions even where efficacy trials are
+positive. Every effect size in this corpus was measured in a supervised session with a compliant
+participant. That is not the same population as someone who installed a menu-bar app in March.
+
+### 13. Adverse-event reporting in this field is thin
+
+Reviews of breathwork note that only a minority of trials report on adverse events at all.
+[`laborde2022-vsb-meta`](#laborde2022-vsb-meta) concludes that few adverse effects are expected from
+*slow* breathing specifically, which is the mode exhale is built around. exhale's sliders can also
+be set to fast, hold-heavy patterns that leave that evidence base entirely; those belong to the
+high-ventilation literature ([`fincham2024-high-ventilation-rct`](#fincham2024-high-ventilation-rct)),
+where transient tetany, light-headedness and distress are documented. This is the honest basis for
+the README's existing advice to take breaks if intense feelings arise, and for it staying there.
+
+### 14. The tradition sources are lineage, not evidence, and are tiered accordingly
+
+exhale's four-phase structure, inhale / retention / exhale / retention, is pranayama. It did not come
+from psychophysiology, and the corpus says so: [`satyananda2008-apmb`](#satyananda2008-apmb) and
+[`muktibodhananda1998-hatha-yoga-pradipika`](#muktibodhananda1998-hatha-yoga-pradipika) are carried
+at tier **E**, meaning they may be cited for where a practice came from and never for whether it
+works.
+
+This is a deliberate inclusion rather than an endorsement, for two reasons. Retrofitting a 2020s HRV
+citation onto an instruction that is centuries older would be revisionist about the app's actual
+design history. And the "longer exhale" idea specifically entered modern breathing apps through this
+tradition, not through a laboratory, which is worth knowing when weighing how much of the supporting
+literature was designed to test a pre-existing belief rather than to discover something.
+
+Both entries are marked `NOT READ`. Their bibliographic records were checked against Open Library;
+their contents were not consulted, and no claim in this repo rests on them. The Satyananda edition
+history is genuinely tangled: Open Library returns the Yoga Publications Trust 553-page edition under
+the cited ISBN but dates its record 1999, while the printing generally referred to is the 2008 Fourth
+Revised Edition. That is not resolved here.
+
+## What would close the biggest gaps
+
+In rough order of value per unit effort:
+
+1. Read the `NUMBERS NOT READ` entries and either promote or downgrade the claims resting on them.
+   [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the highest value: it bears
+   directly on gaps 4 and 11.
+2. Decide, deliberately, whether the shipped default should move from 4.0 breaths/min to
+   `5` / `0` / `5` / `0`, which is 6 breaths/min and is what the head-to-head evidence in gap 3
+   points at. This is a release-note decision, not a silent one.
+3. Ship named presets with the citation attached to each, instead of asking users to invent numbers:
+   6 breaths/min (`5` / `0` / `5` / `0`), A52 (`5` / `0` / `5` / `2`), box (`4` / `4` / `4` / `4`),
+   and the current default as "extended exhale." A preset carrying its own evidence tier is more
+   honest than a slider that implies every value is equally supported.
+4. **Queued for the next release, no release needed of its own:** a "Research & Citations" item in
+   the tray menu that opens this file in the browser. Roughly ten lines: one `MenuItem` built and
+   appended in [`tray.rs`](../rust/crates/exhale-app/src/tray.rs) alongside `preferences_item`, and one
+   arm in the `MenuEvent` loop at [`main.rs:1066`](../rust/crates/exhale-app/src/main.rs). It rides
+   along with whatever is tagged next rather than justifying a build, re-sign and three store
+   resubmissions on its own. A link out is deliberately preferred over rendering this corpus inside
+   the settings window: exhale ships through Apple, Microsoft and Snap review, and putting prose about
+   parasympathetic activation inside a health-adjacent binary invites scrutiny that a repo link does
+   not.
+5. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+   real, publishable question that exhale is unusually well placed to ask.

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -1,0 +1,339 @@
+# Citation corpus
+
+<!-- SUMMARY -->
+
+Machine-readable companion: [`CITATIONS.csl.json`](./CITATIONS.csl.json) (CSL-JSON).
+Verification pass completed 2026-08-28 against the Crossref REST API.
+
+> **This file is generated.** Edit [`CITATIONS.csl.json`](./CITATIONS.csl.json) for records and
+> [`citations-notes.md`](./citations-notes.md) for the prose, then run
+> `uv run --no-project scripts/generate-citations.py`. Editing `CITATIONS.md` directly will be
+> overwritten. `--check` fails if the two drift apart.
+
+exhale is a breathing overlay, not a medical device, and nothing here is medical advice. See the
+[disclaimer](../README.md#disclaimer). This corpus exists so that anyone, including the author, can
+check which of exhale's claims and defaults rest on published evidence and which do not. The
+[gaps ledger](#gaps-and-unsupported-choices) at the end is the more useful half.
+
+## How to read this
+
+### Verification status
+
+This says how the *bibliographic record* was checked. It says nothing about whether the finding is
+true, and nothing about whether the full text was read.
+
+| Status | Meaning |
+|---|---|
+| `crossref-verified` | The DOI resolves in Crossref, and the title, authors, year, journal, volume and pages printed here are the ones Crossref returned, not the ones a search result claimed. |
+| `openlibrary-verified` | No DOI exists because the source is a book. The title, author, publisher and page count printed here were checked against the Open Library record for the stated ISBN. Edition ambiguities are written into the caveat. |
+| `unverified` | No resolvable DOI and no catalogue record. Bibliographic details are inherited from secondary citation and may be wrong. |
+
+A `crossref-verified` record can still carry a loud caveat. Several entries here are Crossref-verified
+but were paywalled to full-text fetch, meaning we confirmed the paper exists and is what we say it is
+but never read its numbers. Those carry `NUMBERS NOT READ` in the caveat. Verification confirms the
+*citation*, not the *claim*.
+
+### Access level
+
+`open-access` (a CC licence is registered with Crossref, or the title is fully open access) |
+`paywalled`. Where a Crossref `license` field was present, the access level is taken from it rather
+than guessed; where it was absent the basis is stated in the entry's caveat.
+
+### Evidence tier
+
+Applied to sources making a claim about what happens to a human being. Physiological and animal
+mechanism papers are tier D by definition: they explain why something might work, they do not
+establish that it does.
+
+| Tier | Definition | How exhale is allowed to use it |
+|---|---|---|
+| A | Systematic review or meta-analysis of controlled trials, or a large pre-registered RCT | May be cited for an outcome claim |
+| B | Controlled experiment with an internal replication, or a systematic review of controlled experiments | May be cited for an outcome claim, with its scope conditions stated |
+| C | Single controlled experiment, small n, or lab-only | Cite as suggestive; never as "research shows" |
+| D | Narrative review, mechanism, or animal work | Cite for *why*, never for *whether* |
+| E | Not peer reviewed, or contradicted by better evidence | May be cited for provenance, meaning where a practice came from. Never for whether it works |
+
+<!-- COUNTS -->
+
+<!-- CORPUS -->
+
+---
+
+## Gaps and unsupported choices
+
+Written by hand. This section is the point of the exercise: everything below is a place where exhale
+either claims more than the literature supports, or ships a default that the literature does not
+back. Nothing here is a reason not to use the app. It is a list of things that are currently
+believed rather than known.
+
+### 1. Shallow breathing at screens: a retraction, and what the evidence actually supports
+
+**An earlier revision of this file said no peer-reviewed study had measured respiration during
+ordinary screen use. That was wrong, and it was wrong because the first search was not deep enough.**
+The literature exists, it is just old and small and filed under ergonomics rather than under
+breathwork.
+
+- [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2): eleven data-entry operators, monitored
+  continuously across three consecutive six-hour work days. During computer work, end-tidal CO2 was
+  significantly **lower** and respiration frequency significantly **higher** than during either
+  baseline relaxation or progressive muscle relaxation.
+- [`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work): the same group,
+  fourteen years later, n = 23. Lower end-tidal CO2 under high mental workload during computer data
+  entry, and it tracked reduced trapezius EMG gaps.
+- [`schleifer2002-hyperventilation-job-stress`](#schleifer2002-hyperventilation-job-stress): the
+  theory paper tying it together, which states that hyperventilation "is often characterised by a
+  shift from a **diaphragmatic to a thoracic** breathing pattern," recruiting sternocleidomastoid,
+  scalene and trapezius.
+
+That diaphragmatic-to-thoracic shift is what people mean by "shallow." It is chest breathing instead
+of belly breathing. So the folk claim has a real mechanism in the peer-reviewed record.
+
+There is a second, independent line of support through posture.
+[`jung2016-smartphone-posture-respiration`](#jung2016-smartphone-posture-respiration) found that
+people using smartphones more than four hours a day had significantly worse craniovertebral angle
+and lower peak expiratory flow than lighter users, and
+[`deniz2024-forward-head-lung-volumes`](#deniz2024-forward-head-lung-volumes) found forward head
+posture associated with FVC reductions of 0.25 to 0.81 L across 115 participants.
+
+**What is still not supported** is "shallow" meaning reduced *volume of air moved*.
+[`grassmann2016-cognitive-load-respiration`](#grassmann2016-cognitive-load-respiration), 54
+experiments, finds respiratory amplitude roughly stable and minute ventilation **up** under
+cognitive load. Both things are true at once: more air per minute, moved by the wrong muscles, from
+a slumped posture with less capacity available.
+
+So the precise, defensible statement is: at a screen people breathe **faster, higher in the chest,
+and slightly over-ventilated**, from a posture that reduces how much the diaphragm can do. That is
+the claim the README now makes.
+
+Separately, and still true: the specific popular framing of "screen apnea" or "email apnea," meaning
+outright breath-*holding* at a screen, traces to unpublished observations by Linda Stone from 2007,
+tested informally on acquaintances with no protocol, no published data and no replication. Nothing
+found in this pass measures breath-holding during screen use. The over-breathing finding above is
+close to the opposite of breath-holding, and the two claims should not be run together.
+
+### 2. exhale's default breathing rate is below the band anyone has tested
+
+exhale ships 5 s inhale and 10 s exhale
+([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)). That is a
+15-second cycle, or **4.0 breaths per minute**.
+
+[`you2023-respiratory-frequency`](#you2023-respiratory-frequency) tested 5, 5.5, 6, 6.5 and 7 cycles
+per minute and found all of them raised cardiac vagal activity above spontaneous breathing. It did
+not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts the average resonance
+frequency at about 5.5 breaths per minute and notes it varies by individual.
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 bpm outperformed 6.
+
+So exhale's out-of-the-box default sits below the bottom of the range with direct support. It may be
+fine, or better, for a given person; nobody has measured it.
+
+The shipped default has deliberately **not** been changed. Silently moving the pace under people who
+already have exhale installed is worse than documenting where the number came from. Changing it is a
+decision to make on purpose, in a release note, not as a side effect of writing this file.
+
+### 3. Box breathing is not the beginner-friendly default it looks like
+
+A natural thought is that `4` / `4` / `4` / `4` box breathing would be a gentler default than the
+current 5 / 10. Two problems.
+
+First, arithmetic: 4+4+4+4 is a 16-second cycle, or **3.75 breaths per minute**. That is *slower*
+than the current default and further below the tested band, not closer to it. The holds hide the
+rate.
+
+Second, and more decisively, box breathing has been tested head-to-head and lost twice:
+
+- [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84, compared square breathing,
+  4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 bpm raised HRV **more than
+  either square or 4-7-8**, with small to medium effects. The paper opens by stating flatly that
+  square and 4-7-8 "are popularly promoted by psychotherapists but have little empirical support."
+- [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing), a pre-registered RCT, tested box
+  breathing against cyclic sighing and cyclic hyperventilation over a month. Box breathing was not
+  the best-performing arm; the exhale-emphasising one was.
+
+The same evidence rules out 4-7-8, sometimes attributed to Andrew Weil, for the same reason: it lost
+in Marchant, and at 4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
+
+**The evidence-based beginner default is `5` / `0` / `5` / `0`**: 6 breaths per minute, no holds,
+a 10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and it
+is genuinely easier for a beginner than box breathing, because holding the breath is the hard part,
+not the slow part. Box breathing remains a perfectly reasonable thing to want and exhale still
+supports it. It is just not the choice the evidence points at.
+
+### 4. The 1:2 ratio: what it does and does not support
+
+The README used to say to make the exhale twice as long as the inhale "to engage the parasympathetic
+nervous system." That mechanism claim is not supportable as stated. But the practice is *not*
+unsupported, and the reason is a distinction worth getting right: **the HRV studies and the
+how-do-you-feel studies disagree with each other, and they disagree in a consistent direction.**
+
+On HRV, four results, and they do not line up:
+
+| Source | n | Design | Result on ratio |
+|---|---|---|---|
+| [`bae2021-exhalation-inhalation-ratio`](#bae2021-exhalation-inhalation-ratio) | 28 | 2:1 vs 1:1 cue at spontaneous rate | Longer exhale raised RMSSD and HF-HRV |
+| [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) | 30 | i/e 0.42 vs 2.33, at 6 and 12 bpm | Longer exhale raised HF-HRV, but only at the slow rate |
+| [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) | 47 | 5:5 vs 4:6 at 5.5 and 6 bpm | **Equal** ratio won on SDNN and LF |
+| [`meehan2024-longer-exhalations`](#meehan2024-longer-exhalations) | 26 + 16 replication | 1:1 vs 1:2 at 6 bpm | No difference, in the original *and* the replication |
+
+Two for, one against, one null. Nobody should be asserting a mechanism from that.
+
+On how people actually felt, the picture is cleaner.
+[`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) is the only study here that
+measured subjective state across ratios, and participants reported more relaxation, more stress
+reduction, more mindfulness and more positive energy with the longer exhale. Slowing the rate alone
+moved only one of those four. [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) points the
+same way over a month, on mood.
+
+So: **keep the recommendation, drop the mechanism.** A longer exhale is worth preferring because
+people report feeling better doing it, which is the outcome anyone installing exhale actually cares
+about. It should not be sold as a way to "engage the parasympathetic nervous system," because the
+cardiac measures that would show that are split. Note also
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv)'s second finding: *every* slow pattern it
+tested increased relaxation over baseline. Rate is doing most of the work. Ratio is a preference
+with a modest, contested edge.
+
+### 5. Pacing someone slowly at a screen may push them further into over-breathing
+
+This one is a genuine tension between two entries and nobody has looked at it.
+
+[`marchant2025-square-478-six`](#marchant2025-square-478-six) reports, as an unexpected finding, that
+breathing at 6 breaths per minute produced **mild over-breathing**: HRV went up and end-tidal CO2
+went down. Meanwhile [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2) and
+[`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work) show that a person
+at a keyboard is *already* mildly hypocapnic.
+
+exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while
+taking large breaths moves more air per minute, not less. The whole benefit of slow breathing is
+usually framed as calming, and the CO2 direction here runs the other way. No study in this corpus
+tests a slow pacer on an already-hypocapnic screen worker, which is exactly exhale's user.
+
+Nothing actionable follows yet, and this is not a safety warning: the effect Marchant reports is
+mild and was measured in a single session. It is recorded because it is the most interesting
+unanswered question this corpus turned up, and because an app that paces breathing should know that
+pacing rate is not the same as pacing volume.
+
+### 6. `drift` has no literature behind it at all
+
+exhale defaults `drift` to `1.01`, making each cycle 1% longer than the last. Over 30 cycles that is
+a 1.35x stretch, taking a 4.0 breaths/min pace down to roughly 3.0 and further outside any tested
+range. No study in this corpus examines a progressively lengthening pace. It is an invented feature.
+It may be a pleasant one. It is not evidence-based, and the default is not zero.
+
+### 7. Randomised timing has no literature behind it either
+
+The four randomisation sliders inject per-phase jitter. Every pacing study in this corpus uses a
+fixed rate; that is what "paced" means. The nearest adjacent literature is
+[`vlemincx2013-sigh-reset-model`](#vlemincx2013-sigh-reset-model), on natural respiratory
+variability and sighs, which is about spontaneous breathing rather than about deliberately
+destabilising a pacer. Defaults are 0, which is the right default. Treat the sliders as an
+aesthetic option.
+
+### 8. Nothing about exhale itself has ever been measured
+
+No study in this corpus is about exhale. The closest published analogue is
+[`moraveji2011-peripheral-paced-respiration`](#moraveji2011-peripheral-paced-respiration): a
+translucent animated bar across the screen, running in the periphery during real information work,
+which significantly lowered participants' breathing rate. Its limitation is the one that matters
+here. The reduction happened **while the pacing was active** and did not persist as a lasting change
+in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as
+it is on.
+
+The strongest design warrant is [`tabor2022-guided-breathing-design`](#tabor2022-guided-breathing-design):
+an expanding and contracting circle at 6 breaths/min matched sensor-driven HRV biofeedback on HRV
+amplitude, with effects appearing in about two minutes and no hardware needed. That is exhale's
+Circle mode, and it is why exhale needs no sensor, no account and no telemetry. It is still n = 28
+in one session.
+
+### 9. Visual-only guidance is the weaker modality for the outcome users care about
+
+[`wongsuphasawat2012-cant-force-calm`](#wongsuphasawat2012-cant-force-calm) found visual pacing
+produced more measured respiratory change than auditory pacing, but auditory was rated more calming.
+exhale is visual-only by design, because it is meant to sit silently in the corner of a working
+screen. That is a real trade-off against felt calm, made deliberately. The source is a two-page
+adjunct paper, so it is a signal rather than a result.
+
+### 10. exhale cites blink research and does nothing about blinking
+
+The blink-rate literature is well supported, and exhale does not act on it. The overlay paces
+breathing; it does not prompt a blink, does not detect blinks, and does not implement anything from
+the digital eye strain literature. The blink finding is context for why screens deserve a nudge, not
+a description of what this app does.
+
+Also relevant to exhale's whole genre: [`johnson2023-20-20-20`](#johnson2023-20-20-20) found that
+scheduled 20-second breaks at any of three intervals produced no significant effect on symptoms,
+reading speed or accuracy. A periodic on-screen nudge is not effective merely because it is popular.
+
+### 11. Both hold sliders default to 0, with no cited basis either way
+
+`post_inhale_hold_duration` and `post_exhale_hold_duration` both default to 0.
+[`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the study that manipulates
+respiratory pauses directly, and it was paywalled to full-text fetch in this pass, so its numbers
+have not been read. [`little2025-a52-breath-method`](#little2025-a52-breath-method) argues for a 2 s
+post-exhale hold, while [`marchant2025-square-478-six`](#marchant2025-square-478-six) found the two
+hold-heavy patterns it tested underperformed a no-hold 6 bpm pace. On current evidence, 0 is a
+defensible default.
+
+### 12. Nobody knows whether anyone keeps using it
+
+exhale has no telemetry, by design and stated in [PRIVACY.md](../PRIVACY.md). The consequence is
+that the single biggest determinant of whether a tool like this does anything, namely whether people
+keep it running, is unmeasured and unmeasurable here.
+[`linardon2020-app-attrition`](#linardon2020-app-attrition) is the reality check: dropout and
+non-adherence dominate outcomes for app-delivered interventions even where efficacy trials are
+positive. Every effect size in this corpus was measured in a supervised session with a compliant
+participant. That is not the same population as someone who installed a menu-bar app in March.
+
+### 13. Adverse-event reporting in this field is thin
+
+Reviews of breathwork note that only a minority of trials report on adverse events at all.
+[`laborde2022-vsb-meta`](#laborde2022-vsb-meta) concludes that few adverse effects are expected from
+*slow* breathing specifically, which is the mode exhale is built around. exhale's sliders can also
+be set to fast, hold-heavy patterns that leave that evidence base entirely; those belong to the
+high-ventilation literature ([`fincham2024-high-ventilation-rct`](#fincham2024-high-ventilation-rct)),
+where transient tetany, light-headedness and distress are documented. This is the honest basis for
+the README's existing advice to take breaks if intense feelings arise, and for it staying there.
+
+### 14. The tradition sources are lineage, not evidence, and are tiered accordingly
+
+exhale's four-phase structure, inhale / retention / exhale / retention, is pranayama. It did not come
+from psychophysiology, and the corpus says so: [`satyananda2008-apmb`](#satyananda2008-apmb) and
+[`muktibodhananda1998-hatha-yoga-pradipika`](#muktibodhananda1998-hatha-yoga-pradipika) are carried
+at tier **E**, meaning they may be cited for where a practice came from and never for whether it
+works.
+
+This is a deliberate inclusion rather than an endorsement, for two reasons. Retrofitting a 2020s HRV
+citation onto an instruction that is centuries older would be revisionist about the app's actual
+design history. And the "longer exhale" idea specifically entered modern breathing apps through this
+tradition, not through a laboratory, which is worth knowing when weighing how much of the supporting
+literature was designed to test a pre-existing belief rather than to discover something.
+
+Both entries are marked `NOT READ`. Their bibliographic records were checked against Open Library;
+their contents were not consulted, and no claim in this repo rests on them. The Satyananda edition
+history is genuinely tangled: Open Library returns the Yoga Publications Trust 553-page edition under
+the cited ISBN but dates its record 1999, while the printing generally referred to is the 2008 Fourth
+Revised Edition. That is not resolved here.
+
+## What would close the biggest gaps
+
+In rough order of value per unit effort:
+
+1. Read the `NUMBERS NOT READ` entries and either promote or downgrade the claims resting on them.
+   [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the highest value: it bears
+   directly on gaps 4 and 11.
+2. Decide, deliberately, whether the shipped default should move from 4.0 breaths/min to
+   `5` / `0` / `5` / `0`, which is 6 breaths/min and is what the head-to-head evidence in gap 3
+   points at. This is a release-note decision, not a silent one.
+3. Ship named presets with the citation attached to each, instead of asking users to invent numbers:
+   6 breaths/min (`5` / `0` / `5` / `0`), A52 (`5` / `0` / `5` / `2`), box (`4` / `4` / `4` / `4`),
+   and the current default as "extended exhale." A preset carrying its own evidence tier is more
+   honest than a slider that implies every value is equally supported.
+4. **Queued for the next release, no release needed of its own:** a "Research & Citations" item in
+   the tray menu that opens this file in the browser. Roughly ten lines: one `MenuItem` built and
+   appended in [`tray.rs`](../rust/crates/exhale-app/src/tray.rs) alongside `preferences_item`, and one
+   arm in the `MenuEvent` loop at [`main.rs:1066`](../rust/crates/exhale-app/src/main.rs). It rides
+   along with whatever is tagged next rather than justifying a build, re-sign and three store
+   resubmissions on its own. A link out is deliberately preferred over rendering this corpus inside
+   the settings window: exhale ships through Apple, Microsoft and Snap review, and putting prose about
+   parasympathetic activation inside a health-adjacent binary invites scrutiny that a repo link does
+   not.
+5. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+   real, publishable question that exhale is unusually well placed to ask.

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Render docs/CITATIONS.md from the CSL-JSON corpus and the hand-written notes.
+
+Single source of truth:
+  - docs/CITATIONS.csl.json  bibliographic records + provenance metadata
+  - docs/citations-notes.md  preamble, reading guide, gaps ledger
+
+docs/CITATIONS.md is generated from both and must never be hand-edited.
+
+Usage:
+    uv run --no-project scripts/generate-citations.py            # write
+    uv run --no-project scripts/generate-citations.py --check    # fail on drift
+
+Stdlib only, so it runs anywhere the repo is checked out
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+DOCS = Path(__file__).resolve().parent.parent / "docs"
+CORPUS = DOCS / "CITATIONS.csl.json"
+NOTES = DOCS / "citations-notes.md"
+OUT = DOCS / "CITATIONS.md"
+
+# Section order in the rendered document. Each group answers one question the
+# app actually raises, rather than following the shape of the literature
+GROUPS = [
+    ("premise", "Why a breathing reminder next to a screen"),
+    ("slow-breathing", "Whether slow paced breathing does anything"),
+    ("timing", "What the numbers should be"),
+    ("tradition", "Where the practice came from"),
+    ("interface", "Whether an on-screen visual pacer works"),
+    ("mechanism", "Physiology and neuroscience"),
+    ("safety", "Limits, harms and adherence"),
+]
+GROUP_IDS = {g for g, _ in GROUPS}
+
+VERIFICATIONS = {"crossref-verified", "openlibrary-verified", "unverified"}
+ACCESS_LEVELS = {"open-access", "paywalled"}
+TIERS = {"A", "B", "C", "D", "E", None}
+
+ID_RE = re.compile(r"^[a-z][a-z0-9]+[0-9]{4}-[a-z0-9-]+$")
+# Same shape, unanchored, for spotting citekeys named inside prose
+MENTION_RE = re.compile(r"\b[a-z][a-z0-9]+[0-9]{4}-[a-z0-9-]+\b")
+
+
+class CorpusError(Exception):
+    pass
+
+
+def load_corpus() -> list[dict]:
+    records = json.loads(CORPUS.read_text(encoding="utf-8"))
+    if not isinstance(records, list):
+        raise CorpusError(f"{CORPUS.name} must hold a JSON array")
+
+    problems: list[str] = []
+    seen: set[str] = set()
+
+    for index, rec in enumerate(records):
+        rid = rec.get("id", f"<record {index}>")
+
+        if not ID_RE.match(str(rec.get("id", ""))):
+            problems.append(f"{rid}: id must match {ID_RE.pattern}")
+        else:
+            keyed = re.search(r"(\d{4})-", rid)
+            issued = (rec.get("issued", {}).get("date-parts") or [[None]])[0][0]
+            if keyed and issued and keyed.group(1) != str(issued):
+                problems.append(
+                    f"{rid}: citekey year {keyed.group(1)} does not match issued year {issued}"
+                )
+        if rid in seen:
+            problems.append(f"{rid}: duplicate id")
+        seen.add(rid)
+
+        for field in ("type", "title", "issued"):
+            if not rec.get(field):
+                problems.append(f"{rid}: missing '{field}'")
+
+        custom = rec.get("custom")
+        if not isinstance(custom, dict):
+            problems.append(f"{rid}: missing 'custom' block")
+            continue
+
+        if custom.get("group") not in GROUP_IDS:
+            problems.append(f"{rid}: group must be one of {sorted(GROUP_IDS)}")
+        if custom.get("verification") not in VERIFICATIONS:
+            problems.append(f"{rid}: verification must be one of {sorted(VERIFICATIONS)}")
+        if custom.get("accessLevel") not in ACCESS_LEVELS:
+            problems.append(f"{rid}: accessLevel must be one of {sorted(ACCESS_LEVELS)}")
+        if custom.get("evidenceTier", "missing") not in TIERS:
+            problems.append(f"{rid}: evidenceTier must be A-E or null")
+
+        claims = custom.get("backsClaims")
+        if not isinstance(claims, list) or not claims:
+            problems.append(f"{rid}: backsClaims must be a non-empty list")
+
+        # A record with no DOI cannot honestly call itself Crossref-verified
+        if custom.get("verification") == "crossref-verified" and not rec.get("DOI"):
+            problems.append(f"{rid}: crossref-verified but carries no DOI")
+
+    if problems:
+        raise CorpusError("\n".join("  - " + p for p in problems))
+
+    return sorted(records, key=lambda r: r["id"])
+
+
+def check_cross_references(records: list[dict]) -> None:
+    """Caveats point at sibling entries by citekey. Catch the ones that rot.
+
+    These cross-references are the most useful thing in the corpus and the
+    easiest to break, because renaming an entry leaves every mention of it
+    behind as plausible-looking prose
+    """
+    known = {r["id"] for r in records}
+    problems: list[str] = []
+    for rec in records:
+        custom = rec["custom"]
+        prose = " ".join([custom.get("caveat") or "", *custom.get("backsClaims", [])])
+        for mention in MENTION_RE.findall(prose):
+            if mention not in known:
+                problems.append(f"{rec['id']}: names unknown entry '{mention}'")
+    if problems:
+        raise CorpusError("\n".join("  - " + p for p in problems))
+
+
+def check_note_links(records: list[dict], notes: str) -> None:
+    """The gaps ledger links to entries by anchor. Catch the ones that rot."""
+    known = {r["id"] for r in records}
+    # Only anchors shaped like a citekey are entry references; the rest are
+    # ordinary intra-document links to headings in the notes
+    referenced = {
+        a for a in re.findall(r"\]\(#([a-z0-9-]+)\)", notes) if ID_RE.match(a)
+    }
+    dangling = sorted(referenced - known)
+    if dangling:
+        raise CorpusError(
+            "\n".join(f"  - {NOTES.name} links to unknown entry #{d}" for d in dangling)
+        )
+
+
+def authors(rec: dict) -> str:
+    people = rec.get("author") or []
+    return "; ".join(
+        f'{p.get("family", "?")}, {p.get("given", "?")}' for p in people
+    )
+
+
+def year(rec: dict) -> str:
+    parts = (rec.get("issued", {}).get("date-parts") or [[None]])[0]
+    return str(parts[0]) if parts and parts[0] else "n.d."
+
+
+def locator(rec: dict) -> str:
+    """Volume(issue): pages, omitting whatever the record does not have."""
+    bits = ""
+    if rec.get("volume"):
+        bits += str(rec["volume"])
+        if rec.get("issue"):
+            bits += f'({rec["issue"]})'
+    if rec.get("page"):
+        bits += (": " if bits else "") + str(rec["page"])
+    if not bits and rec.get("number-of-pages"):
+        bits = f'{rec["number-of-pages"]} pp'
+    return bits
+
+
+def render_entry(rec: dict) -> list[str]:
+    c = rec["custom"]
+    lines = [f'#### `{rec["id"]}`', ""]
+
+    # Titles that already end in their own punctuation should not collect a second period
+    tail = "" if rec["title"].rstrip().endswith(("?", "!", ".")) else "."
+    # Journal articles carry a container title; books carry a publisher and place
+    source = rec.get("container-title") or ": ".join(
+        p for p in (rec.get("publisher-place"), rec.get("publisher")) if p
+    )
+    head = f'{authors(rec)}. ({year(rec)}). *{rec["title"]}*{tail} {source}'
+    loc = locator(rec)
+    lines.append(head + (f" {loc}" if loc else ""))
+    lines.append("")
+
+    if rec.get("DOI"):
+        lines.append(f'- DOI: [{rec["DOI"]}](https://doi.org/{rec["DOI"]})')
+    elif rec.get("ISBN"):
+        lines.append(f'- ISBN: {rec["ISBN"]} | [Open Library record]({rec["URL"]})')
+    elif rec.get("URL"):
+        lines.append(f'- URL: <{rec["URL"]}>')
+
+    tier = c.get("evidenceTier")
+    tier_text = f"evidence tier **{tier}**" if tier else "no evidence tier (not a study)"
+    lines.append(
+        f'- Verification: {c["verification"]} | Access: {c["accessLevel"]} | {tier_text}'
+    )
+
+    lines.append("- Backs:")
+    lines.extend(f"  - {claim}" for claim in c["backsClaims"])
+
+    if c.get("caveat"):
+        lines.append(f'- Caveat: {c["caveat"]}')
+
+    lines.append("")
+    return lines
+
+
+def tally(records: list[dict], key: str) -> list[str]:
+    counts: dict[str, int] = {}
+    for r in records:
+        value = r["custom"].get(key)
+        label = value if value is not None else "null (not a study)"
+        counts[label] = counts.get(label, 0) + 1
+    rows = [f"| {label} | {n} |" for label, n in sorted(counts.items())]
+    rows.append(f"| **total** | **{len(records)}** |")
+    return rows
+
+
+def render_counts(records: list[dict]) -> str:
+    out: list[str] = ["### Counts", ""]
+    for key, heading in (
+        ("verification", "Verification"),
+        ("accessLevel", "Access level"),
+        ("evidenceTier", "Evidence tier"),
+    ):
+        out += [f"| {heading} | n |", "|---|---|", *tally(records, key), ""]
+    return "\n".join(out).rstrip()
+
+
+def render_corpus(records: list[dict]) -> str:
+    out: list[str] = []
+    for group, heading in GROUPS:
+        in_group = [r for r in records if r["custom"]["group"] == group]
+        if not in_group:
+            continue
+        plural = "source" if len(in_group) == 1 else "sources"
+        out += ["---", "", f"## {heading}", "", f"{len(in_group)} {plural}.", ""]
+        for rec in in_group:
+            out += render_entry(rec)
+    return "\n".join(out).rstrip()
+
+
+def render_summary(records: list[dict]) -> str:
+    verified = sum(
+        1 for r in records if r["custom"]["verification"] == "crossref-verified"
+    )
+    catalogued = sum(
+        1 for r in records if r["custom"]["verification"] == "openlibrary-verified"
+    )
+    unread = sum(1 for r in records if "NUMBERS NOT READ" in (r["custom"].get("caveat") or ""))
+    tiered_out = sum(1 for r in records if r["custom"].get("evidenceTier") == "E")
+    return (
+        f"{len(records)} sources: {verified} Crossref-verified, {catalogued} verified against "
+        f"Open Library. {unread} are cited from their abstract only and say so, and "
+        f"{tiered_out} are not peer-reviewed and are tiered E so they can back lineage but "
+        f"never a claim."
+    )
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+
+    try:
+        records = load_corpus()
+        check_cross_references(records)
+        notes = NOTES.read_text(encoding="utf-8")
+        check_note_links(records, notes)
+    except CorpusError as exc:
+        print(f"{CORPUS.name}: invalid corpus\n{exc}", file=sys.stderr)
+        return 1
+
+    rendered = notes
+    for marker, replacement in (
+        ("<!-- SUMMARY -->", render_summary(records)),
+        ("<!-- COUNTS -->", render_counts(records)),
+        ("<!-- CORPUS -->", render_corpus(records)),
+    ):
+        if marker not in rendered:
+            print(f"{NOTES.name}: missing marker {marker}", file=sys.stderr)
+            return 1
+        rendered = rendered.replace(marker, replacement)
+
+    if not rendered.endswith("\n"):
+        rendered += "\n"
+
+    if check:
+        current = OUT.read_text(encoding="utf-8") if OUT.exists() else ""
+        if current != rendered:
+            print(
+                f"{OUT.name} is stale. Run: uv run --no-project scripts/generate-citations.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{OUT.name} is up to date ({len(records)} sources).")
+        return 0
+
+    OUT.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {OUT.name}: {len(records)} sources.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a research-provenance apparatus to exhale, matching the pattern already running in `carbonlens`, `agrivoltaic-garden-designer` and `carbon-aware-dispatcher`.

## What's here

| File | Role |
|---|---|
| `docs/CITATIONS.csl.json` | 42 records, source of truth. 40 verified against the Crossref REST API, 2 against Open Library |
| `docs/citations-notes.md` | Hand-written prose: reading guide and the gaps ledger |
| `docs/CITATIONS.md` | Generated from both |
| `scripts/generate-citations.py` | Stdlib only, `--check` mode |
| `.github/workflows/test.yml` | New `citations` job, seconds, no Rust toolchain |
| `README.md` | Corrected claims, 20 inline citations, new "What to expect" section |

Prose lives in its own source file rather than being preserved verbatim inside the generated doc, which is the failure mode `carbon-aware-dispatcher`'s own handoff documents (its preserved section went stale and shipped wrong numbers). Here `CITATIONS.md` is 100% generated, so `--check` catches everything.

## Findings that changed the README

**The opening claim was wrong, then wrong in the other direction.** "We breathe more shallowly at screens" had no citation. A first pass concluded there was no peer-reviewed source at all; a deeper pass found there is, filed under ergonomics rather than breathwork. Schleifer & Ley 1994 (n=11, three six-hour work days) and Schleifer et al. 2008 (n=23) both measured significantly lower end-tidal CO2 and faster respiration at the keyboard, and Schleifer, Ley & Spalding 2002 identifies the diaphragmatic-to-thoracic shift that "shallow" actually names. Two independent posture studies support it further. The ledger opens with an explicit retraction of the intermediate claim.

**The default pace sits outside the tested band.** 5 in / 10 out is 4.0 breaths/min; the directly tested range is 5 to 7. Box breathing is worse at 3.75, and lost head-to-head against 6 bpm (Marchant et al. 2025, n=84) and again on mood (Balban et al. 2023). The shipped default is deliberately unchanged; that is a release-note decision, not a silent one.

**The 1:2 ratio mechanism claim is not supportable.** Four studies split two for, one against, one null. The recommendation survives because the one study that measured how people *felt* across ratios favours the longer exhale; the "engages the parasympathetic nervous system" gloss does not.

## Honest by construction

The corpus carries the published dissent, the failed replications, three entries cited from their abstract only and marked `NUMBERS NOT READ`, and a 14-item ledger of places exhale ships something the literature does not back. The pranayama sources exhale actually descends from are included at evidence tier E, citable for lineage and never for whether anything works.

## Validation

`--check` fails on stale output, malformed citekeys, bad enum values, citekey years that drift from the record year, dangling anchors from the ledger into the corpus, and cross-references between entries. The last two each caught a real bug during authoring.
