### PR TITLE
fix(windows): track .cargo config so CI links the MSVC CRT statically

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,0 +1,12 @@
+# Statically link the MSVC C runtime on Windows so the shipped binary carries no
+# dependency on the Microsoft Visual C++ Redistributable. Store certification
+# (policy 10.2.4.1, Security - Software Dependencies) flags that runtime as
+# undisclosed non-integrated software; linking it statically removes the
+# dependency instead of merely disclosing it.
+#
+# Scoped to the MSVC target only, so macOS and Linux builds are unaffected. Safe
+# here because the dependency tree is pure Rust (wgpu, egui, winit, tray-icon,
+# windows-sys bindings, image with default-features off) with no `cc`-built C
+# code that could pick up a mismatched /MD runtime
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
`rust/.cargo/config.toml` has existed locally since 20 Jul but was never committed. It statically links the MSVC C runtime so the shipped Windows binary carries no dependency on the Visual C++ Redistributable, which Microsoft Store policy 10.2.4.1 flags as undisclosed non-integrated software.

## Why this is a real gap, not just untidiness

- **Not gitignored.** `.gitignore` carries only `target/` and `**/target/`, so this was missed rather than deliberately excluded. It was created the same day as `MICROSOFT_STORE_HANDOFF.md` and appears to have slipped out of that push.
- **The flag is set nowhere else.** Grepped `rust/scripts/`, both workflows, `DEPLOYMENT.md` and the handoff doc. The only `crt-static` in the repo is this file, and `release.yml` explicitly declines to set `RUSTFLAGS` globally.
- **CI builds exactly the target it scopes to.** The `windows` job runs on `windows-2025` targeting `x86_64-pc-windows-msvc`.
- **Cargo will now discover it.** `bundle-msix.ps1:83` does `Push-Location $RustRoot` before `cargo build`, so cargo's CWD is `rust/` and config lookup walks up from there. Worth noting this only works because of that `Push-Location`: had the script used `--manifest-path` from the repo root instead, cargo would resolve config from the repo root and never see this file.

## Consequence

`MICROSOFT_STORE_HANDOFF.md:185` says the MSIX comes from CI. Any CI-built Store package has therefore been dynamically linking the MSVC CRT, which is the exact condition this file exists to prevent. Only a locally built package would have picked up the static link.

Worth checking the currently-live Store package against this to decide whether a resubmission is warranted.

## Scope

Scoped to `[target.x86_64-pc-windows-msvc]`, so macOS and Linux builds are unaffected.
