### PR TITLE
feat: provenance hardening, drift enhancements, and a rendered citation corpus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,3 +84,28 @@ jobs:
 
       - name: Check generated citations are current
         run: python3 scripts/generate-citations.py --check
+
+  # 8,400 lines of Rust currently have no compile gate anywhere in CI: the
+  # release and dev-build workflows only ever run `cargo build --release`, and
+  # there is no `cargo test` / `check` / `clippy` job. `exhale-core` is the
+  # cheap half to cover, since it has no wgpu, winit or GTK dependency and so
+  # needs no system packages. It is also where a generated presets table would
+  # land if the research-panel work proceeds, and a checked-in generated .rs
+  # that nothing compiles is a silent time bomb
+  core-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: cargo check
+        working-directory: rust
+        run: cargo check -p exhale-core --all-targets
+
+      - name: cargo test
+        working-directory: rust
+        run: cargo test -p exhale-core

--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ renamed entry or a stale number breaks the build rather than rotting silently. I
 this project has retracted anywhere it could still be asserted: the Rust sources, the Snap
 description and the Microsoft Store listing copy.
 
-**In the app.** The menu bar carries a *Research, and what it doesn't support* item that opens the
-gaps ledger rather than the top of the reference list. The Timing panel offers five patterns as
+**In the app.** A *Research* item in the macOS app menu, directly under About, and the same item in
+the system-tray menu on every platform. Both open the gaps ledger rather than the top of the
+reference list, which is the whole point of the item: the label is plain, so the anchor carries the
+intent. The Timing panel offers five patterns as
 one-click presets, computes the current rate from the four duration fields, and prints it against
 the tested range, unprompted, so a configuration outside that range says so where it is being
 chosen. Selecting box breathing makes the panel state that it is 3.8 breaths a minute and slower

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every claim above and below is sourced in **[docs/CITATIONS.md](docs/CITATIONS.m
 
 The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable.
 
-**Where to start: `5` / `0` / `5` / `0`.** Five seconds in, five out, no holds. That is 6 breaths per minute, which is the rate with the best direct evidence. The band tested head-on runs 5 to 7 breaths per minute, and every rate in it beat spontaneous breathing ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)); average individual resonance frequency sits near 5.5 ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). In a four-way head-to-head (n = 84), 6 breaths per minute raised heart rate variability more than either box breathing or 4-7-8 ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)). Holding the breath is the hard part for a beginner, not the slow part, so this is also the gentlest place to start.
+**The default is `5` / `0` / `5` / `0`.** Five seconds in, five out, no holds. That is 6 breaths per minute, which is the rate with the best direct evidence. The band tested head-on runs 5 to 7 breaths per minute, and every rate in it beat spontaneous breathing ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)); average individual resonance frequency sits near 5.5 ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). In a four-way head-to-head (n = 84), 6 breaths per minute raised heart rate variability more than either box breathing or 4-7-8 ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)). Holding the breath is the hard part for a beginner, not the slow part, so this is also the gentlest place to start.
 
 Box breathing is `4` / `4` / `4` / `4` and exhale supports it, but note it is a 16-second cycle, or 3.75 breaths per minute: the holds hide the fact that it is *slower* than it looks. It lost that head-to-head ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six), whose authors note square and 4-7-8 breathing "have little empirical support"), and lost again on mood in a month-long randomised trial ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). The same applies to 4-7-8.
 
@@ -20,7 +20,7 @@ Box breathing is `4` / `4` / `4` / `4` and exhale supports it, but note it is a 
 
 What the evidence does support is subjective. In the one study that measured how people *felt* across ratios, the longer exhale produced more reported relaxation, stress reduction, mindfulness and positive energy, while slowing the rate alone moved only one of those four ([Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)); a month-long trial points the same way on mood ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). Prefer a longer exhale because it feels better, which is the outcome that matters here anyway. Worth knowing that *every* slow pattern tested beat baseline on relaxation ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)): rate does most of the work, and ratio is a preference with a modest, contested edge.
 
-exhale's shipped default is `5` in / `10` out, or 4 breaths per minute, below the band anyone has tested ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)). It is kept for continuity with existing installs rather than because it is known to be better. All of this, including the arithmetic, is laid out in [the gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices).
+Being inside the tested band is a claim about coverage, not about optimality: that band is five values wide, and resonance frequency varies from person to person ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)), which no single shipped number can accommodate. Treat 6 a minute as a good starting point rather than as your number. exhale's earlier default, `5` in / `10` out at 4 breaths per minute, is still one click away as a preset; nobody has measured 4 a minute. All of this, including the arithmetic, is laid out in [the gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices).
 
 Take breaks if intense feelings arise; it's important not to overdo it. Few adverse effects are expected from *slow* breathing specifically ([Laborde et al. 2022](docs/CITATIONS.md#laborde2022-vsb-meta)), but exhale's sliders can also be set to fast, hold-heavy patterns that leave that evidence base for the high-ventilation literature, where transient tetany and light-headedness are documented ([Fincham et al. 2024](docs/CITATIONS.md#fincham2024-high-ventilation-rct)).
 
@@ -79,7 +79,7 @@ on-screen breaks did nothing), and a
 [ledger of fourteen places](docs/CITATIONS.md#gaps-and-unsupported-choices) where exhale ships
 something the literature does not settle. Four highlights:
 
-- exhale's **default pace is 4 breaths per minute**, below the 5 to 7 range that has been tested directly ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)). So is box breathing, at 3.75.
+- The **tested range is only 5 to 7 breaths per minute wide** ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)), and individual resonance frequency varies within and beyond it ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)). exhale's default of 6 sits inside it; box breathing, at 3.75, does not.
 - Whether a **longer exhale** beats an equal one on heart rate variability is split four ways ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv), [Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). It holds up on how people report *feeling*, which is why the recommendation survived and the mechanism claim did not.
 - The closest published analogue to exhale, an ambient on-screen pacer running during real information work, lowered breathing rate **only while it was running** ([Moraveji et al. 2011](docs/CITATIONS.md#moraveji2011-peripheral-paced-respiration)). Treat an always-on overlay as an effect that lasts as long as it is on. Visual pacing also changes breathing more than audio while feeling *less* calming ([Wongsuphasawat et al. 2012](docs/CITATIONS.md#wongsuphasawat2012-cant-force-calm)), which is a trade exhale makes deliberately.
 - Slow pacing itself mildly increases over-breathing ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)), and screen workers are already mildly hypocapnic ([Schleifer & Ley 1994](docs/CITATIONS.md#schleifer1994-vdt-petco2), [Schleifer et al. 2008](docs/CITATIONS.md#schleifer2008-emg-gaps-computer-work)). Nobody has tested a slow pacer on that population, which is exactly exhale's user.
@@ -112,12 +112,11 @@ listing is edited somewhere a README review never reaches, which is exactly how 
 **In the app.** A *Research* item in the macOS app menu, directly under About, and the same item in
 the system-tray menu on every platform. Both open the gaps ledger rather than the top of the
 reference list, which is the whole point of the item: the label is plain, so the anchor carries the
-intent. The Timing panel offers five patterns as
-one-click presets, computes the current rate from the four duration fields, and prints it against
-the tested range, unprompted, so a configuration outside that range says so where it is being
-chosen. Selecting box breathing makes the panel state that it is 3.8 breaths a minute and slower
-than anything tested directly, which is the honest thing to say about a pattern people arrive
-looking for by name. No preset carries a badge, a rank or an evidentiary caption: the arithmetic
+intent. The Timing panel offers five patterns as one-click presets, computes the current rate from
+the four duration fields, and prints it against the tested range, unprompted, so a configuration
+outside that range says so where it is being chosen. Selecting box breathing makes the panel state
+that it is 3.8 breaths a minute and slower than anything tested directly, which is the honest thing
+to say about a pattern people arrive looking for by name. No preset carries a badge, a rank or an evidentiary caption: the arithmetic
 below them is computed live for whichever is selected, so it cannot go stale and does not have to
 be maintained against the corpus.
 

--- a/README.md
+++ b/README.md
@@ -109,12 +109,20 @@ this project has retracted anywhere it could still be asserted: the Rust sources
 description and the Microsoft Store listing copy.
 
 **In the app.** The menu bar carries a *Research, and what it doesn't support* item that opens the
-gaps ledger rather than the top of the reference list. The Timing panel computes the current rate
-from the four duration fields and prints it against the tested range, unprompted, so a configuration
-outside that range says so where it is being chosen. The binary states arithmetic and one range and
-nothing else: no effect, no benefit, no condition. That restraint is deliberate. Everything
-evidentiary lives in this repository, which can be corrected in an afternoon, rather than in a
-signed binary that takes a store-review cycle to withdraw.
+gaps ledger rather than the top of the reference list. The Timing panel offers five patterns as
+one-click presets, computes the current rate from the four duration fields, and prints it against
+the tested range, unprompted, so a configuration outside that range says so where it is being
+chosen. Selecting box breathing makes the panel state that it is 3.8 breaths a minute and slower
+than anything tested directly, which is the honest thing to say about a pattern people arrive
+looking for by name. No preset carries a badge, a rank or an evidentiary caption: the arithmetic
+below them is computed live for whichever is selected, so it cannot go stale and does not have to
+be maintained against the corpus.
+
+The binary states arithmetic and one range and nothing else: no effect, no benefit, no condition.
+That restraint is deliberate. Everything evidentiary lives in this repository, which can be
+corrected in an afternoon, rather than in a signed binary that takes a store-review cycle to
+withdraw. Four sources are flagged `inAppCitable: false` in the corpus for exactly that reason, and
+the build fails if a shipped preset points at one of them.
 
 Nothing in this section is medical advice; see the [disclaimer](#disclaimer) above.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Slow paced breathing is the countermeasure with the most evidence behind it ([La
 
 Blink rate also falls sharply at a display ([Tsubota & Nakamori 1993](docs/CITATIONS.md#tsubota1993-vdt-blink), [Rosenfield 2011](docs/CITATIONS.md#rosenfield2011-computer-vision-syndrome), [Sheppard & Wolffsohn 2018](docs/CITATIONS.md#sheppard2018-digital-eye-strain)). exhale does nothing about that; it paces breathing only.
 
-Every claim above and below is sourced in **[docs/CITATIONS.md](docs/CITATIONS.md)**, 42 verified references. Each link lands on that source's corpus entry, which carries its DOI, its access level, its evidence tier and its caveats, rather than on the paper directly, because several of these findings are weaker than a bare citation would suggest. The [gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices) collects fourteen places where exhale ships something the literature does not back.
+Every claim above and below is sourced in **[docs/CITATIONS.md](docs/CITATIONS.md)**, 48 verified references. Each link lands on that source's corpus entry, which carries its DOI, its access level, its evidence tier and its caveats, rather than on the paper directly, because several of these findings are weaker than a bare citation would suggest. The [gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices) collects fourteen places where exhale ships something the literature does not back.
 
 The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable.
 
@@ -65,9 +65,9 @@ breathing pattern to arousal state. It is mice, and it is a reason rather than a
 ## Research and evidence
 
 exhale's premise, its defaults and its interface choices are traced to the literature in
-**[docs/CITATIONS.md](docs/CITATIONS.md)**: 42 sources, 40 verified against the Crossref REST API and
-2 against Open Library, each carrying an access level, an evidence tier and the specific claims it is
-allowed to back.
+**[docs/CITATIONS.md](docs/CITATIONS.md)**: 48 sources, 45 verified against the Crossref REST API,
+2 against Open Library and 1 against PubMed, each carrying an access level, an evidence tier and the
+specific claims it is allowed to back.
 
 The corpus is deliberately not a sales pitch. Alongside the meta-analyses that support slow paced
 breathing it carries the published dissent: a meta-analysis finds sustained slow breathing lowers
@@ -102,8 +102,19 @@ uv run --no-project scripts/generate-citations.py           # regenerate
 uv run --no-project scripts/generate-citations.py --check   # fail if stale
 ```
 
-`--check` also validates citekey format, enum values and every anchor link the gaps ledger makes into
-the corpus, so a renamed entry breaks the build rather than rotting silently.
+`--check` also validates citekey format, enum values, every anchor link the gaps ledger makes into
+the corpus, the source counts quoted in this file, and the deep link the app itself compiles in, so a
+renamed entry or a stale number breaks the build rather than rotting silently. It refuses phrasing
+this project has retracted anywhere it could still be asserted: the Rust sources, the Snap
+description and the Microsoft Store listing copy.
+
+**In the app.** The menu bar carries a *Research, and what it doesn't support* item that opens the
+gaps ledger rather than the top of the reference list. The Timing panel computes the current rate
+from the four duration fields and prints it against the tested range, unprompted, so a configuration
+outside that range says so where it is being chosen. The binary states arithmetic and one range and
+nothing else: no effect, no benefit, no condition. That restraint is deliberate. Everything
+evidentiary lives in this repository, which can be corrected in an afternoon, rather than in a
+signed binary that takes a store-review cycle to withdraw.
 
 Nothing in this section is medical advice; see the [disclaimer](#disclaimer) above.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The overlay is a translucent always-on-top window that gently expands on inhale 
 
 Box breathing is `4` / `4` / `4` / `4` and exhale supports it, but note it is a 16-second cycle, or 3.75 breaths per minute: the holds hide the fact that it is *slower* than it looks. It lost that head-to-head ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six), whose authors note square and 4-7-8 breathing "have little empirical support"), and lost again on mood in a month-long randomised trial ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). The same applies to 4-7-8.
 
-**On making the exhale longer than the inhale:** worth doing, but not for the usual reason. Whether a 1:2 ratio raises heart rate variability more than 1:1 is genuinely split: two studies found an effect ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)), one found the *equal* ratio better ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)), and one found no difference across an original experiment and its own replication ([Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). exhale therefore no longer claims a longer exhale "engages the parasympathetic nervous system."
+**On making the exhale longer than the inhale:** worth doing, but not for the usual reason. Whether a 1:2 ratio raises heart rate variability more than 1:1 is genuinely split: two studies found an effect ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)), one found the *equal* ratio better ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)), and one found no difference across an original experiment and its own replication ([Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). No mechanism claim survives that split, so exhale does not make one.
 
 What the evidence does support is subjective. In the one study that measured how people *felt* across ratios, the longer exhale produced more reported relaxation, stress reduction, mindfulness and positive energy, while slowing the rate alone moved only one of those four ([Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)); a month-long trial points the same way on mood ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). Prefer a longer exhale because it feels better, which is the outcome that matters here anyway. Worth knowing that *every* slow pattern tested beat baseline on relaxation ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)): rate does most of the work, and ratio is a preference with a modest, contested edge.
 
@@ -75,9 +75,9 @@ systolic pressure by about 5.6 mmHg ([Chaddha et al. 2019](docs/CITATIONS.md#cha
 editorial in a hypertension journal argues that case should be considered closed
 ([van Dijk et al. 2018](docs/CITATIONS.md#vandijk2018-close-the-book)). It also carries the failed replications, a null result
 against exhale's own genre ([Johnson & Rosenfield 2023](docs/CITATIONS.md#johnson2023-20-20-20), where scheduled
-on-screen breaks did nothing), a correction to this repo's own earlier claims, and a
+on-screen breaks did nothing), and a
 [ledger of fourteen places](docs/CITATIONS.md#gaps-and-unsupported-choices) where exhale ships
-something the literature does not back. Four highlights:
+something the literature does not settle. Four highlights:
 
 - exhale's **default pace is 4 breaths per minute**, below the 5 to 7 range that has been tested directly ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)). So is box breathing, at 3.75.
 - Whether a **longer exhale** beats an equal one on heart rate variability is split four ways ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv), [Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). It holds up on how people report *feeling*, which is why the recommendation survived and the mechanism claim did not.
@@ -104,9 +104,10 @@ uv run --no-project scripts/generate-citations.py --check   # fail if stale
 
 `--check` also validates citekey format, enum values, every anchor link the gaps ledger makes into
 the corpus, the source counts quoted in this file, and the deep link the app itself compiles in, so a
-renamed entry or a stale number breaks the build rather than rotting silently. It refuses phrasing
-this project has retracted anywhere it could still be asserted: the Rust sources, the Snap
-description and the Microsoft Store listing copy.
+renamed entry or a stale number breaks the build rather than rotting silently. It also refuses a
+short list of claims the corpus does not support, anywhere they could be asserted rather than
+discussed: the Rust sources, the Snap description and the Microsoft Store listing copy. A store
+listing is edited somewhere a README review never reaches, which is exactly how the two drift.
 
 **In the app.** A *Research* item in the macOS app menu, directly under About, and the same item in
 the system-tray menu on every platform. Both open the gaps ledger rather than the top of the

--- a/RESEARCH-SURFACE-HANDOFF.md
+++ b/RESEARCH-SURFACE-HANDOFF.md
@@ -2,8 +2,9 @@
 
 Brief for an agent picking this up cold. Read this before touching the settings window.
 
-**Status:** phases 0, 1, 2 and 3 are done and are on `feat/provenance-and-drift-enhancements`.
-Phase 4 is designed and not started. Phase 5 is deliberately deferred.
+**Status:** phases 0 through 4 are done and are on `feat/provenance-and-drift-enhancements`.
+Phase 5 is deliberately deferred, and phase 4 shipping the way it did makes the case for deferring it
+stronger rather than weaker: see the phase 5 note.
 
 What phases 2 and 3 actually shipped is recorded under each phase heading below. Two things were
 found while building them that are not in the design: the README's source counts had been wrong
@@ -29,6 +30,7 @@ with new evidence.
 | CI: `citations` + `core-check` | [`.github/workflows/test.yml`](.github/workflows/test.yml) |
 | Tray deep link + `platform::open_url` | [`tray.rs`](rust/crates/exhale-app/src/tray.rs), [`platform.rs`](rust/crates/exhale-app/src/platform.rs) |
 | Pacing arithmetic and the copy derived from it | [`pacing.rs`](rust/crates/exhale-core/src/pacing.rs) |
+| Preset patterns and derived selection | [`presets.rs`](rust/crates/exhale-core/src/presets.rs) |
 | Store copy under denylist | [`snap/snapcraft.yaml`](snap/snapcraft.yaml), [`rust/packaging/windows/store-listing.md`](rust/packaging/windows/store-listing.md) |
 
 ~~**The binary has no research surface at all.**~~ It has two, as of phases 2 and 3. `platform::open_url`
@@ -222,7 +224,46 @@ claim, and volunteers bad news about the app's own default.
 render **unprompted on first open**, not behind a hover or a disclosure triangle. Disclosure reaches
 users who open the panel; the default is imposed on everyone who never does.
 
-### Phase 4: preset chips. ~70 lines.
+### Phase 4: preset chips. DONE.
+
+**Shipped, with two structural changes and one thing that turned out not to be true.**
+
+1. **No per-chip evidentiary captions.** The design called for captions carrying each pattern's rate
+   ("caption must say 3.75 a minute", "caption says it is below the tested band"). Phase 3's readout
+   now sits three rows under the chips and says exactly that, computed, for whichever chip is lit.
+   Five hand-written captions would restate it worse: they would be prose in the binary rather than
+   arithmetic, they would need maintaining against the corpus, and they would only cover the
+   patterns someone remembered to annotate. The captions that survive carry names and nothing else
+   (`Sometimes called A52.`, `Sometimes called box breathing.`, `exhale's shipped default.`), and a
+   denylist test rejects any label or note that names a rate, an effect or a recommendation.
+2. **Presets set the four durations and nothing else**, not drift and not jitter. The design said
+   presets should set those "and disclose that they do", while also saying not to silently zero a
+   setting the user tuned. Not touching them satisfies both, and it is what makes derived selection
+   sound: selection compares exactly the four fields a preset writes.
+3. **The contrast worry did not hold.** Measured rather than estimated, the dark-mode selected pill
+   is **4.94:1 at its worst across every possible backdrop**, not the ~4.0:1 the design feared,
+   because alpha 230 leaves little of the card showing through. The real finding is next door:
+   *unselected* text on the translucent card is fine on any backdrop the app controls and on any
+   non-inverting vibrancy, and bottoms out near **3.0:1** against a near-white backdrop behind a
+   dark-mode window. That is a property of every `ui.label` in this window, not of the chips, and it
+   is now a pinned number in `widgets.rs` rather than an assumption.
+
+The open question the design flagged is answered: **egui 0.29 does synthesise a click from Space and
+Enter** on a focused `ui.interact` response (`Context::create_widget` sets `fake_primary_click`).
+Both keys, and Tab-reachability of all five chips in display order, are covered by tests.
+
+`selected_pill_fill`, `selected_pill_text` and `card_fill` were hoisted out of `segmented_row` and
+`section` so the pickers and the chips share one definition and one contrast test.
+
+**Two traps for whoever works on this file next.** `ui.set_width` on a `CentralPanel`'s own `Ui` is
+silently undone (`Placer::set_max_width` unions the result back with `min_rect`, which for a panel is
+already the full panel), so the first version of the chip test laid out at 384 pt and would have
+passed while the shipped card is 308; go through `section` instead. And the Timing card is now
+**324 pt**, measured, up from 160 before phase 3, which is why `INITIAL_PREFERRED_H` stayed at 796
+and the fold moved up rather than the window growing to 960.
+
+Original design notes follow.
+
 
 Chips live **inside the existing Timing card** (`settings_window.rs:1355`), above the four
 `duration_row` calls, so a click visibly moves all four steppers.
@@ -256,7 +297,16 @@ Candidate set, deliberately including one that ships its own disconfirming evide
 | `4 / 4 / 4 / 4` | box | caption must say 3.75 a minute |
 | `5 s in, 10 s out` | 5/0/10/0 | the shipped default; caption says it is below the tested band |
 
-### Phase 5: deferred, and the two engineers never agreed.
+### Phase 5: still deferred, and phase 4 strengthened the case.
+
+The instruction was to ship 2-4 and see whether anything feels missing. What phase 4 found is that
+the place prose would have gone is already occupied by something better: the live readout answers
+"what is this pattern" for every preset, and a generated `custom.uiCaption` would be a second,
+staler answer to the same question. Revisit only if a specific gap turns up that arithmetic cannot
+fill.
+
+Original notes on the disagreement follow.
+
 
 Whether to add `custom.uiCaption` to the corpus (UX: yes, generated, under `--check`, with a
 banned-vocabulary gate) or ship no prose at all (full-stack: any prose authored for the binary
@@ -283,9 +333,15 @@ strings are ruled out by both.
 
 ## 6. Open decisions and loose ends
 
-- **`feat/provenance-and-drift-enhancements` has no PR.** Four commits, from `60d567b`.
-- **Neither phase 2 nor phase 3 has been seen running.** The tray item needs a click on a signed
-  sandboxed build; the readout needs a look at the Timing card at the shipped window width.
+- **`feat/provenance-and-drift-enhancements` has no PR.** Five commits, from `60d567b`.
+- **None of phases 2, 3 or 4 has been seen running.** The tray item needs a click on a signed
+  sandboxed build; the readout and the chips need a look at the Timing card at the shipped window
+  width. Layout, wrapping, click and keyboard behaviour are covered by headless egui tests, and
+  contrast is computed from the shipped colour constants, so what is unverified is specifically the
+  visual result rather than the behaviour.
+- **Unselected text bottoms out near 3.0:1** against a near-white backdrop behind a dark-mode
+  window. Pre-existing for every label in the settings window, pinned by a test, unfixed. The same
+  accessibility debt as the missing AccessKit tree.
 - **The Snap listing is still live with the retracted claims.** `snapcraft.yaml` is fixed in the repo,
   but the store shows the old copy until someone re-uploads. Memory says Snap upload is manual via
   Docker `snapcore/snapcraft` + interactive `snapcraft login`.

--- a/RESEARCH-SURFACE-HANDOFF.md
+++ b/RESEARCH-SURFACE-HANDOFF.md
@@ -2,8 +2,14 @@
 
 Brief for an agent picking this up cold. Read this before touching the settings window.
 
-**Status:** phases 0 and 1 are done and are on `feat/provenance-and-drift-enhancements`. Phases 2-4
-are designed and not started. Phase 5 is deliberately deferred.
+**Status:** phases 0, 1, 2 and 3 are done and are on `feat/provenance-and-drift-enhancements`.
+Phase 4 is designed and not started. Phase 5 is deliberately deferred.
+
+What phases 2 and 3 actually shipped is recorded under each phase heading below. Two things were
+found while building them that are not in the design: the README's source counts had been wrong
+since the corpus grew (42/40/2 against an actual 48/45/2/1), and the gaps ledger still described a
+drift step of 0.01 percentage points when the code shipped 0.1. Both are fixed, and both now have
+`--check` gates so they fail the build rather than rotting again.
 
 The design below is the verdict of a four-specialist review (UX, full-stack, egui/frontend, and a
 psychophysiology professor) that argued to convergence. Where they disagreed, the resolution and the
@@ -21,10 +27,12 @@ with new evidence.
 | Generated render | [`docs/CITATIONS.md`](docs/CITATIONS.md) |
 | Generator, stdlib only, `--check` mode | [`scripts/generate-citations.py`](scripts/generate-citations.py) |
 | CI: `citations` + `core-check` | [`.github/workflows/test.yml`](.github/workflows/test.yml) |
+| Tray deep link + `platform::open_url` | [`tray.rs`](rust/crates/exhale-app/src/tray.rs), [`platform.rs`](rust/crates/exhale-app/src/platform.rs) |
+| Pacing arithmetic and the copy derived from it | [`pacing.rs`](rust/crates/exhale-core/src/pacing.rs) |
 | Store copy under denylist | [`snap/snapcraft.yaml`](snap/snapcraft.yaml), [`rust/packaging/windows/store-listing.md`](rust/packaging/windows/store-listing.md) |
 
-**The binary has no research surface at all.** `git grep -i "citation\|research\|evidence" -- rust/`
-returns only a code comment in `controller.rs`. `platform::open_url` does not exist.
+~~**The binary has no research surface at all.**~~ It has two, as of phases 2 and 3. `platform::open_url`
+now exists with three cfg'd implementations and an `https://`-only allowlist.
 
 ---
 
@@ -126,7 +134,31 @@ Rules that follow:
 
 ## 4. Phases
 
-### Phase 2: tray link. Ship-blocker. ~25 lines.
+### Phase 2: tray link. Ship-blocker. DONE, commit `cfbb180`.
+
+**Shipped as designed.** `RESEARCH_URL` and its label are pinned together in `tray.rs` because the
+wording and the anchor are one decision; the item sits directly under Preferences; the handler is
+inline in the `MenuEvent` loop rather than routed through an `AppEvent`, since opening a URL touches
+no app state and `about_to_wait` is already on the main thread, which is where `NSWorkspace` has to
+be called from.
+
+Three things worth knowing before changing it:
+
+- The URL is pinned to `main`, not to a release tag. A binary outlives its tag, and a retraction has
+  to reach people running old builds. A moved anchor is a CI failure; a stale claim is not.
+- `scripts/generate-citations.py` now parses `RESEARCH_URL` out of `tray.rs` and fails if the
+  constant disappears or its fragment matches no heading in the rendered document. Both failure
+  modes were tested by injection.
+- The allowlist is `is_openable` in `platform.rs`, with tests. It is load-bearing rather than
+  decorative even though every current caller passes a constant: `ShellExecuteW` resolves a `file:`
+  URL through the shell association table and would launch a local program.
+
+macOS reaches `NSWorkspace` through `class!` + `msg_send!` rather than the typed bindings, so no new
+cargo feature and no new dependency were needed on any platform. **The signed-sandboxed smoke test is
+still outstanding** and is the one thing here that was verified by reading rather than by clicking.
+
+Original design notes follow.
+
 
 One `MenuItem` in [`tray.rs`](rust/crates/exhale-app/src/tray.rs) beside `preferences_item`, one arm
 in the `MenuEvent` loop at [`main.rs:1066`](rust/crates/exhale-app/src/main.rs), plus
@@ -140,7 +172,37 @@ support"**. Same code, opposite epistemic effect.
 Smoke-test `NSWorkspace openURL:` on a signed sandboxed build before submission. The API surface,
 feature flags and entitlements were verified; an actual signed click was not.
 
-### Phase 3: computed readout. The highest-value item.
+### Phase 3: computed readout. DONE.
+
+**Shipped, with three changes to the design, all deliberate.**
+
+1. **The copy lives in `exhale-core`, not next to the widget.** CI runs `cargo test -p exhale-core`
+   and does not compile `exhale-app`, which needs wgpu, winit and GTK. Copy that makes a coverage
+   statement should not be the only text in the project with no test behind it. `pacing.rs` holds
+   the range constants, the classification and the strings; the widget only paints.
+2. **The drift line reports a doubling time as well as an hour-out rate.** "0.1 % per cycle" tells
+   nobody whether they picked something gentle or something that runs away before lunch; "twice this
+   cycle length after 4.2 hours" does. `Settings::breaths_per_min_after` turned out to have an exact
+   closed form (`D = c + 60·T·(d − 1)`, derived in the doc comment), so both numbers are one line of
+   arithmetic with no loop and no `powi`. A cycle-by-cycle simulation is kept as a test oracle.
+3. **A fourth coverage state was added.** A pace that starts inside the tested range and drifts out
+   of it within the hour says so, rather than reporting only its starting classification, which
+   would read "one of them" and be misleading.
+
+Two details that are constraints rather than polish: the classification runs on the **rounded**
+displayed rate, so the panel can never print "5.0 breaths a minute" above "slower than any of them";
+and `no_line_names_an_effect_a_benefit_or_a_condition` is a denylist test over the generated strings,
+not a style rule. It is what enforces section 3's rule inside the binary, and it is the reason
+`custom.backsClaims` still cannot be quoted verbatim however well-sourced those strings are.
+
+`INITIAL_PREFERRED_H` went 796 -> 848 to keep the Randomization card above the fold on first run. The
+figure is estimated, not measured, which is safe in both directions: it only picks the first-run
+height, a saved height always wins, and `set_max_inner_size` clamps to laid-out content on frame one.
+**Nobody has looked at this on a screen yet.** Everything above is compile-, test- and
+arithmetic-verified; the visual result is not.
+
+Original design notes follow.
+
 
 One live line under the Timing sliders, computed from real settings:
 
@@ -221,7 +283,9 @@ strings are ruled out by both.
 
 ## 6. Open decisions and loose ends
 
-- **`feat/provenance-and-drift-enhancements` has no PR.** Commit `60d567b`.
+- **`feat/provenance-and-drift-enhancements` has no PR.** Four commits, from `60d567b`.
+- **Neither phase 2 nor phase 3 has been seen running.** The tray item needs a click on a signed
+  sandboxed build; the readout needs a look at the Timing card at the shipped window width.
 - **The Snap listing is still live with the retracted claims.** `snapcraft.yaml` is fixed in the repo,
   but the store shows the old copy until someone re-uploads. Memory says Snap upload is manual via
   Docker `snapcore/snapcraft` + interactive `snapcraft login`.

--- a/RESEARCH-SURFACE-HANDOFF.md
+++ b/RESEARCH-SURFACE-HANDOFF.md
@@ -138,11 +138,26 @@ Rules that follow:
 
 ### Phase 2: tray link. Ship-blocker. DONE, commit `cfbb180`.
 
-**Shipped as designed.** `RESEARCH_URL` and its label are pinned together in `tray.rs` because the
-wording and the anchor are one decision; the item sits directly under Preferences; the handler is
-inline in the `MenuEvent` loop rather than routed through an `AppEvent`, since opening a URL touches
-no app state and `about_to_wait` is already on the main thread, which is where `NSWorkspace` has to
-be called from.
+**Shipped, and then revised twice on the user's call.**
+
+`RESEARCH_URL` and its label are pinned together in `tray.rs` because the wording and the anchor are
+one decision; the item sits directly under Preferences; the handler is inline in the `MenuEvent` loop
+rather than routed through an `AppEvent`, since opening a URL touches no app state and
+`about_to_wait` is already on the main thread, which is where `NSWorkspace` has to be called from.
+
+**The label is now just "Research".** The design argued for wording that leaned toward the ledger
+("Research, and what it doesn't support"); the user asked for the plain word. The epistemic intent is
+intact because it never lived in the label alone: the anchor is `#gaps-and-unsupported-choices`, so
+the item still opens on the fourteen things the literature does not support rather than on 48
+references. Do not "simplify" the anchor to the top of the file.
+
+**It is also in the macOS app menu**, directly under About, sharing `RESEARCH_LABEL` and
+`platform::open_url` with the tray so the two can never disagree. Implemented as a second selector
+(`exhaleShowResearch:`) on the existing leaked handler class, renamed `ExhaleAboutHandler` ->
+`ExhaleMenuHandler` now that it serves two items. This matters more than menu parity: `NSMenu` items
+are exposed to the accessibility tree and nothing inside the egui settings window is, so between
+them the tray and the app menu are the only evidentiary strings a VoiceOver user can perceive.
+Windows and Linux have no app-menu concept; the tray item is the whole surface there.
 
 Three things worth knowing before changing it:
 
@@ -182,11 +197,19 @@ feature flags and entitlements were verified; an actual signed click was not.
    and does not compile `exhale-app`, which needs wgpu, winit and GTK. Copy that makes a coverage
    statement should not be the only text in the project with no test behind it. `pacing.rs` holds
    the range constants, the classification and the strings; the widget only paints.
-2. **The drift line reports a doubling time as well as an hour-out rate.** "0.1 % per cycle" tells
-   nobody whether they picked something gentle or something that runs away before lunch; "twice this
-   cycle length after 4.2 hours" does. `Settings::breaths_per_min_after` turned out to have an exact
-   closed form (`D = c + 60·T·(d − 1)`, derived in the doc comment), so both numbers are one line of
-   arithmetic with no loop and no `powi`. A cycle-by-cycle simulation is kept as a test oracle.
+2. **The drift line reports a doubling point and a projection, both revised after review.** The
+   first version quoted a doubling *time* and an hour-out *rate*, and both were unreadable in
+   different ways. The time depends on the starting cycle, so the same 1 % read as 17 minutes from a
+   10 s cycle and 25 minutes from a 15 s one, which made the panel look like it could not do
+   arithmetic even though both figures were right. The rate, "about 1.3 a minute after an hour", is
+   correct and impossible to picture. What ships instead is *"the cycle doubles every 70 breaths.
+   After an hour it is 46 s, not 10 s."* Breaths because `dᵏ = 2` has no `c` in it, so the count is
+   a property of the drift setting alone and is a true repeat interval rather than a first
+   milestone; seconds because that is the unit the four steppers above are set in. The second clause
+   is suppressed when an hour moves the number by less than half a second, or 0.001 % would render
+   "after an hour it is 15 s, not 15 s". `Settings::breaths_per_min_after` has an exact closed form
+   (`D = c + 60·T·(d - 1)`, derived in the doc comment), so nothing here loops or calls `powi`, and
+   a cycle-by-cycle simulation is kept as a test oracle.
 3. **A fourth coverage state was added.** A pace that starts inside the tested range and drifts out
    of it within the hour says so, rather than reporting only its starting classification, which
    would read "one of them" and be misleading.

--- a/RESEARCH-SURFACE-HANDOFF.md
+++ b/RESEARCH-SURFACE-HANDOFF.md
@@ -1,0 +1,239 @@
+# Handoff: the in-app research surface (phases 2-5)
+
+Brief for an agent picking this up cold. Read this before touching the settings window.
+
+**Status:** phases 0 and 1 are done and are on `feat/provenance-and-drift-enhancements`. Phases 2-4
+are designed and not started. Phase 5 is deliberately deferred.
+
+The design below is the verdict of a four-specialist review (UX, full-stack, egui/frontend, and a
+psychophysiology professor) that argued to convergence. Where they disagreed, the resolution and the
+reason are recorded. **Do not re-litigate the settled parts without new evidence**; do challenge them
+with new evidence.
+
+---
+
+## 1. What already exists
+
+| Thing | Where |
+|---|---|
+| 48-source corpus | [`docs/CITATIONS.csl.json`](docs/CITATIONS.csl.json) |
+| Hand-written prose + 14-item gaps ledger | [`docs/citations-notes.md`](docs/citations-notes.md) |
+| Generated render | [`docs/CITATIONS.md`](docs/CITATIONS.md) |
+| Generator, stdlib only, `--check` mode | [`scripts/generate-citations.py`](scripts/generate-citations.py) |
+| CI: `citations` + `core-check` | [`.github/workflows/test.yml`](.github/workflows/test.yml) |
+| Store copy under denylist | [`snap/snapcraft.yaml`](snap/snapcraft.yaml), [`rust/packaging/windows/store-listing.md`](rust/packaging/windows/store-listing.md) |
+
+**The binary has no research surface at all.** `git grep -i "citation\|research\|evidence" -- rust/`
+returns only a code comment in `controller.rs`. `platform::open_url` does not exist.
+
+---
+
+## 2. Verified facts. Do not re-derive these.
+
+Each was checked against the code or a live API. Several contradict what you would reasonably assume.
+
+**egui and rendering**
+- egui **0.29.1** (+ `egui-winit`, `egui-wgpu` 0.29.1), wgpu 22, winit 0.30 via a **vendored fork** in
+  `vendor/winit` that stubs `Window::set_blur`, because Apple rejected the private
+  `_CGSSetWindowBackgroundBlurRadius` symbol. `lto = true` exists to strip it. App Review has already
+  bitten this repo once.
+- **`egui::Modal` does not exist in 0.29** (landed in 0.31). A modal means `egui::Window` plus
+  hand-rolled dimming; there is precedent at `settings_window.rs:1436` (shortcut capture).
+- **`ui.hyperlink_to` is doubly broken here.** `theme.rs:108` sets `override_text_color`, which bakes
+  body-text colour into the galley so links render as ordinary text; and the macOS
+  `handle_platform_output` bypass at `settings_window.rs:610-647` drops `open_url` on the floor. Use
+  `ui.link()` plus an explicit `platform::open_url()`.
+- **A second egui window would roughly double RSS.** `theme.rs:38` reads `/System/Library/Fonts/SFNS.ttf`
+  (**8,330,740 bytes**, measured) into `FontData::from_owned`, resident for the life of the
+  `egui::Context`. The release binary is ~7.7 MB. A second context is a second 8.3 MB blob plus a
+  second atlas. **Option "separate research window" is dead.**
+- **Tooltips cannot carry caveats.** `area.rs:429` clamps tooltip width to `ctx.screen_rect()`, which
+  here is the 360 pt window, so a 350-character caveat truncates. `SETTINGS_WIDTH` is a
+  `const 360` at `settings_window.rs:195`; only height is user-resizable, which is why long text is
+  cheap (wrap width never changes).
+- Card content width is `360 - 2*OUTER_PAD(14) - 2*CARD_PAD(12) = 308 pt`. `INITIAL_PREFERRED_H` is
+  796 (`settings_window.rs:222`) and the comment at `:208` says Timers is deliberately just below the
+  fold. **Adding a section may push existing content below the fold. Measure.**
+- The full corpus rendered in-app would be **~11,000 pt, about eleven screens**, and would flip
+  `set_max_inner_size` from ~900 to ~11,000 in one frame, fighting the `last_max_height` cache.
+
+**Dependencies**
+- `webbrowser` 1.2.1 is already in the graph via `egui-winit`'s default `links` feature. Linking out
+  costs **zero new dependencies**. (It uses `LSCopyDefaultApplicationURLForURL` on macOS, not a
+  subprocess; an earlier claim that it shells out to `open(1)` was wrong.)
+- **`serde_json` is NOT in the graph.** Runtime-parsing the corpus would add a real dependency;
+  having the Python generator emit a `.rs` file needs no Rust-side JSON parser at all.
+- `windows-sys` already enables `Win32_UI_Shell`, so `ShellExecuteW` is reachable today.
+  `objc2-app-kit` is already a direct dep; `NSWorkspace openURL:` needs only the `"NSWorkspace"`
+  feature added, is public and unentitled, and **MAS entitlements need no change**
+  (`bundle-mas.sh:208-217` ships only app-sandbox + user-selected read-only). Linux: `xdg-open`, and
+  `snapcraft.yaml` already plugs `desktop`.
+- `build.rs` already reaches three levels above the workspace into `swift/.../Assets.xcassets` and
+  degrades to `cargo:warning` when the file is missing. All three store pipelines build from a full
+  repo checkout.
+
+**Accessibility. This is a hard constraint, not an aspiration.**
+- `grep -c 'name = "accesskit' Cargo.lock` returns **0**. VoiceOver, Narrator and Orca see a blank
+  window. **Every existing control is already invisible to screen readers.**
+- Enabling AccessKit would not fix macOS on its own: tree updates are delivered through the very
+  `handle_platform_output` call the vibrancy/RefCell workaround bypasses.
+- Consequence: **tray menu items are native and ARE exposed to screen readers.** The tray link is
+  therefore the only evidentiary string a blind user can perceive, which promotes phase 2 from
+  nice-to-have to ship-blocker. Nothing rendered inside the egui panel may be caveat-load-bearing
+  until AccessKit lands.
+
+**Measurement**
+- `rust/crates/exhale-render/examples/cpu_bench.rs` **cannot** measure any of this: it is an
+  `exhale-render` example with no egui and no window. Use the README's own protocol instead
+  (`ps -o %cpu`, 30 s, 15 samples, normalised to one core), in three conditions: settings closed,
+  open+collapsed, open+expanded. The README's 3.19 % figure was taken with the settings window
+  **closed**, so nothing here can regress it.
+
+---
+
+## 3. The design, and why
+
+**The binary asserts no English sentences about the literature.** It ships numbers, one range, and
+citekeys as identifiers. This is the load-bearing decision and it was reached the hard way.
+
+The full-stack agent initially argued for quoting `custom.backsClaims` verbatim (never paraphrase,
+always generate). That is right about drift-prevention and unusable in practice: the actual strings
+read *"raised cardiac vagal activity"*, *"anxiety reduction"*, *"perceived stress"*. The professor
+blocklists exactly that vocabulary from a store-reviewed binary, and the UX agent independently
+banned it. Both were right; their conclusions were incompatible; so the app ships **derived arithmetic
+instead of quoted prose**. Arithmetic cannot be retracted.
+
+Rules that follow:
+- **Rates are never stored.** Compute from live settings via `Settings::breaths_per_min()` and
+  `breaths_per_min_after(minutes)`. True by construction, for slider users as well as preset users.
+  A cached rate in a preset is false the moment `drift` is non-zero.
+- **Chips are labelled by pattern, never by rate** (`5 s in, 5 s out`, not `6 a minute`).
+- **No badges.** A badge slot is positionally a verdict whatever words are in it. "Most tested" was
+  rejected on facts too: `lin2014` found 5.5 beat 6, and `you2023` singled out no rate. Use a
+  sentence with an explicit referent: *"Rates from 5 to 7 a minute are the ones tested directly.
+  This is one of them."*
+- **No evidence-tier letters in the UI.** Tiers grade sources and license citation behaviour; a
+  preset is not a sentence. Stamping `B` on a button drops the scope conditions that were the
+  condition of the licence.
+- **Brand names move out of labels into captions.** `5 a minute, short pause`, with "Sometimes called
+  A52" in the caption. Removing a name is not removing an option.
+- **Blocklisted from the binary entirely:** `chaddha2019` (blood pressure), `fincham2023` (anxiety /
+  depression effect sizes), `balban2023` (NCT-registered mood trial), `little2025` (anxiety /
+  perceived stress). Note `fincham2023` is the strongest warrant in the corpus and still cannot be
+  used in-app. That cost is real; take it anyway.
+
+---
+
+## 4. Phases
+
+### Phase 2: tray link. Ship-blocker. ~25 lines.
+
+One `MenuItem` in [`tray.rs`](rust/crates/exhale-app/src/tray.rs) beside `preferences_item`, one arm
+in the `MenuEvent` loop at [`main.rs:1066`](rust/crates/exhale-app/src/main.rs), plus
+`platform::open_url` (three cfg'd impls, reject anything not `https://` at the boundary).
+
+**The label and the anchor are the whole feature.** Not "Citations" pointing at the top of
+`CITATIONS.md`, which lands the reader in 48 references and reads as a wall of authority. Point it at
+`#gaps-and-unsupported-choices` and label it toward the ledger, e.g. **"Research, and what it doesn't
+support"**. Same code, opposite epistemic effect.
+
+Smoke-test `NSWorkspace openURL:` on a signed sandboxed build before submission. The API surface,
+feature flags and entitlements were verified; an actual signed click was not.
+
+### Phase 3: computed readout. The highest-value item.
+
+One live line under the Timing sliders, computed from real settings:
+
+```
+Now: 4.0 breaths a minute (15 s cycle).
+Drift is on: about 3.5 a minute after 4 minutes.
+```
+
+Plus a coverage line, one of three states, phrased about the literature and never about the user:
+*"Rates from 5 to 7 a minute are the ones tested directly. Yours is below that range."*
+
+It performs arithmetic the user genuinely cannot do (especially with `drift` compounding, and
+especially for box breathing where the holds hide that 4/4/4/4 is 3.75 a minute), makes no health
+claim, and volunteers bad news about the app's own default.
+
+**Condition attached, from the professor:** if the shipped default stays out of band, this line must
+render **unprompted on first open**, not behind a hover or a disclosure triangle. Disclosure reaches
+users who open the panel; the default is imposed on everyone who never does.
+
+### Phase 4: preset chips. ~70 lines.
+
+Chips live **inside the existing Timing card** (`settings_window.rs:1355`), above the four
+`duration_row` calls, so a click visibly moves all four steppers.
+
+- **Selection is derived, not stored.** Compare the four `f64`s with the same `1e-9` epsilon
+  `SettingsDiff::from` uses at `settings.rs:457-460`. No new persisted field, no desync, no
+  migration. This is the single most important implementation decision.
+- **No "Custom" chip.** Custom is the absence of a selected pill. A disabled chip is a Tab-traversal
+  hazard; this file documents that at `:1245` and `:1298`.
+- Build them the way `segmented_row` builds segments (`widgets.rs:520-745`): precomputed rects,
+  `ui.interact`, `resp.gained_focus() -> scroll_to_me`, the same focus halo at `widgets.rs:672-696`.
+- **Verify keyboard activation with a test.** It is unconfirmed whether egui 0.29 synthesises a click
+  from Space/Enter on a focused `ui.interact` response. The harness exists at
+  `settings_window.rs:1534` onward. Without this the feature is mouse-only.
+- **Wrap, never truncate.** `paint_label_with_width` sets `max_rows: 1, overflow_character: Some('…')`
+  (`widgets.rs:501-503`); do not use it for chip captions.
+- **Contrast needs measuring.** The dark-mode selected pill is `rgb(110,110,110)` at alpha 230 with
+  white text (`widgets.rs:603`), which lands near 4.0:1, under the 4.5:1 AA threshold. Measure the
+  composite over the translucent card, not the nominal colour.
+- Presets set the pattern **and** `drift`/jitter, and disclose that they do. Do **not** silently zero
+  a setting the user tuned; the UX agent's `Make steady` inline action is the pattern: the app offers
+  the fix rather than performing it.
+
+Candidate set, deliberately including one that ships its own disconfirming evidence:
+
+| Chip label | Pattern | Note |
+|---|---|---|
+| `5 s in, 5 s out` | 5/0/5/0 | 6 a minute, inside the tested band |
+| `4 s in, 6 s out` | 4/0/6/0 | 6 a minute, keeps the longer exhale |
+| `5 s in, 5 s out, 2 s pause` | 5/0/5/2 | "Sometimes called A52" in the caption |
+| `4 / 4 / 4 / 4` | box | caption must say 3.75 a minute |
+| `5 s in, 10 s out` | 5/0/10/0 | the shipped default; caption says it is below the tested band |
+
+### Phase 5: deferred, and the two engineers never agreed.
+
+Whether to add `custom.uiCaption` to the corpus (UX: yes, generated, under `--check`, with a
+banned-vocabulary gate) or ship no prose at all (full-stack: any prose authored for the binary
+inherits a two-week retraction latency through MAS review). **Ship 2-4 first and see whether anything
+feels missing.** If it does, the UX position is the one to implement, because hand-written Rust
+strings are ruled out by both.
+
+---
+
+## 5. Data pipeline, if phase 4 proceeds
+
+- Hand-written input at `rust/crates/exhale-core/presets.json`: id, label, nine numbers (four
+  durations, four jitters, drift), one citekey. **Nothing evidentiary.**
+- Generated, checked-in output `rust/crates/exhale-core/src/presets.rs`, emitted by
+  `scripts/generate-citations.py` as a third output beside `CITATIONS.md`, under the same `--check`
+  diff gate. Checked in rather than `OUT_DIR` so the exact shipped strings appear in a PR diff.
+- New `--check` rules: every `citekey` exists; is `group: timing` or `slow-breathing`; is not tier E;
+  is not blocklisted. Encode the blocklist as `custom.inAppCitable: false` in the corpus, so the
+  policy lives where the professor edits.
+- `core-check` already runs `cargo check -p exhale-core --all-targets` and `cargo test`, so a
+  generated `.rs` that does not compile fails CI. That job was added for exactly this reason.
+
+---
+
+## 6. Open decisions and loose ends
+
+- **`feat/provenance-and-drift-enhancements` has no PR.** Commit `60d567b`.
+- **The Snap listing is still live with the retracted claims.** `snapcraft.yaml` is fixed in the repo,
+  but the store shows the old copy until someone re-uploads. Memory says Snap upload is manual via
+  Docker `snapcore/snapcraft` + interactive `snapcraft login`.
+- **Mac App Store listing copy is nowhere in this repo.** Snap and Windows are now both tracked and
+  scanned; MAS is not, and may still be asserting the retracted claims. Nobody has looked.
+- **`MICROSOFT_STORE_HANDOFF.md` stays untracked** (session transcript, stale version pins). Its
+  field values now live in `rust/packaging/windows/store-listing.md`.
+- **Pre-existing test failure:** `platform::mac::tests::apply_app_visibility_roundtrip`, objc2 return
+  type mismatch at `mac.rs:1710`, fails on a clean tree. `core-check` does not cover `exhale-app`.
+- **Default cadence:** still 5/0/10/0 = 4.0 a minute, below the 4.5-6.5 resonance band. The professor
+  recommended 4/0/6/0 for new installs only (timing fields carry no `#[serde(default)]`, so this
+  touches fresh installs and Reset only, no cohort flag) then deprioritised it himself. Unresolved by
+  choice, and gap 2 documents it.
+- `drift` now defaults to 1.0 (off) with a 0.1 percentage-point step and no ceiling. See gaps ledger
+  item 6, which carries two corrections worth reading before touching it.

--- a/RESEARCH-SURFACE-HANDOFF.md
+++ b/RESEARCH-SURFACE-HANDOFF.md
@@ -259,8 +259,16 @@ Both keys, and Tab-reachability of all five chips in display order, are covered 
 silently undone (`Placer::set_max_width` unions the result back with `min_rect`, which for a panel is
 already the full panel), so the first version of the chip test laid out at 384 pt and would have
 passed while the shipped card is 308; go through `section` instead. And the Timing card is now
-**324 pt**, measured, up from 160 before phase 3, which is why `INITIAL_PREFERRED_H` stayed at 796
-and the fold moved up rather than the window growing to 960.
+**250 pt**, measured, up from 160 before phase 3, which is why `INITIAL_PREFERRED_H` stayed at 796
+and the fold moved up rather than the window growing.
+
+**On the vertical budget.** The first working version measured 324 pt and looked it: a heading line,
+three rows of chips and a caption line, five lines of chrome above four steppers. Three changes got
+it to 250 without dropping anything. The labels became the four-number form; the caption merged into
+the heading, which also stopped the card jumping as the selection changed; and `CHIP_PAD_X` and
+`CHIP_GAP` went to 7 and 5, which is the difference between 297 pt of chips and 331 in a 308 pt card.
+A test pins the result at no more than two rows, so a sixth preset makes that a deliberate decision
+rather than a silent regression.
 
 Original design notes follow.
 
@@ -289,13 +297,19 @@ Chips live **inside the existing Timing card** (`settings_window.rs:1355`), abov
 
 Candidate set, deliberately including one that ships its own disconfirming evidence:
 
-| Chip label | Pattern | Note |
+Shipped set. Labels are the four-number form, not the spelled-out one the design proposed: at 360 pt
+the spelled-out labels took three rows, and `5/0/5/0` reads in the same order as the four steppers
+directly beneath it.
+
+| Chip | Pattern | Note shown when selected |
 |---|---|---|
-| `5 s in, 5 s out` | 5/0/5/0 | 6 a minute, inside the tested band |
-| `4 s in, 6 s out` | 4/0/6/0 | 6 a minute, keeps the longer exhale |
-| `5 s in, 5 s out, 2 s pause` | 5/0/5/2 | "Sometimes called A52" in the caption |
-| `4 / 4 / 4 / 4` | box | caption must say 3.75 a minute |
-| `5 s in, 10 s out` | 5/0/10/0 | the shipped default; caption says it is below the tested band |
+| `5/0/5/0` | 5/0/5/0 | none needed |
+| `4/0/6/0` | 4/0/6/0 | none needed |
+| `5/0/5/2` | 5/0/5/2 | `· sometimes called A52.` |
+| `4/4/4/4` | box | `· sometimes called box breathing.` |
+| `5/0/10/0` | 5/0/10/0 | `· exhale's shipped default.` |
+
+The original design's rate captions are gone; see point 1 below.
 
 ### Phase 5: still deferred, and phase 4 strengthened the case.
 

--- a/docs/CITATIONS.csl.json
+++ b/docs/CITATIONS.csl.json
@@ -1014,7 +1014,7 @@
         "5.5 breaths per minute with an equal 5:5 inhale-to-exhale ratio produced higher SDNN and LF power than 6 bpm or than a 4:6 ratio",
         "all four slow-breathing patterns increased self-reported relaxation relative to spontaneous breathing"
       ],
-      "caveat": "n = 47, Latin-square counterbalanced. The clearest published result AGAINST a longer exhale on HRV grounds, and it is why exhale's README no longer asserts the 1:2 mechanism. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works."
+      "caveat": "n = 47, Latin-square counterbalanced. The clearest published result AGAINST a longer exhale on HRV grounds, and the reason exhale makes no mechanism claim for the 1:2 ratio. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works."
     }
   },
   {
@@ -1177,7 +1177,7 @@
         "at 6 breaths per minute, a 1:2 inhale-to-exhale ratio produced no HRV advantage over 1:1 in either an original experiment or its replication",
         "the finding held across time-domain, frequency-domain and nonlinear HRV metrics"
       ],
-      "caveat": "Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of four disagreeing studies; see also vandiest2014-ie-ratio-relaxation and lin2014-equal-ratio-hrv. Critically, all four measured HRV; none of them measured how participants felt except vandiest2014-ie-ratio-relaxation, which is why exhale's recommendation now rests on the subjective outcome rather than on this dispute."
+      "caveat": "Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of four disagreeing studies; see also vandiest2014-ie-ratio-relaxation and lin2014-equal-ratio-hrv. Critically, all four measured HRV; none measured how participants felt except vandiest2014-ie-ratio-relaxation, which is why exhale's recommendation rests on the subjective outcome rather than on this dispute."
     }
   },
   {
@@ -1415,7 +1415,7 @@
         "during computer data-entry work, end-tidal CO2 was significantly lower and respiration frequency significantly higher than during either baseline relaxation or progressive muscle relaxation",
         "breathing changes measurably at a screen, and end-tidal CO2 discriminates the state"
       ],
-      "caveat": "n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real screen work over real working days, not a lab proxy. This entry retracts an earlier claim in this repo that no peer-reviewed study had measured respiration during ordinary screen use. It had; this is it, from 1994."
+      "caveat": "n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real screen work over real working days, not a lab proxy. Along with schleifer2008-emg-gaps-computer-work it is the direct evidence that screen work changes respiration, and it dates from 1994, well before the topic reached breathwork writing."
     }
   },
   {

--- a/docs/CITATIONS.csl.json
+++ b/docs/CITATIONS.csl.json
@@ -165,6 +165,7 @@
       "verification": "crossref-verified",
       "accessLevel": "open-access",
       "evidenceTier": "A",
+      "inAppCitable": false,
       "backsClaims": [
         "five minutes a day of exhale-emphasising cyclic sighing improved mood and lowered respiratory rate more than an equal period of mindfulness meditation over one month",
         "box breathing, equal inhale / hold / exhale, was tested head-to-head and was not the best-performing arm"
@@ -345,6 +346,7 @@
       "verification": "crossref-verified",
       "accessLevel": "paywalled",
       "evidenceTier": "A",
+      "inAppCitable": false,
       "backsClaims": [
         "sustained slow breathing programmes lower systolic blood pressure by about 5.6 mmHg and diastolic by about 3.0 mmHg in hypertensive and prehypertensive adults"
       ],
@@ -434,6 +436,7 @@
       "verification": "crossref-verified",
       "accessLevel": "open-access",
       "evidenceTier": "A",
+      "inAppCitable": false,
       "backsClaims": [
         "breathwork lowers self-reported stress against control conditions, g = -0.35 (95% CI -0.55 to -0.14), 12 RCTs, 785 adults",
         "comparable small-to-medium effects for anxiety (g = -0.32, k = 20) and depressive symptoms (g = -0.40, k = 18)"
@@ -1080,6 +1083,7 @@
       "verification": "crossref-verified",
       "accessLevel": "open-access",
       "evidenceTier": "D",
+      "inAppCitable": false,
       "backsClaims": [
         "a 5 s inhale, 5 s exhale, 2 s post-exhale hold at five breaths per minute is a protocol a recent review argues is representative of the effective literature",
         "23 of 30 reviewed studies reported significant HRV improvement; 10 reported anxiety reduction and 9 reported reduced perceived stress",

--- a/docs/CITATIONS.csl.json
+++ b/docs/CITATIONS.csl.json
@@ -173,6 +173,140 @@
     }
   },
   {
+    "id": "bernardi2001-slow-breathing-chemoreflex",
+    "type": "article-journal",
+    "title": "Slow breathing reduces chemoreflex response to hypoxia and hypercapnia, and increases baroreflex sensitivity",
+    "author": [
+      {
+        "family": "Bernardi",
+        "given": "Luciano"
+      },
+      {
+        "family": "Gabutti",
+        "given": "Alessandra"
+      },
+      {
+        "family": "Porta",
+        "given": "Cesare"
+      },
+      {
+        "family": "Spicuzza",
+        "given": "Lucia"
+      }
+    ],
+    "container-title": "Journal of Hypertension",
+    "volume": "19",
+    "issue": "12",
+    "page": "2221-2229",
+    "issued": {
+      "date-parts": [
+        [
+          2001
+        ]
+      ]
+    },
+    "DOI": "10.1097/00004872-200112000-00016",
+    "URL": "https://doi.org/10.1097/00004872-200112000-00016",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "breathing at 6 per minute depressed both hypoxic and hypercapnic chemoreflex responses compared with spontaneous or 15 per minute breathing",
+        "baroreflex sensitivity was greater during slow breathing"
+      ],
+      "caveat": "n = 15 healthy individuals. Carried mainly to mark where the studied territory ENDS: this literature is conducted at roughly 3 to 6 breaths per minute, and 6 is the rate tested here. Below about 3 per minute there is essentially nothing to appeal to, which is what bounds exhale's `drift` ceiling. See also bilo2012-slow-breathing-altitude."
+    }
+  },
+  {
+    "id": "bilo2012-slow-breathing-altitude",
+    "type": "article-journal",
+    "title": "Effects of Slow Deep Breathing at High Altitude on Oxygen Saturation, Pulmonary and Systemic Hemodynamics",
+    "author": [
+      {
+        "family": "Bilo",
+        "given": "Grzegorz"
+      },
+      {
+        "family": "Revera",
+        "given": "Miriam"
+      },
+      {
+        "family": "Bussotti",
+        "given": "Maurizio"
+      },
+      {
+        "family": "Bonacina",
+        "given": "Daniele"
+      },
+      {
+        "family": "Styczkiewicz",
+        "given": "Katarzyna"
+      },
+      {
+        "family": "Caldara",
+        "given": "Gianluca"
+      },
+      {
+        "family": "Giglio",
+        "given": "Alessia"
+      },
+      {
+        "family": "Faini",
+        "given": "Andrea"
+      },
+      {
+        "family": "Giuliano",
+        "given": "Andrea"
+      },
+      {
+        "family": "Lombardi",
+        "given": "Carolina"
+      },
+      {
+        "family": "Kawecka-Jaszcz",
+        "given": "Kalina"
+      },
+      {
+        "family": "Mancia",
+        "given": "Giuseppe"
+      },
+      {
+        "family": "Agostoni",
+        "given": "Piergiuseppe"
+      },
+      {
+        "family": "Parati",
+        "given": "Gianfranco"
+      }
+    ],
+    "container-title": "PLoS ONE",
+    "volume": "7",
+    "issue": "11",
+    "page": "e49074",
+    "issued": {
+      "date-parts": [
+        [
+          2012
+        ]
+      ]
+    },
+    "DOI": "10.1371/journal.pone.0049074",
+    "URL": "https://doi.org/10.1371/journal.pone.0049074",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "fifteen minutes of paced breathing at 6 per minute raised arterial oxygen saturation and lowered systemic and pulmonary arterial pressure at high altitude",
+        "the proposed mechanism is a larger tidal volume reducing the proportion of each breath spent on anatomical dead space"
+      ],
+      "caveat": "Conducted at high altitude in a hypoxic state, so it does not transfer to a desk at sea level and must not be cited as if it did. It is carried for two narrow purposes: it is the second entry fixing the studied range at roughly 3 to 6 breaths per minute, and its dead-space mechanism is the reason slow breathing is not simply less breathing."
+    }
+  },
+  {
     "id": "chaddha2019-slow-breathing-bp",
     "type": "article-journal",
     "title": "Device and non-device-guided slow breathing to reduce blood pressure: A systematic review and meta-analysis",
@@ -445,6 +579,49 @@
         "scheduled 20-second breaks every 5, 10 or 20 minutes produced no significant effect on ocular symptoms, reading speed or task accuracy"
       ],
       "caveat": "n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge is not self-evidently effective just because it is popular and plausible."
+    }
+  },
+  {
+    "id": "joshi1992-pranayam-training",
+    "type": "article-journal",
+    "title": "Effect of short term 'Pranayam' practice on breathing rate and ventilatory functions of lung",
+    "author": [
+      {
+        "family": "Joshi",
+        "given": "L. N."
+      },
+      {
+        "family": "Joshi",
+        "given": "V. D."
+      },
+      {
+        "family": "Gokhale",
+        "given": "L. V."
+      }
+    ],
+    "container-title": "Indian Journal of Physiology and Pharmacology",
+    "volume": "36",
+    "issue": "2",
+    "page": "105-108",
+    "issued": {
+      "date-parts": [
+        [
+          1992
+        ]
+      ]
+    },
+    "PMID": "1506070",
+    "URL": "https://pubmed.ncbi.nlm.nih.gov/1506070/",
+    "custom": {
+      "group": "tradition",
+      "verification": "pubmed-verified",
+      "accessLevel": "paywalled",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "six weeks of pranayama practice in 75 young adults lowered resting respiratory rate and prolonged breath-holding time",
+        "the same training raised forced vital capacity, FEV1, maximum voluntary ventilation and peak expiratory flow rate"
+      ],
+      "caveat": "NUMBERS NOT READ 2026-08-30; no DOI exists, and the record was verified against the NCBI eutils API by PMID rather than Crossref. Uncontrolled before-and-after design in a 1992 regional journal, so treat the effect sizes as unusable. It is carried because it is the only entry in this corpus that speaks to pranayama's GRADED EXTENSION as a training progression: capacity grew over six weeks of practice. That is a claim about adaptation across sessions, and it is NOT evidence for extending the breath without limit inside a single sitting, which is a different proposition that shaffer2020-resonance-frequency-assessment argues against."
     }
   },
   {
@@ -1374,6 +1551,45 @@
     }
   },
   {
+    "id": "shaffer2020-resonance-frequency-assessment",
+    "type": "article-journal",
+    "title": "A Practical Guide to Resonance Frequency Assessment for Heart Rate Variability Biofeedback",
+    "author": [
+      {
+        "family": "Shaffer",
+        "given": "Fred"
+      },
+      {
+        "family": "Meehan",
+        "given": "Zachary M."
+      }
+    ],
+    "container-title": "Frontiers in Neuroscience",
+    "volume": "14",
+    "page": "570400",
+    "issued": {
+      "date-parts": [
+        [
+          2020
+        ]
+      ]
+    },
+    "DOI": "10.3389/fnins.2020.570400",
+    "URL": "https://doi.org/10.3389/fnins.2020.570400",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "D",
+      "backsClaims": [
+        "the relationship between breathing rate and heart-rate-variability amplitude is an inverted U with a peak, not a slope",
+        "resonance frequency ranges from 4.5 to 6.5 breaths per minute in adults, and 6.5 to 9.5 in children",
+        "breathing in a narrow band around the resonance frequency stimulates the baroreflex better than breathing across a wider range"
+      ],
+      "caveat": "Methods guide rather than an experiment, hence tier D. It is nonetheless the entry that decides exhale's `drift` question: if the curve peaks, then breathing progressively slower moves AWAY from the optimum once past it, and 'slower is always better' is false. Shaffer is also an author of meehan2024-longer-exhalations, so this corpus leans on one group twice; that is worth knowing, though the inverted-U is not a contested finding."
+    }
+  },
+  {
     "id": "sheppard2018-digital-eye-strain",
     "type": "article-journal",
     "title": "Digital eye strain: prevalence, measurement and amelioration",
@@ -1410,6 +1626,77 @@
         "reduced blink rate and incomplete blinks during screen work are among its established contributors"
       ],
       "caveat": "Crossref carries no license field for this record; access level is taken from BMJ Open Ophthalmology being a fully open-access title."
+    }
+  },
+  {
+    "id": "szulczewski2019-antihyperventilation-instruction",
+    "type": "article-journal",
+    "title": "An Anti-hyperventilation Instruction Decreases the Drop in End-tidal CO2 and Symptoms of Hyperventilation During Breathing at 0.1 Hz",
+    "author": [
+      {
+        "family": "Szulczewski",
+        "given": "Mikołaj Tytus"
+      }
+    ],
+    "container-title": "Applied Psychophysiology and Biofeedback",
+    "volume": "44",
+    "issue": "3",
+    "page": "247-256",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "DOI": "10.1007/s10484-019-09438-y",
+    "URL": "https://doi.org/10.1007/s10484-019-09438-y",
+    "custom": {
+      "group": "safety",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "B",
+      "backsClaims": [
+        "one sentence of instruction cut the end-tidal CO2 drop during 6-per-minute paced breathing from 5.21 to 2.7 mmHg",
+        "hyperventilation symptoms rose 0.63 points on a 7-point scale without the instruction and did not rise significantly with it",
+        "the instruction used was to avoid excessively deep breathing and to breathe shallowly and naturally"
+      ],
+      "caveat": "Randomised, two groups, n = 46 aged 19-26. This is the mitigation for gap 5 and it is unusually cheap: the problem with slow pacing is DEPTH, not rate, and a single sentence fixes most of it. exhale paces rate and says nothing about depth, so this is the one piece of prose in the whole corpus that would earn its place in the app on safety grounds rather than persuasion grounds."
+    }
+  },
+  {
+    "id": "szulczewski2019-training-relaxation",
+    "type": "article-journal",
+    "title": "Training of paced breathing at 0.1 Hz improves CO2 homeostasis and relaxation during a paced breathing task",
+    "author": [
+      {
+        "family": "Szulczewski",
+        "given": "Mikołaj Tytus"
+      }
+    ],
+    "container-title": "PLOS ONE",
+    "volume": "14",
+    "issue": "6",
+    "page": "e0218550",
+    "issued": {
+      "date-parts": [
+        [
+          2019
+        ]
+      ]
+    },
+    "DOI": "10.1371/journal.pone.0218550",
+    "URL": "https://doi.org/10.1371/journal.pone.0218550",
+    "custom": {
+      "group": "timing",
+      "verification": "crossref-verified",
+      "accessLevel": "open-access",
+      "evidenceTier": "C",
+      "backsClaims": [
+        "across seven consecutive days of ten-minute paced breathing, self-reported task pleasantness rose significantly and unpleasant arousal fell, with the affective gains emerging by mid-training rather than on day one",
+        "the end-tidal CO2 drop caused by paced breathing shrank with practice: 37.5% of participants dropped below 30 mmHg on day one against 6.3% on day seven"
+      ],
+      "caveat": "n = 16, single group, no control, one week. Small and uncontrolled, so treat the magnitudes as indicative. It is carried because it is the closest thing in this corpus to evidence for the pranayama proposition that the practice improves with practice: relaxation was not immediate, it accrued. Note carefully what it does NOT show. Training was at a FIXED 0.1 Hz throughout; it is evidence that repeated practice at one rate gets better, not that progressively slowing within a session helps. That second proposition remains untested. See also joshi1992-pranayam-training."
     }
   },
   {

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -717,6 +717,16 @@ The shipped default has deliberately **not** been changed. Silently moving the p
 already have exhale installed is worse than documenting where the number came from. Changing it is a
 decision to make on purpose, in a release note, not as a side effect of writing this file.
 
+**What shipped instead: the app says it out loud.** The Timing card in the settings window now
+computes the current rate from the four duration fields and prints it next to the range above, so
+the default discloses its own coverage on first open rather than only here. It renders unprompted,
+not behind a hover or a disclosure triangle, for a specific reason: a disclosure reaches the people
+who go looking, and the default is imposed on everyone who never opens the panel at all. The copy
+lives in [`rust/crates/exhale-core/src/pacing.rs`](../rust/crates/exhale-core/src/pacing.rs) with a
+test per line, including one asserting that no line names an effect, a benefit or a condition. The
+binary states arithmetic and one range; everything evidentiary stays in this document, which can be
+corrected in an afternoon rather than in a store-review cycle.
+
 ### 3. Box breathing is not the beginner-friendly default it looks like
 
 A natural thought is that `4` / `4` / `4` / `4` box breathing would be a gentler default than the
@@ -839,11 +849,14 @@ what they actually practise. The ceiling was paternalism wearing a citation.
 address the real problem, which was never that slow breathing is bad but that the *control was too
 coarse to ask for anything gentle*:
 
-1. **The stepper step is now 0.01 percentage points, was 1.0.** Compounding makes whole percents
+1. **The stepper step is now 0.1 percentage points, was 1.0.** Compounding makes whole percents
    enormous. From a 15 s cycle, 1 % doubles the breath in 70 cycles (~25 min); 0.1 % takes 693 cycles
    (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
    drift a user could previously select was one that ran away inside a single sitting. Display is
-   capped at three decimals, so 0.001 % is the finest value the field round-trips.
+   capped at three decimals, so 0.001 % is the finest value the field round-trips, and anything
+   below the step is typed rather than clicked. The settings window now reports the doubling time
+   directly whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen
+   something gentle or something that runs away before lunch.
 2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
    is harmful: on by default it moved every new user out of the region anyone has measured, within
    minutes, without asking. It is one field away for anyone who wants it.

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -1,6 +1,6 @@
 # Citation corpus
 
-42 sources: 40 Crossref-verified, 2 verified against Open Library. 5 are cited from their abstract only and say so, and 2 are not peer-reviewed and are tiered E so they can back lineage but never a claim.
+48 sources: 45 Crossref-verified, 2 verified against Open Library. 6 are cited from their abstract only and say so, and 2 are not peer-reviewed and are tiered E so they can back lineage but never a claim.
 
 Machine-readable companion: [`CITATIONS.csl.json`](./CITATIONS.csl.json) (CSL-JSON).
 Verification pass completed 2026-08-28 against the Crossref REST API.
@@ -57,25 +57,26 @@ establish that it does.
 
 | Verification | n |
 |---|---|
-| crossref-verified | 40 |
+| crossref-verified | 45 |
 | openlibrary-verified | 2 |
-| **total** | **42** |
+| pubmed-verified | 1 |
+| **total** | **48** |
 
 | Access level | n |
 |---|---|
-| open-access | 17 |
-| paywalled | 25 |
-| **total** | **42** |
+| open-access | 21 |
+| paywalled | 27 |
+| **total** | **48** |
 
 | Evidence tier | n |
 |---|---|
 | A | 7 |
-| B | 7 |
-| C | 16 |
-| D | 9 |
+| B | 8 |
+| C | 20 |
+| D | 10 |
 | E | 2 |
 | null (not a study) | 1 |
-| **total** | **42** |
+| **total** | **48** |
 
 ---
 
@@ -162,7 +163,7 @@ Schleifer, Lawrence M.; Ley, Ronald. (1994). *End-tidal PCO2 as an index of psyc
 
 #### `schleifer2002-hyperventilation-job-stress`
 
-Schleifer, Lawrence M.; Ley, Ronald; Spalding, Thomas W.. (2002). *A hyperventilation theory of job stress and musculoskeletal disorders*. American Journal of Industrial Medicine 41(5): 420-432
+Schleifer, Lawrence M.; Ley, Ronald; Spalding, Thomas W. (2002). *A hyperventilation theory of job stress and musculoskeletal disorders*. American Journal of Industrial Medicine 41(5): 420-432
 
 - DOI: [10.1002/ajim.10061](https://doi.org/10.1002/ajim.10061)
 - Verification: crossref-verified | Access: paywalled | evidence tier **D**
@@ -174,7 +175,7 @@ Schleifer, Lawrence M.; Ley, Ronald; Spalding, Thomas W.. (2002). *A hyperventil
 
 #### `schleifer2008-emg-gaps-computer-work`
 
-Schleifer, Lawrence M.; Spalding, Thomas W.; Kerick, Scott E.; Cram, Jeffrey R.; Ley, Ronald; Hatfield, Bradley D.. (2008). *Mental stress and trapezius muscle activation under psychomotor challenge: A focus on EMG gaps during computer work*. Psychophysiology 45(3): 356-365
+Schleifer, Lawrence M.; Spalding, Thomas W.; Kerick, Scott E.; Cram, Jeffrey R.; Ley, Ronald; Hatfield, Bradley D. (2008). *Mental stress and trapezius muscle activation under psychomotor challenge: A focus on EMG gaps during computer work*. Psychophysiology 45(3): 356-365
 
 - DOI: [10.1111/j.1469-8986.2008.00645.x](https://doi.org/10.1111/j.1469-8986.2008.00645.x)
 - Verification: crossref-verified | Access: paywalled | evidence tier **C**
@@ -185,7 +186,7 @@ Schleifer, Lawrence M.; Spalding, Thomas W.; Kerick, Scott E.; Cram, Jeffrey R.;
 
 #### `sheppard2018-digital-eye-strain`
 
-Sheppard, Amy L.; Wolffsohn, James S.. (2018). *Digital eye strain: prevalence, measurement and amelioration*. BMJ Open Ophthalmology 3(1): e000146
+Sheppard, Amy L.; Wolffsohn, James S. (2018). *Digital eye strain: prevalence, measurement and amelioration*. BMJ Open Ophthalmology 3(1): e000146
 
 - DOI: [10.1136/bmjophth-2018-000146](https://doi.org/10.1136/bmjophth-2018-000146)
 - Verification: crossref-verified | Access: open-access | evidence tier **B**
@@ -212,7 +213,7 @@ Tsubota, Kazuo; Nakamori, Katsu. (1993). *Dry Eyes and Video Display Terminals*.
 
 #### `chaddha2019-slow-breathing-bp`
 
-Chaddha, Ashish; Modaff, Daniel; Hooper-Lane, Christopher; Feldstein, David A.. (2019). *Device and non-device-guided slow breathing to reduce blood pressure: A systematic review and meta-analysis*. Complementary Therapies in Medicine 45: 179-184
+Chaddha, Ashish; Modaff, Daniel; Hooper-Lane, Christopher; Feldstein, David A. (2019). *Device and non-device-guided slow breathing to reduce blood pressure: A systematic review and meta-analysis*. Complementary Therapies in Medicine 45: 179-184
 
 - DOI: [10.1016/j.ctim.2019.03.005](https://doi.org/10.1016/j.ctim.2019.03.005)
 - Verification: crossref-verified | Access: paywalled | evidence tier **A**
@@ -233,7 +234,7 @@ Fincham, Guy William; Strauss, Clara; Montero-Marin, Jesus; Cavanagh, Kate. (202
 
 #### `laborde2022-vsb-meta`
 
-Laborde, S.; Allen, M. S.; Borges, U.; Dosseville, F.; Hosang, T. J.; Iskra, M.; Mosley, E.; Salvotti, C.; Spolverato, L.; Zammit, N.; Javelle, F.. (2022). *Effects of voluntary slow breathing on heart rate and heart rate variability: A systematic review and a meta-analysis*. Neuroscience & Biobehavioral Reviews 138: 104711
+Laborde, S.; Allen, M. S.; Borges, U.; Dosseville, F.; Hosang, T. J.; Iskra, M.; Mosley, E.; Salvotti, C.; Spolverato, L.; Zammit, N.; Javelle, F. (2022). *Effects of voluntary slow breathing on heart rate and heart rate variability: A systematic review and a meta-analysis*. Neuroscience & Biobehavioral Reviews 138: 104711
 
 - DOI: [10.1016/j.neubiorev.2022.104711](https://doi.org/10.1016/j.neubiorev.2022.104711)
 - Verification: crossref-verified | Access: paywalled | evidence tier **A**
@@ -244,7 +245,7 @@ Laborde, S.; Allen, M. S.; Borges, U.; Dosseville, F.; Hosang, T. J.; Iskra, M.;
 
 #### `little2025-a52-breath-method`
 
-Little, Abbie L.. (2025). *The A52 Breath Method: A Narrative Review of Breathwork for Mental Health and Stress Resilience*. Stress and Health 41(4): e70098
+Little, Abbie L. (2025). *The A52 Breath Method: A Narrative Review of Breathwork for Mental Health and Stress Resilience*. Stress and Health 41(4): e70098
 
 - DOI: [10.1002/smi.70098](https://doi.org/10.1002/smi.70098)
 - Verification: crossref-verified | Access: open-access | evidence tier **D**
@@ -266,7 +267,7 @@ Russo, Marc A.; Santarelli, Danielle M.; O'Rourke, Dean. (2017). *The physiologi
 
 #### `vandijk2018-close-the-book`
 
-van Dijk, Peter R.; van Hateren, Kornelis J. J.; Kleefstra, Nanne; Landman, Gijs W. D.. (2018). *It is time to close the book on device-guided slow breathing*. Blood Pressure 27(3): 181-182
+van Dijk, Peter R.; van Hateren, Kornelis J. J.; Kleefstra, Nanne; Landman, Gijs W. D. (2018). *It is time to close the book on device-guided slow breathing*. Blood Pressure 27(3): 181-182
 
 - DOI: [10.1080/08037051.2018.1435260](https://doi.org/10.1080/08037051.2018.1435260)
 - Verification: crossref-verified | Access: paywalled | no evidence tier (not a study)
@@ -289,7 +290,7 @@ Zaccaro, Andrea; Piarulli, Andrea; Laurino, Marco; Garbella, Erika; Menicucci, D
 
 ## What the numbers should be
 
-10 sources.
+14 sources.
 
 #### `bae2021-exhalation-inhalation-ratio`
 
@@ -304,7 +305,7 @@ Bae, Dalbyeol; Matthews, Jacob J. L.; Chen, J. Jean; Mah, Linda. (2021). *Increa
 
 #### `balban2023-cyclic-sighing`
 
-Balban, Melis Yilmaz; Neri, Eric; Kogon, Manuela M.; Weed, Lara; Nouriani, Bita; Jo, Booil; Holl, Gary; Zeitzer, Jamie M.; Spiegel, David; Huberman, Andrew D.. (2023). *Brief structured respiration practices enhance mood and reduce physiological arousal*. Cell Reports Medicine 4(1): 100895
+Balban, Melis Yilmaz; Neri, Eric; Kogon, Manuela M.; Weed, Lara; Nouriani, Bita; Jo, Booil; Holl, Gary; Zeitzer, Jamie M.; Spiegel, David; Huberman, Andrew D. (2023). *Brief structured respiration practices enhance mood and reduce physiological arousal*. Cell Reports Medicine 4(1): 100895
 
 - DOI: [10.1016/j.xcrm.2022.100895](https://doi.org/10.1016/j.xcrm.2022.100895)
 - Verification: crossref-verified | Access: open-access | evidence tier **A**
@@ -312,6 +313,28 @@ Balban, Melis Yilmaz; Neri, Eric; Kogon, Manuela M.; Weed, Lara; Nouriani, Bita;
   - five minutes a day of exhale-emphasising cyclic sighing improved mood and lowered respiratory rate more than an equal period of mindfulness meditation over one month
   - box breathing, equal inhale / hold / exhale, was tested head-to-head and was not the best-performing arm
 - Caveat: Remote randomised controlled study, pre-registered as NCT05304000. The primary comparator is mindfulness meditation, not a sham, so the arms differ in more than breath ratio. The mood difference reached p < 0.05 in a mixed-effects model; this is a real but modest separation. Directly relevant to exhale twice over: it is the best evidence that a longer exhale is the right emphasis, and it is the reason the README should stop presenting box breathing as equivalent.
+
+#### `bernardi2001-slow-breathing-chemoreflex`
+
+Bernardi, Luciano; Gabutti, Alessandra; Porta, Cesare; Spicuzza, Lucia. (2001). *Slow breathing reduces chemoreflex response to hypoxia and hypercapnia, and increases baroreflex sensitivity*. Journal of Hypertension 19(12): 2221-2229
+
+- DOI: [10.1097/00004872-200112000-00016](https://doi.org/10.1097/00004872-200112000-00016)
+- Verification: crossref-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - breathing at 6 per minute depressed both hypoxic and hypercapnic chemoreflex responses compared with spontaneous or 15 per minute breathing
+  - baroreflex sensitivity was greater during slow breathing
+- Caveat: n = 15 healthy individuals. Carried mainly to mark where the studied territory ENDS: this literature is conducted at roughly 3 to 6 breaths per minute, and 6 is the rate tested here. Below about 3 per minute there is essentially nothing to appeal to, which is what bounds exhale's `drift` ceiling. See also bilo2012-slow-breathing-altitude.
+
+#### `bilo2012-slow-breathing-altitude`
+
+Bilo, Grzegorz; Revera, Miriam; Bussotti, Maurizio; Bonacina, Daniele; Styczkiewicz, Katarzyna; Caldara, Gianluca; Giglio, Alessia; Faini, Andrea; Giuliano, Andrea; Lombardi, Carolina; Kawecka-Jaszcz, Kalina; Mancia, Giuseppe; Agostoni, Piergiuseppe; Parati, Gianfranco. (2012). *Effects of Slow Deep Breathing at High Altitude on Oxygen Saturation, Pulmonary and Systemic Hemodynamics*. PLoS ONE 7(11): e49074
+
+- DOI: [10.1371/journal.pone.0049074](https://doi.org/10.1371/journal.pone.0049074)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - fifteen minutes of paced breathing at 6 per minute raised arterial oxygen saturation and lowered systemic and pulmonary arterial pressure at high altitude
+  - the proposed mechanism is a larger tidal volume reducing the proportion of each breath spent on anatomical dead space
+- Caveat: Conducted at high altitude in a hypoxic state, so it does not transfer to a desk at sea level and must not be cited as if it did. It is carried for two narrow purposes: it is the second entry fixing the studied range at roughly 3 to 6 breaths per minute, and its dead-space mechanism is the reason slow breathing is not simply less breathing.
 
 #### `laborde2021-ie-ratio-pauses`
 
@@ -336,7 +359,7 @@ Laborde, Sylvain; Allen, Mark S.; Borges, Uirassu; Iskra, Maša; Zammit, Nina; Y
 
 #### `lin2014-equal-ratio-hrv`
 
-Lin, I. M.; Tai, L. Y.; Fan, S. Y.. (2014). *Breathing at a rate of 5.5 breaths per minute with equal inhalation-to-exhalation ratio increases heart rate variability*. International Journal of Psychophysiology 91(3): 206-211
+Lin, I. M.; Tai, L. Y.; Fan, S. Y. (2014). *Breathing at a rate of 5.5 breaths per minute with equal inhalation-to-exhalation ratio increases heart rate variability*. International Journal of Psychophysiology 91(3): 206-211
 
 - DOI: [10.1016/j.ijpsycho.2013.12.006](https://doi.org/10.1016/j.ijpsycho.2013.12.006)
 - Verification: crossref-verified | Access: paywalled | evidence tier **C**
@@ -379,6 +402,29 @@ Sevoz-Couche, Caroline; Laborde, Sylvain. (2022). *Heart rate variability and sl
   - coherence and resonance are distinct phenomena that are frequently conflated in the slow-breathing literature
 - Caveat: Narrative review. Carried as a terminology guard: much of the popular writing exhale competes with uses 'coherence' loosely, and this is the paper to check before adopting that vocabulary in the app or the README.
 
+#### `shaffer2020-resonance-frequency-assessment`
+
+Shaffer, Fred; Meehan, Zachary M. (2020). *A Practical Guide to Resonance Frequency Assessment for Heart Rate Variability Biofeedback*. Frontiers in Neuroscience 14: 570400
+
+- DOI: [10.3389/fnins.2020.570400](https://doi.org/10.3389/fnins.2020.570400)
+- Verification: crossref-verified | Access: open-access | evidence tier **D**
+- Backs:
+  - the relationship between breathing rate and heart-rate-variability amplitude is an inverted U with a peak, not a slope
+  - resonance frequency ranges from 4.5 to 6.5 breaths per minute in adults, and 6.5 to 9.5 in children
+  - breathing in a narrow band around the resonance frequency stimulates the baroreflex better than breathing across a wider range
+- Caveat: Methods guide rather than an experiment, hence tier D. It is nonetheless the entry that decides exhale's `drift` question: if the curve peaks, then breathing progressively slower moves AWAY from the optimum once past it, and 'slower is always better' is false. Shaffer is also an author of meehan2024-longer-exhalations, so this corpus leans on one group twice; that is worth knowing, though the inverted-U is not a contested finding.
+
+#### `szulczewski2019-training-relaxation`
+
+Szulczewski, Mikołaj Tytus. (2019). *Training of paced breathing at 0.1 Hz improves CO2 homeostasis and relaxation during a paced breathing task*. PLOS ONE 14(6): e0218550
+
+- DOI: [10.1371/journal.pone.0218550](https://doi.org/10.1371/journal.pone.0218550)
+- Verification: crossref-verified | Access: open-access | evidence tier **C**
+- Backs:
+  - across seven consecutive days of ten-minute paced breathing, self-reported task pleasantness rose significantly and unpleasant arousal fell, with the affective gains emerging by mid-training rather than on day one
+  - the end-tidal CO2 drop caused by paced breathing shrank with practice: 37.5% of participants dropped below 30 mmHg on day one against 6.3% on day seven
+- Caveat: n = 16, single group, no control, one week. Small and uncontrolled, so treat the magnitudes as indicative. It is carried because it is the closest thing in this corpus to evidence for the pranayama proposition that the practice improves with practice: relaxation was not immediate, it accrued. Note carefully what it does NOT show. Training was at a FIXED 0.1 Hz throughout; it is evidence that repeated practice at one rate gets better, not that progressively slowing within a session helps. That second proposition remains untested. See also joshi1992-pranayam-training.
+
 #### `vandiest2014-ie-ratio-relaxation`
 
 Van Diest, Ilse; Verstappen, Karen; Aubert, André E.; Widjaja, Devy; Vansteenwegen, Debora; Vlemincx, Elke. (2014). *Inhalation/Exhalation Ratio Modulates the Effect of Slow Breathing on Heart Rate Variability and Relaxation*. Applied Psychophysiology and Biofeedback 39(3-4): 171-180
@@ -407,7 +453,18 @@ You, Min; Laborde, Sylvain; Ackermann, Stefan; Borges, Uirassu; Dosseville, Fabr
 
 ## Where the practice came from
 
-2 sources.
+3 sources.
+
+#### `joshi1992-pranayam-training`
+
+Joshi, L. N.; Joshi, V. D.; Gokhale, L. V. (1992). *Effect of short term 'Pranayam' practice on breathing rate and ventilatory functions of lung*. Indian Journal of Physiology and Pharmacology 36(2): 105-108
+
+- PMID: [1506070](https://pubmed.ncbi.nlm.nih.gov/1506070/) (no DOI exists)
+- Verification: pubmed-verified | Access: paywalled | evidence tier **C**
+- Backs:
+  - six weeks of pranayama practice in 75 young adults lowered resting respiratory rate and prolonged breath-holding time
+  - the same training raised forced vital capacity, FEV1, maximum voluntary ventilation and peak expiratory flow rate
+- Caveat: NUMBERS NOT READ 2026-08-30; no DOI exists, and the record was verified against the NCBI eutils API by PMID rather than Crossref. Uncontrolled before-and-after design in a 1992 regional journal, so treat the effect sizes as unusable. It is carried because it is the only entry in this corpus that speaks to pranayama's GRADED EXTENSION as a training progression: capacity grew over six weeks of practice. That is a claim about adaptation across sessions, and it is NOT evidence for extending the breath without limit inside a single sitting, which is a different proposition that shaffer2020-resonance-frequency-assessment argues against.
 
 #### `muktibodhananda1998-hatha-yoga-pradipika`
 
@@ -448,7 +505,7 @@ Moraveji, Neema; Olson, Ben; Nguyen, Truc; Saadat, Mahmoud; Khalighi, Yaser; Pea
 
 #### `tabor2022-guided-breathing-design`
 
-Tabor, Aaron; Bateman, Scott; Scheme, Erik J.; schraefel, m.c.. (2022). *Comparing heart rate variability biofeedback and simple paced breathing to inform the design of guided breathing technologies*. Frontiers in Computer Science 4: 926649
+Tabor, Aaron; Bateman, Scott; Scheme, Erik J.; schraefel, m.c. (2022). *Comparing heart rate variability biofeedback and simple paced breathing to inform the design of guided breathing technologies*. Frontiers in Computer Science 4: 926649
 
 - DOI: [10.3389/fcomp.2022.926649](https://doi.org/10.3389/fcomp.2022.926649)
 - Verification: crossref-verified | Access: open-access | evidence tier **C**
@@ -489,7 +546,7 @@ Lehrer, Paul M.; Gevirtz, Richard. (2014). *Heart rate variability biofeedback: 
 
 #### `li2016-sigh-circuit`
 
-Li, Peng; Janczewski, Wiktor A.; Yackle, Kevin; Kam, Kaiwen; Pagliardini, Silvia; Krasnow, Mark A.; Feldman, Jack L.. (2016). *The peptidergic control circuit for sighing*. Nature 530(7590): 293-297
+Li, Peng; Janczewski, Wiktor A.; Yackle, Kevin; Kam, Kaiwen; Pagliardini, Silvia; Krasnow, Mark A.; Feldman, Jack L. (2016). *The peptidergic control circuit for sighing*. Nature 530(7590): 293-297
 
 - DOI: [10.1038/nature16964](https://doi.org/10.1038/nature16964)
 - Verification: crossref-verified | Access: paywalled | evidence tier **D**
@@ -520,7 +577,7 @@ Vlemincx, Elke; Van Diest, Ilse; Van den Bergh, Omer. (2016). *A sigh of relief 
 
 #### `yackle2017-breathing-arousal-neurons`
 
-Yackle, Kevin; Schwarz, Lindsay A.; Kam, Kaiwen; Sorokin, Jordan M.; Huguenard, John R.; Feldman, Jack L.; Luo, Liqun; Krasnow, Mark A.. (2017). *Breathing control center neurons that promote arousal in mice*. Science 355(6332): 1411-1415
+Yackle, Kevin; Schwarz, Lindsay A.; Kam, Kaiwen; Sorokin, Jordan M.; Huguenard, John R.; Feldman, Jack L.; Luo, Liqun; Krasnow, Mark A. (2017). *Breathing control center neurons that promote arousal in mice*. Science 355(6332): 1411-1415
 
 - DOI: [10.1126/science.aai7984](https://doi.org/10.1126/science.aai7984)
 - Verification: crossref-verified | Access: paywalled | evidence tier **D**
@@ -541,7 +598,7 @@ Yasuma, Fumihiko; Hayano, Jun-ichiro. (2004). *Respiratory Sinus Arrhythmia: Why
 
 #### `zelano2016-nasal-respiration-limbic`
 
-Zelano, Christina; Jiang, Heidi; Zhou, Guangyu; Arora, Nikita; Schuele, Stephan; Rosenow, Joshua; Gottfried, Jay A.. (2016). *Nasal Respiration Entrains Human Limbic Oscillations and Modulates Cognitive Function*. The Journal of Neuroscience 36(49): 12448-12467
+Zelano, Christina; Jiang, Heidi; Zhou, Guangyu; Arora, Nikita; Schuele, Stephan; Rosenow, Joshua; Gottfried, Jay A. (2016). *Nasal Respiration Entrains Human Limbic Oscillations and Modulates Cognitive Function*. The Journal of Neuroscience 36(49): 12448-12467
 
 - DOI: [10.1523/JNEUROSCI.2586-16.2016](https://doi.org/10.1523/JNEUROSCI.2586-16.2016)
 - Verification: crossref-verified | Access: open-access | evidence tier **C**
@@ -553,7 +610,7 @@ Zelano, Christina; Jiang, Heidi; Zhou, Guangyu; Arora, Nikita; Schuele, Stephan;
 
 ## Limits, harms and adherence
 
-2 sources.
+3 sources.
 
 #### `fincham2024-high-ventilation-rct`
 
@@ -574,6 +631,18 @@ Linardon, Jake; Fuller-Tyszkiewicz, Matthew. (2020). *Attrition and adherence in
 - Backs:
   - dropout and non-adherence are the dominant practical failure mode of smartphone-delivered mental health interventions, even where efficacy trials are positive
 - Caveat: NUMBERS NOT READ 2026-08-28. Carried as the reality check on every other entry in this corpus: an effect measured in a supervised session says little about a tool someone installs and forgets. exhale has no telemetry and therefore no idea whether anyone keeps it running, which is stated plainly in the gaps ledger rather than hidden.
+
+#### `szulczewski2019-antihyperventilation-instruction`
+
+Szulczewski, Mikołaj Tytus. (2019). *An Anti-hyperventilation Instruction Decreases the Drop in End-tidal CO2 and Symptoms of Hyperventilation During Breathing at 0.1 Hz*. Applied Psychophysiology and Biofeedback 44(3): 247-256
+
+- DOI: [10.1007/s10484-019-09438-y](https://doi.org/10.1007/s10484-019-09438-y)
+- Verification: crossref-verified | Access: open-access | evidence tier **B**
+- Backs:
+  - one sentence of instruction cut the end-tidal CO2 drop during 6-per-minute paced breathing from 5.21 to 2.7 mmHg
+  - hyperventilation symptoms rose 0.63 points on a 7-point scale without the instruction and did not rise significantly with it
+  - the instruction used was to avoid excessively deep breathing and to breathe shallowly and naturally
+- Caveat: Randomised, two groups, n = 46 aged 19-26. This is the mitigation for gap 5 and it is unusually cheap: the problem with slow pacing is DEPTH, not rate, and a single sentence fixes most of it. exhale paces rate and says nothing about depth, so this is the one piece of prose in the whole corpus that would earn its place in the app on safety grounds rather than persuasion grounds.
 
 ---
 
@@ -729,12 +798,60 @@ mild and was measured in a single session. It is recorded because it is the most
 unanswered question this corpus turned up, and because an app that paces breathing should know that
 pacing rate is not the same as pacing volume.
 
-### 6. `drift` has no literature behind it at all
+### 6. `drift`: the tradition is uncontradicted, and the app should not pretend otherwise
 
-exhale defaults `drift` to `1.01`, making each cycle 1% longer than the last. Over 30 cycles that is
-a 1.35x stretch, taking a 4.0 breaths/min pace down to roughly 3.0 and further outside any tested
-range. No study in this corpus examines a progressively lengthening pace. It is an invented feature.
-It may be a pleasant one. It is not evidence-based, and the default is not zero.
+**Two corrections in this entry, 2026-08-31.** Both were caught by the maintainer pushing back, and
+both are the same mistake in different clothes: treating the edge of the research literature as if it
+were the edge of legitimate practice.
+
+**Correction 1 (the overclaim).** An earlier revision said the inverted-U relationship between
+breathing rate and HRV meant progressively slower breathing "moves away from the optimum."
+[`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment)
+describes a peak in **HRV amplitude**, not in relaxation, comfort or benefit. Sliding from one to the
+other is exactly what this corpus's tier-D rule forbids, and it was done here to justify a code
+change that had already been decided on.
+
+**Correction 2 (the cap).** On the strength of that overclaim, a ceiling was added capping `drift` at
+three breaths a minute. It has been **removed**. The argument against it is simple and correct: a
+10-second inhale with a 20-second exhale is unremarkable in pranayama, absence of research is not
+evidence of harm, and an app has no business preventing an advanced practitioner from configuring
+what they actually practise. The ceiling was paternalism wearing a citation.
+
+**What actually counters the tradition on elongating the breath: nothing found in this review.**
+
+- No study located here tests subjective relaxation below about 5 breaths a minute. The literature
+  stops; it does not turn around.
+- The subjective evidence that exists **supports** the tradition.
+  [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
+  produced more relaxation, stress reduction and positive energy;
+  [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found every slow pattern beat baseline on
+  relaxation; [`szulczewski2019-training-relaxation`](#szulczewski2019-training-relaxation) found
+  relaxation *accrued over a week of practice* rather than arriving on day one, which is the
+  tradition's own claim about training; and
+  [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of practice lowered
+  resting respiratory rate and lengthened breath-holding time.
+- The one real caution is about **depth, not rate**:
+  [`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
+  shows paced breathing at 6 a minute drops end-tidal CO2 by 5.21 mmHg, and that one sentence of
+  instruction cuts that to 2.7 mmHg. See gap 5.
+
+**What shipped instead of a cap.** `drift` compounds without limit, as it always did. Two changes
+address the real problem, which was never that slow breathing is bad but that the *control was too
+coarse to ask for anything gentle*:
+
+1. **The stepper step is now 0.01 percentage points, was 1.0.** Compounding makes whole percents
+   enormous. From a 15 s cycle, 1 % doubles the breath in 70 cycles (~25 min); 0.1 % takes 693 cycles
+   (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
+   drift a user could previously select was one that ran away inside a single sitting. Display is
+   capped at three decimals, so 0.001 % is the finest value the field round-trips.
+2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
+   is harmful: on by default it moved every new user out of the region anyone has measured, within
+   minutes, without asking. It is one field away for anyone who wants it.
+
+**Still unsupported, and worth stating.** No study examines a *progressively lengthening* pace at
+all. `szulczewski2019-training-relaxation` trained at a fixed rate, so it supports "keep practising,"
+not "keep slowing down within a session." The compounding ramp remains an invention of this app. That
+is a reason to describe it honestly, which is what this entry is for, and not a reason to forbid it.
 
 ### 7. Randomised timing has no literature behind it either
 

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -876,9 +876,18 @@ coarse to ask for anything gentle*:
    (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
    drift a user could previously select was one that ran away inside a single sitting. Display is
    capped at three decimals, so 0.001 % is the finest value the field round-trips, and anything
-   below the step is typed rather than clicked. The settings window now reports the doubling time
-   directly whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen
-   something gentle or something that runs away before lunch.
+   below the step is typed rather than clicked. The settings window reports the doubling point
+   whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen something
+   gentle or something that runs away before lunch.
+
+   **Counted in breaths, not minutes.** The doubling *time* depends on the cycle you start from, so
+   the same 1 % reads as 17 minutes from a 10 s cycle and 25 minutes from a 15 s one; the first
+   version of the readout said exactly that and looked like it could not do arithmetic. The doubling
+   *count* has no such dependence: cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at `k = ln2 / ln d` and the
+   starting length cancels. One per cent is 70 breaths from anywhere, 0.1 % is 693, 0.001 % is
+   69,315. It is also a true repeat interval rather than a first milestone, since the same count
+   takes the cycle from double to quadruple. The figures quoted in this entry are in minutes because
+   they are anchored to the 15 s shipped default; the app cannot assume that.
 2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
    is harmful: on by default it moved every new user out of the region anyone has measured, within
    minutes, without asking. It is one field away for anyone who wants it.

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -1,6 +1,6 @@
 # Citation corpus
 
-48 sources: 45 Crossref-verified, 2 verified against Open Library. 6 are cited from their abstract only and say so, and 2 are not peer-reviewed and are tiered E so they can back lineage but never a claim.
+48 sources: 45 Crossref-verified, 2 verified against Open Library, 1 verified against PubMed. 6 are cited from their abstract only and say so, and 2 are not peer-reviewed and are tiered E so they can back lineage but never a claim.
 
 Machine-readable companion: [`CITATIONS.csl.json`](./CITATIONS.csl.json) (CSL-JSON).
 Verification pass completed 2026-08-28 against the Crossref REST API.
@@ -159,7 +159,7 @@ Schleifer, Lawrence M.; Ley, Ronald. (1994). *End-tidal PCO2 as an index of psyc
 - Backs:
   - during computer data-entry work, end-tidal CO2 was significantly lower and respiration frequency significantly higher than during either baseline relaxation or progressive muscle relaxation
   - breathing changes measurably at a screen, and end-tidal CO2 discriminates the state
-- Caveat: n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real screen work over real working days, not a lab proxy. This entry retracts an earlier claim in this repo that no peer-reviewed study had measured respiration during ordinary screen use. It had; this is it, from 1994.
+- Caveat: n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real screen work over real working days, not a lab proxy. Along with schleifer2008-emg-gaps-computer-work it is the direct evidence that screen work changes respiration, and it dates from 1994, well before the topic reached breathwork writing.
 
 #### `schleifer2002-hyperventilation-job-stress`
 
@@ -366,7 +366,7 @@ Lin, I. M.; Tai, L. Y.; Fan, S. Y. (2014). *Breathing at a rate of 5.5 breaths p
 - Backs:
   - 5.5 breaths per minute with an equal 5:5 inhale-to-exhale ratio produced higher SDNN and LF power than 6 bpm or than a 4:6 ratio
   - all four slow-breathing patterns increased self-reported relaxation relative to spontaneous breathing
-- Caveat: n = 47, Latin-square counterbalanced. The clearest published result AGAINST a longer exhale on HRV grounds, and it is why exhale's README no longer asserts the 1:2 mechanism. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works.
+- Caveat: n = 47, Latin-square counterbalanced. The clearest published result AGAINST a longer exhale on HRV grounds, and the reason exhale makes no mechanism claim for the 1:2 ratio. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works.
 
 #### `marchant2025-square-478-six`
 
@@ -390,7 +390,7 @@ Meehan, Zachary M.; Shaffer, Fred. (2024). *Do Longer Exhalations Increase HRV D
 - Backs:
   - at 6 breaths per minute, a 1:2 inhale-to-exhale ratio produced no HRV advantage over 1:1 in either an original experiment or its replication
   - the finding held across time-domain, frequency-domain and nonlinear HRV metrics
-- Caveat: Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of four disagreeing studies; see also vandiest2014-ie-ratio-relaxation and lin2014-equal-ratio-hrv. Critically, all four measured HRV; none of them measured how participants felt except vandiest2014-ie-ratio-relaxation, which is why exhale's recommendation now rests on the subjective outcome rather than on this dispute.
+- Caveat: Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of four disagreeing studies; see also vandiest2014-ie-ratio-relaxation and lin2014-equal-ratio-hrv. Critically, all four measured HRV; none measured how participants felt except vandiest2014-ie-ratio-relaxation, which is why exhale's recommendation rests on the subjective outcome rather than on this dispute.
 
 #### `sevozcouche2022-coherence-resonance`
 
@@ -649,16 +649,13 @@ Szulczewski, Mikołaj Tytus. (2019). *An Anti-hyperventilation Instruction Decre
 ## Gaps and unsupported choices
 
 Written by hand. This section is the point of the exercise: everything below is a place where exhale
-either claims more than the literature supports, or ships a default that the literature does not
-back. Nothing here is a reason not to use the app. It is a list of things that are currently
-believed rather than known.
+ships something the literature does not settle, or where the evidence is thinner or more divided
+than a bare citation would suggest. Nothing here is a reason not to use the app. It is a list of
+things that are currently believed rather than known.
 
-### 1. Shallow breathing at screens: a retraction, and what the evidence actually supports
+### 1. What is actually measured about breathing at a screen
 
-**An earlier revision of this file said no peer-reviewed study had measured respiration during
-ordinary screen use. That was wrong, and it was wrong because the first search was not deep enough.**
-The literature exists, it is just old and small and filed under ergonomics rather than under
-breathwork.
+The relevant literature is old, small, and filed under ergonomics rather than breathwork.
 
 - [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2): eleven data-entry operators, monitored
   continuously across three consecutive six-hour work days. During computer work, end-tidal CO2 was
@@ -666,123 +663,82 @@ breathwork.
   baseline relaxation or progressive muscle relaxation.
 - [`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work): the same group,
   fourteen years later, n = 23. Lower end-tidal CO2 under high mental workload during computer data
-  entry, and it tracked reduced trapezius EMG gaps.
+  entry, tracking reduced trapezius EMG gaps.
 - [`schleifer2002-hyperventilation-job-stress`](#schleifer2002-hyperventilation-job-stress): the
   theory paper tying it together, which states that hyperventilation "is often characterised by a
   shift from a **diaphragmatic to a thoracic** breathing pattern," recruiting sternocleidomastoid,
   scalene and trapezius.
 
-That diaphragmatic-to-thoracic shift is what people mean by "shallow." It is chest breathing instead
-of belly breathing. So the folk claim has a real mechanism in the peer-reviewed record.
+That diaphragmatic-to-thoracic shift is what people mean by "shallow": chest breathing instead of
+belly breathing.
 
-There is a second, independent line of support through posture.
+A second, independent line runs through posture.
 [`jung2016-smartphone-posture-respiration`](#jung2016-smartphone-posture-respiration) found that
 people using smartphones more than four hours a day had significantly worse craniovertebral angle
 and lower peak expiratory flow than lighter users, and
 [`deniz2024-forward-head-lung-volumes`](#deniz2024-forward-head-lung-volumes) found forward head
 posture associated with FVC reductions of 0.25 to 0.81 L across 115 participants.
 
-**What is still not supported** is "shallow" meaning reduced *volume of air moved*.
+**What the evidence does not support** is "shallow" meaning a reduced *volume of air moved*.
 [`grassmann2016-cognitive-load-respiration`](#grassmann2016-cognitive-load-respiration), 54
 experiments, finds respiratory amplitude roughly stable and minute ventilation **up** under
-cognitive load. Both things are true at once: more air per minute, moved by the wrong muscles, from
-a slumped posture with less capacity available.
+cognitive load. Both things hold at once: more air per minute, moved by the wrong muscles, from a
+slumped posture with less capacity available.
 
-So the precise, defensible statement is: at a screen people breathe **faster, higher in the chest,
+The defensible statement is therefore that at a screen people breathe **faster, higher in the chest,
 and slightly over-ventilated**, from a posture that reduces how much the diaphragm can do. That is
-the claim the README now makes.
+the claim the README makes.
 
-Separately, and still true: the specific popular framing of "screen apnea" or "email apnea," meaning
-outright breath-*holding* at a screen, traces to unpublished observations by Linda Stone from 2007,
-tested informally on acquaintances with no protocol, no published data and no replication. Nothing
-found in this pass measures breath-holding during screen use. The over-breathing finding above is
-close to the opposite of breath-holding, and the two claims should not be run together.
+It is not the same claim as "screen apnea" or "email apnea," meaning outright breath-*holding* at a
+screen. That framing traces to unpublished observations by Linda Stone from 2007, tested informally
+on acquaintances with no protocol, no published data and no replication. Nothing found in this pass
+measures breath-holding during screen use, and the over-breathing finding above points the other
+way. The two claims should not be run together.
 
-### 2. exhale's default breathing rate is below the band anyone has tested
+### 2. The shipped default sits below the band with direct support
 
 exhale ships 5 s inhale and 10 s exhale
-([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)). That is a
+([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)): a
 15-second cycle, or **4.0 breaths per minute**.
 
 [`you2023-respiratory-frequency`](#you2023-respiratory-frequency) tested 5, 5.5, 6, 6.5 and 7 cycles
 per minute and found all of them raised cardiac vagal activity above spontaneous breathing. It did
-not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts the average resonance
+not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts average resonance
 frequency at about 5.5 breaths per minute and notes it varies by individual.
-[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 bpm outperformed 6.
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6.
 
-So exhale's out-of-the-box default sits below the bottom of the range with direct support. It may be
-fine, or better, for a given person; nobody has measured it.
+So 4.0 sits below the bottom of the directly tested range. It may be fine, or better, for a given
+person; nobody has measured it. The default is kept for continuity with existing installs, and the
+Timing panel computes the current rate and states it against that range on open, so the coverage is
+visible where the choice is made. `5` / `0` / `5` / `0`, which is 6 a minute and inside the range,
+is the first of the one-click presets.
 
-The shipped default has deliberately **not** been changed. Silently moving the pace under people who
-already have exhale installed is worse than documenting where the number came from. Changing it is a
-decision to make on purpose, in a release note, not as a side effect of writing this file.
+### 3. Box breathing is slower than it looks
 
-**What shipped instead: the app says it out loud.** The Timing card in the settings window now
-computes the current rate from the four duration fields and prints it next to the range above, so
-the default discloses its own coverage on first open rather than only here. It renders unprompted,
-not behind a hover or a disclosure triangle, for a specific reason: a disclosure reaches the people
-who go looking, and the default is imposed on everyone who never opens the panel at all. The copy
-lives in [`rust/crates/exhale-core/src/pacing.rs`](../rust/crates/exhale-core/src/pacing.rs) with a
-test per line, including one asserting that no line names an effect, a benefit or a condition. The
-binary states arithmetic and one range; everything evidentiary stays in this document, which can be
-corrected in an afternoon rather than in a store-review cycle.
+`4` / `4` / `4` / `4` is a 16-second cycle, or **3.75 breaths per minute**: *slower* than exhale's
+default and further below the tested band, not closer to it. The holds hide the rate, which is why
+the settings panel computes it.
 
-### 3. Box breathing is not the beginner-friendly default it looks like
-
-A natural thought is that `4` / `4` / `4` / `4` box breathing would be a gentler default than the
-current 5 / 10. Two problems.
-
-First, arithmetic: 4+4+4+4 is a 16-second cycle, or **3.75 breaths per minute**. That is *slower*
-than the current default and further below the tested band, not closer to it. The holds hide the
-rate.
-
-Second, and more decisively, box breathing has been tested head-to-head and lost twice:
+Box breathing has also been tested head-to-head twice and did not win either time:
 
 - [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84, compared square breathing,
-  4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 bpm raised HRV **more than
-  either square or 4-7-8**, with small to medium effects. The paper opens by stating flatly that
-  square and 4-7-8 "are popularly promoted by psychotherapists but have little empirical support."
+  4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 raised HRV **more than
+  either square or 4-7-8**, with small to medium effects. The paper opens by stating that square and
+  4-7-8 "are popularly promoted by psychotherapists but have little empirical support."
 - [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing), a pre-registered RCT, tested box
   breathing against cyclic sighing and cyclic hyperventilation over a month. Box breathing was not
   the best-performing arm; the exhale-emphasising one was.
 
-The same evidence rules out 4-7-8, sometimes attributed to Andrew Weil, for the same reason: it lost
-in Marchant, and at 4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
+The same evidence applies to 4-7-8, sometimes attributed to Andrew Weil: it lost in Marchant, and at
+4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
 
-**The evidence-based beginner default is `5` / `0` / `5` / `0`**: 6 breaths per minute, no holds,
-a 10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and it
-is genuinely easier for a beginner than box breathing, because holding the breath is the hard part,
-not the slow part. Box breathing remains a perfectly reasonable thing to want and exhale still
-supports it. It is just not the choice the evidence points at.
+The pattern with the best direct support for someone starting out is `5` / `0` / `5` / `0`: 6 breaths
+per minute, no holds, a 10-second cycle. It sits inside the tested band, it is the condition that won
+in Marchant, and holding the breath is the harder part for a beginner rather than the slow part. Box
+breathing remains a reasonable thing to want, and exhale offers it as a preset. It is simply not the
+pattern the evidence points at.
 
-**What shipped.** Both patterns are offered as one-click presets in the Timing card, `5` / `0` / `5`
-/ `0` first and `4` / `4` / `4` / `4` fourth, and neither carries a badge, a rank or a caption
-claiming anything. Ordering is the only editorial signal, and it is a weak one on purpose. What does
-the work instead is that selecting box breathing makes the readout directly below say *"Now: 3.8
-breaths a minute, a 16 s cycle"* and *"This one is slower than any of them"*, computed rather than
-written. A caption asserting the same thing would have to be maintained against the corpus; the
-arithmetic maintains itself, and it appears for every pattern rather than only the ones somebody
-remembered to annotate. The presets are listed in
-[`rust/crates/exhale-core/src/presets.rs`](../rust/crates/exhale-core/src/presets.rs), where each
-carries a citekey that never reaches the screen and exists only so
-[`scripts/generate-citations.py`](../scripts/generate-citations.py) can fail the build if the record
-behind a shipped pattern is retracted, downgraded to tier E, or marked `inAppCitable: false`.
-
-Four records carry that flag today: [`chaddha2019-slow-breathing-bp`](#chaddha2019-slow-breathing-bp),
-[`fincham2023-breathwork-meta`](#fincham2023-breathwork-meta),
-[`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) and
-[`little2025-a52-breath-method`](#little2025-a52-breath-method). The flag is not a quality judgement
-and reads oddly without that said out loud: `fincham2023` is one of the strongest warrants in this
-corpus. It marks records whose claims are about blood pressure, anxiety, depression or mood, which a
-store-reviewed binary should not be leaning on whatever their quality, because a claim compiled into
-a signed app cannot be withdrawn at the speed evidence changes.
-
-### 4. The 1:2 ratio: what it does and does not support
-
-The README used to say to make the exhale twice as long as the inhale "to engage the parasympathetic
-nervous system." That mechanism claim is not supportable as stated. But the practice is *not*
-unsupported, and the reason is a distinction worth getting right: **the HRV studies and the
-how-do-you-feel studies disagree with each other, and they disagree in a consistent direction.**
+### 4. Longer exhale: supported on how people feel, contested on the heart
 
 On HRV, four results, and they do not line up:
 
@@ -793,109 +749,80 @@ On HRV, four results, and they do not line up:
 | [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) | 47 | 5:5 vs 4:6 at 5.5 and 6 bpm | **Equal** ratio won on SDNN and LF |
 | [`meehan2024-longer-exhalations`](#meehan2024-longer-exhalations) | 26 + 16 replication | 1:1 vs 1:2 at 6 bpm | No difference, in the original *and* the replication |
 
-Two for, one against, one null. Nobody should be asserting a mechanism from that.
+Two for, one against, one null. No mechanism claim survives that split, which is why exhale does not
+make one.
 
-On how people actually felt, the picture is cleaner.
+On how people reported feeling, the picture is cleaner.
 [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) is the only study here that
 measured subjective state across ratios, and participants reported more relaxation, more stress
 reduction, more mindfulness and more positive energy with the longer exhale. Slowing the rate alone
 moved only one of those four. [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) points the
 same way over a month, on mood.
 
-So: **keep the recommendation, drop the mechanism.** A longer exhale is worth preferring because
-people report feeling better doing it, which is the outcome anyone installing exhale actually cares
-about. It should not be sold as a way to "engage the parasympathetic nervous system," because the
-cardiac measures that would show that are split. Note also
+So a longer exhale is worth preferring because people report feeling better doing it, which is the
+outcome anyone installing exhale actually cares about. Note also
 [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv)'s second finding: *every* slow pattern it
-tested increased relaxation over baseline. Rate is doing most of the work. Ratio is a preference
-with a modest, contested edge.
+tested increased relaxation over baseline. Rate does most of the work; ratio is a preference with a
+modest, contested edge.
 
 ### 5. Pacing someone slowly at a screen may push them further into over-breathing
 
-This one is a genuine tension between two entries and nobody has looked at it.
+A genuine tension between two entries that nobody has looked at.
 
 [`marchant2025-square-478-six`](#marchant2025-square-478-six) reports, as an unexpected finding, that
 breathing at 6 breaths per minute produced **mild over-breathing**: HRV went up and end-tidal CO2
 went down. Meanwhile [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2) and
-[`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work) show that a person
-at a keyboard is *already* mildly hypocapnic.
+[`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work) show that a person at
+a keyboard is *already* mildly hypocapnic.
 
-exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while
-taking large breaths moves more air per minute, not less. The whole benefit of slow breathing is
-usually framed as calming, and the CO2 direction here runs the other way. No study in this corpus
-tests a slow pacer on an already-hypocapnic screen worker, which is exactly exhale's user.
+exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while taking
+large breaths moves more air per minute, not less. No study in this corpus tests a slow pacer on an
+already-hypocapnic screen worker, which is exactly exhale's user.
 
-Nothing actionable follows yet, and this is not a safety warning: the effect Marchant reports is
-mild and was measured in a single session. It is recorded because it is the most interesting
-unanswered question this corpus turned up, and because an app that paces breathing should know that
-pacing rate is not the same as pacing volume.
+This is not a safety warning: the effect Marchant reports is mild and was measured in a single
+session. It is recorded because it is the most interesting unanswered question this corpus turned up,
+and because an app that paces breathing should know that pacing rate is not the same as pacing
+volume. The one mitigation with evidence behind it is an instruction rather than a setting:
+[`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
+shows one sentence of anti-hyperventilation guidance cuts the end-tidal CO2 drop from 5.21 mmHg to
+2.7.
 
-### 6. `drift`: the tradition is uncontradicted, and the app should not pretend otherwise
+### 6. `drift` is an invention of this app
 
-**Two corrections in this entry, 2026-08-31.** Both were caught by the maintainer pushing back, and
-both are the same mistake in different clothes: treating the edge of the research literature as if it
-were the edge of legitimate practice.
+`drift` lengthens every cycle by a fixed percentage, compounding, so the breath extends gradually
+across a session. Graded extension of the breath is a long-standing pranayama practice
+([`satyananda2008-apmb`](#satyananda2008-apmb)), but **no study in this corpus examines a
+progressively lengthening pace at all.** [`szulczewski2019-training-relaxation`](#szulczewski2019-training-relaxation)
+trained at a fixed rate and found relaxation accrued over a week of practice, which supports "keep
+practising" rather than "keep slowing down within a session."
 
-**Correction 1 (the overclaim).** An earlier revision said the inverted-U relationship between
-breathing rate and HRV meant progressively slower breathing "moves away from the optimum."
-[`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment)
-describes a peak in **HRV amplitude**, not in relaxation, comfort or benefit. Sliding from one to the
-other is exactly what this corpus's tier-D rule forbids, and it was done here to justify a code
-change that had already been decided on.
+Nothing in this review contradicts the tradition either. The literature simply stops below about 5
+breaths a minute; it does not turn around and report worse outcomes there. What subjective evidence
+exists points the tradition's way:
+[`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
+produced more relaxation, stress reduction and positive energy;
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found every slow pattern beat baseline on
+relaxation; and [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of
+practice lowered resting respiratory rate and lengthened breath-holding time. The inverted-U in
+[`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment) is worth
+reading alongside these, but it describes a peak in **HRV amplitude**, not in relaxation or comfort,
+and does not transfer to one.
 
-**Correction 2 (the cap).** On the strength of that overclaim, a ceiling was added capping `drift` at
-three breaths a minute. It has been **removed**. The argument against it is simple and correct: a
-10-second inhale with a 20-second exhale is unremarkable in pranayama, absence of research is not
-evidence of harm, and an app has no business preventing an advanced practitioner from configuring
-what they actually practise. The ceiling was paternalism wearing a citation.
+The one documented caution is about **depth, not rate**. See gap 5.
 
-**What actually counters the tradition on elongating the breath: nothing found in this review.**
+`drift` is therefore unbounded and **defaults to 0, off**. Off by default is a coverage argument
+rather than a claim of harm: on by default it would move every new user out of the region anyone has
+measured, within minutes, without asking. Unbounded because a 10-second inhale with a 20-second
+exhale is unremarkable in pranayama, and absence of research is not evidence of harm.
 
-- No study located here tests subjective relaxation below about 5 breaths a minute. The literature
-  stops; it does not turn around.
-- The subjective evidence that exists **supports** the tradition.
-  [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
-  produced more relaxation, stress reduction and positive energy;
-  [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found every slow pattern beat baseline on
-  relaxation; [`szulczewski2019-training-relaxation`](#szulczewski2019-training-relaxation) found
-  relaxation *accrued over a week of practice* rather than arriving on day one, which is the
-  tradition's own claim about training; and
-  [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of practice lowered
-  resting respiratory rate and lengthened breath-holding time.
-- The one real caution is about **depth, not rate**:
-  [`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
-  shows paced breathing at 6 a minute drops end-tidal CO2 by 5.21 mmHg, and that one sentence of
-  instruction cuts that to 2.7 mmHg. See gap 5.
-
-**What shipped instead of a cap.** `drift` compounds without limit, as it always did. Two changes
-address the real problem, which was never that slow breathing is bad but that the *control was too
-coarse to ask for anything gentle*:
-
-1. **The stepper step is now 0.1 percentage points, was 1.0.** Compounding makes whole percents
-   enormous. From a 15 s cycle, 1 % doubles the breath in 70 cycles (~25 min); 0.1 % takes 693 cycles
-   (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
-   drift a user could previously select was one that ran away inside a single sitting. Display is
-   capped at three decimals, so 0.001 % is the finest value the field round-trips, and anything
-   below the step is typed rather than clicked. The settings window reports the doubling point
-   whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen something
-   gentle or something that runs away before lunch.
-
-   **Counted in breaths, not minutes.** The doubling *time* depends on the cycle you start from, so
-   the same 1 % reads as 17 minutes from a 10 s cycle and 25 minutes from a 15 s one; the first
-   version of the readout said exactly that and looked like it could not do arithmetic. The doubling
-   *count* has no such dependence: cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at `k = ln2 / ln d` and the
-   starting length cancels. One per cent is 70 breaths from anywhere, 0.1 % is 693, 0.001 % is
-   69,315. It is also a true repeat interval rather than a first milestone, since the same count
-   takes the cycle from double to quadruple. The figures quoted in this entry are in minutes because
-   they are anchored to the 15 s shipped default; the app cannot assume that.
-2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
-   is harmful: on by default it moved every new user out of the region anyone has measured, within
-   minutes, without asking. It is one field away for anyone who wants it.
-
-**Still unsupported, and worth stating.** No study examines a *progressively lengthening* pace at
-all. `szulczewski2019-training-relaxation` trained at a fixed rate, so it supports "keep practising,"
-not "keep slowing down within a session." The compounding ramp remains an invention of this app. That
-is a reason to describe it honestly, which is what this entry is for, and not a reason to forbid it.
+The stepper moves in 0.1 percentage points, and values below that can be typed; display is capped at
+three decimals, so 0.001 % is the finest value the field round-trips. Compounding is steep enough
+that whole percents are unusable: from a 15 s cycle, 1 % doubles the breath in about 25 minutes,
+0.1 % in about 4.2 hours, 0.01 % in about 41. The settings panel reports the doubling point in
+**breaths** rather than minutes, because cycle `k` lasts `c · dᵏ` and so `dᵏ = 2` at
+`k = ln2 / ln d`, with the starting cycle length cancelling out: 1 % is 70 breaths from any starting
+pace, 0.1 % is 693, 0.001 % is 69,315. A doubling time would depend on where the user started and
+would disagree with the minute figures quoted above, which are anchored to the 15 s default.
 
 ### 7. Randomised timing has no literature behind it either
 
@@ -968,8 +895,8 @@ Reviews of breathwork note that only a minority of trials report on adverse even
 *slow* breathing specifically, which is the mode exhale is built around. exhale's sliders can also
 be set to fast, hold-heavy patterns that leave that evidence base entirely; those belong to the
 high-ventilation literature ([`fincham2024-high-ventilation-rct`](#fincham2024-high-ventilation-rct)),
-where transient tetany, light-headedness and distress are documented. This is the honest basis for
-the README's existing advice to take breaks if intense feelings arise, and for it staying there.
+where transient tetany, light-headedness and distress are documented. This is the basis for the
+README's advice to take breaks if intense feelings arise.
 
 ### 14. The tradition sources are lineage, not evidence, and are tiered accordingly
 
@@ -1000,19 +927,9 @@ In rough order of value per unit effort:
    directly on gaps 4 and 11.
 2. Decide, deliberately, whether the shipped default should move from 4.0 breaths/min to
    `5` / `0` / `5` / `0`, which is 6 breaths/min and is what the head-to-head evidence in gap 3
-   points at. This is a release-note decision, not a silent one.
-3. Ship named presets with the citation attached to each, instead of asking users to invent numbers:
-   6 breaths/min (`5` / `0` / `5` / `0`), A52 (`5` / `0` / `5` / `2`), box (`4` / `4` / `4` / `4`),
-   and the current default as "extended exhale." A preset carrying its own evidence tier is more
-   honest than a slider that implies every value is equally supported.
-4. **Queued for the next release, no release needed of its own:** a "Research & Citations" item in
-   the tray menu that opens this file in the browser. Roughly ten lines: one `MenuItem` built and
-   appended in [`tray.rs`](../rust/crates/exhale-app/src/tray.rs) alongside `preferences_item`, and one
-   arm in the `MenuEvent` loop at [`main.rs:1066`](../rust/crates/exhale-app/src/main.rs). It rides
-   along with whatever is tagged next rather than justifying a build, re-sign and three store
-   resubmissions on its own. A link out is deliberately preferred over rendering this corpus inside
-   the settings window: exhale ships through Apple, Microsoft and Snap review, and putting prose about
-   parasympathetic activation inside a health-adjacent binary invites scrutiny that a repo link does
-   not.
-5. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+   points at. This is a release-note decision, not a silent one, because it would change the pace
+   under everyone who has never opened the settings panel.
+3. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
    real, publishable question that exhale is unusually well placed to ask.
+4. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
+   this corpus varies the pace *within* a session, so the question is open in both directions.

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -695,23 +695,35 @@ on acquaintances with no protocol, no published data and no replication. Nothing
 measures breath-holding during screen use, and the over-breathing finding above points the other
 way. The two claims should not be run together.
 
-### 2. The shipped default sits below the band with direct support
+### 2. The default is inside the tested band, but the band is narrow and one person wide
 
-exhale ships 5 s inhale and 10 s exhale
+exhale ships 5 s inhale and 5 s exhale, no holds
 ([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)): a
-15-second cycle, or **4.0 breaths per minute**.
+10-second cycle, or **6.0 breaths per minute**.
 
 [`you2023-respiratory-frequency`](#you2023-respiratory-frequency) tested 5, 5.5, 6, 6.5 and 7 cycles
-per minute and found all of them raised cardiac vagal activity above spontaneous breathing. It did
-not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts average resonance
-frequency at about 5.5 breaths per minute and notes it varies by individual.
-[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6.
+per minute and found all of them raised cardiac vagal activity above spontaneous breathing.
+[`marchant2025-square-478-six`](#marchant2025-square-478-six) ran 6 a minute against square and
+4-7-8 breathing head-to-head, n = 84, and 6 won. So the default is the pace with the most direct
+support of anything exhale could have shipped.
 
-So 4.0 sits below the bottom of the directly tested range. It may be fine, or better, for a given
-person; nobody has measured it. The default is kept for continuity with existing installs, and the
-Timing panel computes the current rate and states it against that range on open, so the coverage is
-visible where the choice is made. `5` / `0` / `5` / `0`, which is 6 a minute and inside the range,
-is the first of the one-click presets.
+That is a weaker statement than it sounds, for two reasons.
+
+**The tested band is five values wide.** Nobody has compared 6 against 3, or against 8, in this
+corpus. "Inside the range that has been tested" is a statement about coverage, not about optimality.
+
+**Resonance frequency is individual.** [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback)
+puts the average at about 5.5 breaths per minute and is explicit that it varies from person to
+person; [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6. A single
+shipped number cannot be right for everyone, and finding a person's own resonance frequency takes an
+assessment protocol and a sensor, neither of which exhale has. The default is a reasonable starting
+point, not a personalised one.
+
+Anyone who already has exhale installed keeps whatever they had: the timing fields carry no
+`#[serde(default)]`, so an existing `settings.toml` is untouched and the change reaches only fresh
+installs and Reset to Defaults. The previous default, `5` / `0` / `10` / `0` at 4 a minute, is still
+offered as a one-click preset. Nobody has measured 4 a minute in this corpus, which is why it is no
+longer what a new user gets without asking.
 
 ### 3. Box breathing is slower than it looks
 
@@ -732,11 +744,11 @@ Box breathing has also been tested head-to-head twice and did not win either tim
 The same evidence applies to 4-7-8, sometimes attributed to Andrew Weil: it lost in Marchant, and at
 4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
 
-The pattern with the best direct support for someone starting out is `5` / `0` / `5` / `0`: 6 breaths
-per minute, no holds, a 10-second cycle. It sits inside the tested band, it is the condition that won
-in Marchant, and holding the breath is the harder part for a beginner rather than the slow part. Box
-breathing remains a reasonable thing to want, and exhale offers it as a preset. It is simply not the
-pattern the evidence points at.
+The pattern with the best direct support is `5` / `0` / `5` / `0`: 6 breaths per minute, no holds, a
+10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and
+holding the breath is the harder part for a beginner rather than the slow part. It is what exhale
+defaults to. Box breathing remains a reasonable thing to want, and exhale offers it as a preset. It
+is simply not the pattern the evidence points at.
 
 ### 4. Longer exhale: supported on how people feel, contested on the heart
 
@@ -925,11 +937,10 @@ In rough order of value per unit effort:
 1. Read the `NUMBERS NOT READ` entries and either promote or downgrade the claims resting on them.
    [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the highest value: it bears
    directly on gaps 4 and 11.
-2. Decide, deliberately, whether the shipped default should move from 4.0 breaths/min to
-   `5` / `0` / `5` / `0`, which is 6 breaths/min and is what the head-to-head evidence in gap 3
-   points at. This is a release-note decision, not a silent one, because it would change the pace
-   under everyone who has never opened the settings panel.
-3. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+2. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
    real, publishable question that exhale is unusually well placed to ask.
-4. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
+3. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
    this corpus varies the pace *within* a session, so the question is open in both directions.
+4. Resonance frequency is individual (gap 2) and exhale ships one number for everyone. Whether a
+   sensorless app can help someone find their own, by any method better than trying a few and
+   noticing, is unresolved and would matter more than the default ever will.

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -755,6 +755,28 @@ is genuinely easier for a beginner than box breathing, because holding the breat
 not the slow part. Box breathing remains a perfectly reasonable thing to want and exhale still
 supports it. It is just not the choice the evidence points at.
 
+**What shipped.** Both patterns are offered as one-click presets in the Timing card, `5` / `0` / `5`
+/ `0` first and `4` / `4` / `4` / `4` fourth, and neither carries a badge, a rank or a caption
+claiming anything. Ordering is the only editorial signal, and it is a weak one on purpose. What does
+the work instead is that selecting box breathing makes the readout directly below say *"Now: 3.8
+breaths a minute, a 16 s cycle"* and *"This one is slower than any of them"*, computed rather than
+written. A caption asserting the same thing would have to be maintained against the corpus; the
+arithmetic maintains itself, and it appears for every pattern rather than only the ones somebody
+remembered to annotate. The presets are listed in
+[`rust/crates/exhale-core/src/presets.rs`](../rust/crates/exhale-core/src/presets.rs), where each
+carries a citekey that never reaches the screen and exists only so
+[`scripts/generate-citations.py`](../scripts/generate-citations.py) can fail the build if the record
+behind a shipped pattern is retracted, downgraded to tier E, or marked `inAppCitable: false`.
+
+Four records carry that flag today: [`chaddha2019-slow-breathing-bp`](#chaddha2019-slow-breathing-bp),
+[`fincham2023-breathwork-meta`](#fincham2023-breathwork-meta),
+[`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) and
+[`little2025-a52-breath-method`](#little2025-a52-breath-method). The flag is not a quality judgement
+and reads oddly without that said out loud: `fincham2023` is one of the strongest warrants in this
+corpus. It marks records whose claims are about blood pressure, anxiety, depression or mood, which a
+store-reviewed binary should not be leaning on whatever their quality, because a claim compiled into
+a signed app cannot be withdrawn at the speed evidence changes.
+
 ### 4. The 1:2 ratio: what it does and does not support
 
 The README used to say to make the exhale twice as long as the inhale "to engage the parasympathetic

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -108,23 +108,35 @@ on acquaintances with no protocol, no published data and no replication. Nothing
 measures breath-holding during screen use, and the over-breathing finding above points the other
 way. The two claims should not be run together.
 
-### 2. The shipped default sits below the band with direct support
+### 2. The default is inside the tested band, but the band is narrow and one person wide
 
-exhale ships 5 s inhale and 10 s exhale
+exhale ships 5 s inhale and 5 s exhale, no holds
 ([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)): a
-15-second cycle, or **4.0 breaths per minute**.
+10-second cycle, or **6.0 breaths per minute**.
 
 [`you2023-respiratory-frequency`](#you2023-respiratory-frequency) tested 5, 5.5, 6, 6.5 and 7 cycles
-per minute and found all of them raised cardiac vagal activity above spontaneous breathing. It did
-not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts average resonance
-frequency at about 5.5 breaths per minute and notes it varies by individual.
-[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6.
+per minute and found all of them raised cardiac vagal activity above spontaneous breathing.
+[`marchant2025-square-478-six`](#marchant2025-square-478-six) ran 6 a minute against square and
+4-7-8 breathing head-to-head, n = 84, and 6 won. So the default is the pace with the most direct
+support of anything exhale could have shipped.
 
-So 4.0 sits below the bottom of the directly tested range. It may be fine, or better, for a given
-person; nobody has measured it. The default is kept for continuity with existing installs, and the
-Timing panel computes the current rate and states it against that range on open, so the coverage is
-visible where the choice is made. `5` / `0` / `5` / `0`, which is 6 a minute and inside the range,
-is the first of the one-click presets.
+That is a weaker statement than it sounds, for two reasons.
+
+**The tested band is five values wide.** Nobody has compared 6 against 3, or against 8, in this
+corpus. "Inside the range that has been tested" is a statement about coverage, not about optimality.
+
+**Resonance frequency is individual.** [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback)
+puts the average at about 5.5 breaths per minute and is explicit that it varies from person to
+person; [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6. A single
+shipped number cannot be right for everyone, and finding a person's own resonance frequency takes an
+assessment protocol and a sensor, neither of which exhale has. The default is a reasonable starting
+point, not a personalised one.
+
+Anyone who already has exhale installed keeps whatever they had: the timing fields carry no
+`#[serde(default)]`, so an existing `settings.toml` is untouched and the change reaches only fresh
+installs and Reset to Defaults. The previous default, `5` / `0` / `10` / `0` at 4 a minute, is still
+offered as a one-click preset. Nobody has measured 4 a minute in this corpus, which is why it is no
+longer what a new user gets without asking.
 
 ### 3. Box breathing is slower than it looks
 
@@ -145,11 +157,11 @@ Box breathing has also been tested head-to-head twice and did not win either tim
 The same evidence applies to 4-7-8, sometimes attributed to Andrew Weil: it lost in Marchant, and at
 4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
 
-The pattern with the best direct support for someone starting out is `5` / `0` / `5` / `0`: 6 breaths
-per minute, no holds, a 10-second cycle. It sits inside the tested band, it is the condition that won
-in Marchant, and holding the breath is the harder part for a beginner rather than the slow part. Box
-breathing remains a reasonable thing to want, and exhale offers it as a preset. It is simply not the
-pattern the evidence points at.
+The pattern with the best direct support is `5` / `0` / `5` / `0`: 6 breaths per minute, no holds, a
+10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and
+holding the breath is the harder part for a beginner rather than the slow part. It is what exhale
+defaults to. Box breathing remains a reasonable thing to want, and exhale offers it as a preset. It
+is simply not the pattern the evidence points at.
 
 ### 4. Longer exhale: supported on how people feel, contested on the heart
 
@@ -338,11 +350,10 @@ In rough order of value per unit effort:
 1. Read the `NUMBERS NOT READ` entries and either promote or downgrade the claims resting on them.
    [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the highest value: it bears
    directly on gaps 4 and 11.
-2. Decide, deliberately, whether the shipped default should move from 4.0 breaths/min to
-   `5` / `0` / `5` / `0`, which is 6 breaths/min and is what the head-to-head evidence in gap 3
-   points at. This is a release-note decision, not a silent one, because it would change the pace
-   under everyone who has never opened the settings panel.
-3. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+2. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
    real, publishable question that exhale is unusually well placed to ask.
-4. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
+3. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
    this corpus varies the pace *within* a session, so the question is open in both directions.
+4. Resonance frequency is individual (gap 2) and exhale ships one number for everyone. Whether a
+   sensorless app can help someone find their own, by any method better than trying a few and
+   noticing, is unresolved and would matter more than the default ever will.

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -211,12 +211,60 @@ mild and was measured in a single session. It is recorded because it is the most
 unanswered question this corpus turned up, and because an app that paces breathing should know that
 pacing rate is not the same as pacing volume.
 
-### 6. `drift` has no literature behind it at all
+### 6. `drift`: the tradition is uncontradicted, and the app should not pretend otherwise
 
-exhale defaults `drift` to `1.01`, making each cycle 1% longer than the last. Over 30 cycles that is
-a 1.35x stretch, taking a 4.0 breaths/min pace down to roughly 3.0 and further outside any tested
-range. No study in this corpus examines a progressively lengthening pace. It is an invented feature.
-It may be a pleasant one. It is not evidence-based, and the default is not zero.
+**Two corrections in this entry, 2026-08-31.** Both were caught by the maintainer pushing back, and
+both are the same mistake in different clothes: treating the edge of the research literature as if it
+were the edge of legitimate practice.
+
+**Correction 1 (the overclaim).** An earlier revision said the inverted-U relationship between
+breathing rate and HRV meant progressively slower breathing "moves away from the optimum."
+[`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment)
+describes a peak in **HRV amplitude**, not in relaxation, comfort or benefit. Sliding from one to the
+other is exactly what this corpus's tier-D rule forbids, and it was done here to justify a code
+change that had already been decided on.
+
+**Correction 2 (the cap).** On the strength of that overclaim, a ceiling was added capping `drift` at
+three breaths a minute. It has been **removed**. The argument against it is simple and correct: a
+10-second inhale with a 20-second exhale is unremarkable in pranayama, absence of research is not
+evidence of harm, and an app has no business preventing an advanced practitioner from configuring
+what they actually practise. The ceiling was paternalism wearing a citation.
+
+**What actually counters the tradition on elongating the breath: nothing found in this review.**
+
+- No study located here tests subjective relaxation below about 5 breaths a minute. The literature
+  stops; it does not turn around.
+- The subjective evidence that exists **supports** the tradition.
+  [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
+  produced more relaxation, stress reduction and positive energy;
+  [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found every slow pattern beat baseline on
+  relaxation; [`szulczewski2019-training-relaxation`](#szulczewski2019-training-relaxation) found
+  relaxation *accrued over a week of practice* rather than arriving on day one, which is the
+  tradition's own claim about training; and
+  [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of practice lowered
+  resting respiratory rate and lengthened breath-holding time.
+- The one real caution is about **depth, not rate**:
+  [`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
+  shows paced breathing at 6 a minute drops end-tidal CO2 by 5.21 mmHg, and that one sentence of
+  instruction cuts that to 2.7 mmHg. See gap 5.
+
+**What shipped instead of a cap.** `drift` compounds without limit, as it always did. Two changes
+address the real problem, which was never that slow breathing is bad but that the *control was too
+coarse to ask for anything gentle*:
+
+1. **The stepper step is now 0.01 percentage points, was 1.0.** Compounding makes whole percents
+   enormous. From a 15 s cycle, 1 % doubles the breath in 70 cycles (~25 min); 0.1 % takes 693 cycles
+   (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
+   drift a user could previously select was one that ran away inside a single sitting. Display is
+   capped at three decimals, so 0.001 % is the finest value the field round-trips.
+2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
+   is harmful: on by default it moved every new user out of the region anyone has measured, within
+   minutes, without asking. It is one field away for anyone who wants it.
+
+**Still unsupported, and worth stating.** No study examines a *progressively lengthening* pace at
+all. `szulczewski2019-training-relaxation` trained at a fixed rate, so it supports "keep practising,"
+not "keep slowing down within a session." The compounding ramp remains an invention of this app. That
+is a reason to describe it honestly, which is what this entry is for, and not a reason to forbid it.
 
 ### 7. Randomised timing has no literature behind it either
 

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -130,6 +130,16 @@ The shipped default has deliberately **not** been changed. Silently moving the p
 already have exhale installed is worse than documenting where the number came from. Changing it is a
 decision to make on purpose, in a release note, not as a side effect of writing this file.
 
+**What shipped instead: the app says it out loud.** The Timing card in the settings window now
+computes the current rate from the four duration fields and prints it next to the range above, so
+the default discloses its own coverage on first open rather than only here. It renders unprompted,
+not behind a hover or a disclosure triangle, for a specific reason: a disclosure reaches the people
+who go looking, and the default is imposed on everyone who never opens the panel at all. The copy
+lives in [`rust/crates/exhale-core/src/pacing.rs`](../rust/crates/exhale-core/src/pacing.rs) with a
+test per line, including one asserting that no line names an effect, a benefit or a condition. The
+binary states arithmetic and one range; everything evidentiary stays in this document, which can be
+corrected in an afternoon rather than in a store-review cycle.
+
 ### 3. Box breathing is not the beginner-friendly default it looks like
 
 A natural thought is that `4` / `4` / `4` / `4` box breathing would be a gentler default than the
@@ -252,11 +262,14 @@ what they actually practise. The ceiling was paternalism wearing a citation.
 address the real problem, which was never that slow breathing is bad but that the *control was too
 coarse to ask for anything gentle*:
 
-1. **The stepper step is now 0.01 percentage points, was 1.0.** Compounding makes whole percents
+1. **The stepper step is now 0.1 percentage points, was 1.0.** Compounding makes whole percents
    enormous. From a 15 s cycle, 1 % doubles the breath in 70 cycles (~25 min); 0.1 % takes 693 cycles
    (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
    drift a user could previously select was one that ran away inside a single sitting. Display is
-   capped at three decimals, so 0.001 % is the finest value the field round-trips.
+   capped at three decimals, so 0.001 % is the finest value the field round-trips, and anything
+   below the step is typed rather than clicked. The settings window now reports the doubling time
+   directly whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen
+   something gentle or something that runs away before lunch.
 2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
    is harmful: on by default it moved every new user out of the region anyone has measured, within
    minutes, without asking. It is one field away for anyone who wants it.

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -62,16 +62,13 @@ establish that it does.
 ## Gaps and unsupported choices
 
 Written by hand. This section is the point of the exercise: everything below is a place where exhale
-either claims more than the literature supports, or ships a default that the literature does not
-back. Nothing here is a reason not to use the app. It is a list of things that are currently
-believed rather than known.
+ships something the literature does not settle, or where the evidence is thinner or more divided
+than a bare citation would suggest. Nothing here is a reason not to use the app. It is a list of
+things that are currently believed rather than known.
 
-### 1. Shallow breathing at screens: a retraction, and what the evidence actually supports
+### 1. What is actually measured about breathing at a screen
 
-**An earlier revision of this file said no peer-reviewed study had measured respiration during
-ordinary screen use. That was wrong, and it was wrong because the first search was not deep enough.**
-The literature exists, it is just old and small and filed under ergonomics rather than under
-breathwork.
+The relevant literature is old, small, and filed under ergonomics rather than breathwork.
 
 - [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2): eleven data-entry operators, monitored
   continuously across three consecutive six-hour work days. During computer work, end-tidal CO2 was
@@ -79,123 +76,82 @@ breathwork.
   baseline relaxation or progressive muscle relaxation.
 - [`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work): the same group,
   fourteen years later, n = 23. Lower end-tidal CO2 under high mental workload during computer data
-  entry, and it tracked reduced trapezius EMG gaps.
+  entry, tracking reduced trapezius EMG gaps.
 - [`schleifer2002-hyperventilation-job-stress`](#schleifer2002-hyperventilation-job-stress): the
   theory paper tying it together, which states that hyperventilation "is often characterised by a
   shift from a **diaphragmatic to a thoracic** breathing pattern," recruiting sternocleidomastoid,
   scalene and trapezius.
 
-That diaphragmatic-to-thoracic shift is what people mean by "shallow." It is chest breathing instead
-of belly breathing. So the folk claim has a real mechanism in the peer-reviewed record.
+That diaphragmatic-to-thoracic shift is what people mean by "shallow": chest breathing instead of
+belly breathing.
 
-There is a second, independent line of support through posture.
+A second, independent line runs through posture.
 [`jung2016-smartphone-posture-respiration`](#jung2016-smartphone-posture-respiration) found that
 people using smartphones more than four hours a day had significantly worse craniovertebral angle
 and lower peak expiratory flow than lighter users, and
 [`deniz2024-forward-head-lung-volumes`](#deniz2024-forward-head-lung-volumes) found forward head
 posture associated with FVC reductions of 0.25 to 0.81 L across 115 participants.
 
-**What is still not supported** is "shallow" meaning reduced *volume of air moved*.
+**What the evidence does not support** is "shallow" meaning a reduced *volume of air moved*.
 [`grassmann2016-cognitive-load-respiration`](#grassmann2016-cognitive-load-respiration), 54
 experiments, finds respiratory amplitude roughly stable and minute ventilation **up** under
-cognitive load. Both things are true at once: more air per minute, moved by the wrong muscles, from
-a slumped posture with less capacity available.
+cognitive load. Both things hold at once: more air per minute, moved by the wrong muscles, from a
+slumped posture with less capacity available.
 
-So the precise, defensible statement is: at a screen people breathe **faster, higher in the chest,
+The defensible statement is therefore that at a screen people breathe **faster, higher in the chest,
 and slightly over-ventilated**, from a posture that reduces how much the diaphragm can do. That is
-the claim the README now makes.
+the claim the README makes.
 
-Separately, and still true: the specific popular framing of "screen apnea" or "email apnea," meaning
-outright breath-*holding* at a screen, traces to unpublished observations by Linda Stone from 2007,
-tested informally on acquaintances with no protocol, no published data and no replication. Nothing
-found in this pass measures breath-holding during screen use. The over-breathing finding above is
-close to the opposite of breath-holding, and the two claims should not be run together.
+It is not the same claim as "screen apnea" or "email apnea," meaning outright breath-*holding* at a
+screen. That framing traces to unpublished observations by Linda Stone from 2007, tested informally
+on acquaintances with no protocol, no published data and no replication. Nothing found in this pass
+measures breath-holding during screen use, and the over-breathing finding above points the other
+way. The two claims should not be run together.
 
-### 2. exhale's default breathing rate is below the band anyone has tested
+### 2. The shipped default sits below the band with direct support
 
 exhale ships 5 s inhale and 10 s exhale
-([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)). That is a
+([`rust/crates/exhale-core/src/settings.rs`](../rust/crates/exhale-core/src/settings.rs)): a
 15-second cycle, or **4.0 breaths per minute**.
 
 [`you2023-respiratory-frequency`](#you2023-respiratory-frequency) tested 5, 5.5, 6, 6.5 and 7 cycles
 per minute and found all of them raised cardiac vagal activity above spontaneous breathing. It did
-not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts the average resonance
+not test 4. [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback) puts average resonance
 frequency at about 5.5 breaths per minute and notes it varies by individual.
-[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 bpm outperformed 6.
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6.
 
-So exhale's out-of-the-box default sits below the bottom of the range with direct support. It may be
-fine, or better, for a given person; nobody has measured it.
+So 4.0 sits below the bottom of the directly tested range. It may be fine, or better, for a given
+person; nobody has measured it. The default is kept for continuity with existing installs, and the
+Timing panel computes the current rate and states it against that range on open, so the coverage is
+visible where the choice is made. `5` / `0` / `5` / `0`, which is 6 a minute and inside the range,
+is the first of the one-click presets.
 
-The shipped default has deliberately **not** been changed. Silently moving the pace under people who
-already have exhale installed is worse than documenting where the number came from. Changing it is a
-decision to make on purpose, in a release note, not as a side effect of writing this file.
+### 3. Box breathing is slower than it looks
 
-**What shipped instead: the app says it out loud.** The Timing card in the settings window now
-computes the current rate from the four duration fields and prints it next to the range above, so
-the default discloses its own coverage on first open rather than only here. It renders unprompted,
-not behind a hover or a disclosure triangle, for a specific reason: a disclosure reaches the people
-who go looking, and the default is imposed on everyone who never opens the panel at all. The copy
-lives in [`rust/crates/exhale-core/src/pacing.rs`](../rust/crates/exhale-core/src/pacing.rs) with a
-test per line, including one asserting that no line names an effect, a benefit or a condition. The
-binary states arithmetic and one range; everything evidentiary stays in this document, which can be
-corrected in an afternoon rather than in a store-review cycle.
+`4` / `4` / `4` / `4` is a 16-second cycle, or **3.75 breaths per minute**: *slower* than exhale's
+default and further below the tested band, not closer to it. The holds hide the rate, which is why
+the settings panel computes it.
 
-### 3. Box breathing is not the beginner-friendly default it looks like
-
-A natural thought is that `4` / `4` / `4` / `4` box breathing would be a gentler default than the
-current 5 / 10. Two problems.
-
-First, arithmetic: 4+4+4+4 is a 16-second cycle, or **3.75 breaths per minute**. That is *slower*
-than the current default and further below the tested band, not closer to it. The holds hide the
-rate.
-
-Second, and more decisively, box breathing has been tested head-to-head and lost twice:
+Box breathing has also been tested head-to-head twice and did not win either time:
 
 - [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84, compared square breathing,
-  4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 bpm raised HRV **more than
-  either square or 4-7-8**, with small to medium effects. The paper opens by stating flatly that
-  square and 4-7-8 "are popularly promoted by psychotherapists but have little empirical support."
+  4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 raised HRV **more than
+  either square or 4-7-8**, with small to medium effects. The paper opens by stating that square and
+  4-7-8 "are popularly promoted by psychotherapists but have little empirical support."
 - [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing), a pre-registered RCT, tested box
   breathing against cyclic sighing and cyclic hyperventilation over a month. Box breathing was not
   the best-performing arm; the exhale-emphasising one was.
 
-The same evidence rules out 4-7-8, sometimes attributed to Andrew Weil, for the same reason: it lost
-in Marchant, and at 4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
+The same evidence applies to 4-7-8, sometimes attributed to Andrew Weil: it lost in Marchant, and at
+4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
 
-**The evidence-based beginner default is `5` / `0` / `5` / `0`**: 6 breaths per minute, no holds,
-a 10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and it
-is genuinely easier for a beginner than box breathing, because holding the breath is the hard part,
-not the slow part. Box breathing remains a perfectly reasonable thing to want and exhale still
-supports it. It is just not the choice the evidence points at.
+The pattern with the best direct support for someone starting out is `5` / `0` / `5` / `0`: 6 breaths
+per minute, no holds, a 10-second cycle. It sits inside the tested band, it is the condition that won
+in Marchant, and holding the breath is the harder part for a beginner rather than the slow part. Box
+breathing remains a reasonable thing to want, and exhale offers it as a preset. It is simply not the
+pattern the evidence points at.
 
-**What shipped.** Both patterns are offered as one-click presets in the Timing card, `5` / `0` / `5`
-/ `0` first and `4` / `4` / `4` / `4` fourth, and neither carries a badge, a rank or a caption
-claiming anything. Ordering is the only editorial signal, and it is a weak one on purpose. What does
-the work instead is that selecting box breathing makes the readout directly below say *"Now: 3.8
-breaths a minute, a 16 s cycle"* and *"This one is slower than any of them"*, computed rather than
-written. A caption asserting the same thing would have to be maintained against the corpus; the
-arithmetic maintains itself, and it appears for every pattern rather than only the ones somebody
-remembered to annotate. The presets are listed in
-[`rust/crates/exhale-core/src/presets.rs`](../rust/crates/exhale-core/src/presets.rs), where each
-carries a citekey that never reaches the screen and exists only so
-[`scripts/generate-citations.py`](../scripts/generate-citations.py) can fail the build if the record
-behind a shipped pattern is retracted, downgraded to tier E, or marked `inAppCitable: false`.
-
-Four records carry that flag today: [`chaddha2019-slow-breathing-bp`](#chaddha2019-slow-breathing-bp),
-[`fincham2023-breathwork-meta`](#fincham2023-breathwork-meta),
-[`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) and
-[`little2025-a52-breath-method`](#little2025-a52-breath-method). The flag is not a quality judgement
-and reads oddly without that said out loud: `fincham2023` is one of the strongest warrants in this
-corpus. It marks records whose claims are about blood pressure, anxiety, depression or mood, which a
-store-reviewed binary should not be leaning on whatever their quality, because a claim compiled into
-a signed app cannot be withdrawn at the speed evidence changes.
-
-### 4. The 1:2 ratio: what it does and does not support
-
-The README used to say to make the exhale twice as long as the inhale "to engage the parasympathetic
-nervous system." That mechanism claim is not supportable as stated. But the practice is *not*
-unsupported, and the reason is a distinction worth getting right: **the HRV studies and the
-how-do-you-feel studies disagree with each other, and they disagree in a consistent direction.**
+### 4. Longer exhale: supported on how people feel, contested on the heart
 
 On HRV, four results, and they do not line up:
 
@@ -206,109 +162,80 @@ On HRV, four results, and they do not line up:
 | [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) | 47 | 5:5 vs 4:6 at 5.5 and 6 bpm | **Equal** ratio won on SDNN and LF |
 | [`meehan2024-longer-exhalations`](#meehan2024-longer-exhalations) | 26 + 16 replication | 1:1 vs 1:2 at 6 bpm | No difference, in the original *and* the replication |
 
-Two for, one against, one null. Nobody should be asserting a mechanism from that.
+Two for, one against, one null. No mechanism claim survives that split, which is why exhale does not
+make one.
 
-On how people actually felt, the picture is cleaner.
+On how people reported feeling, the picture is cleaner.
 [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) is the only study here that
 measured subjective state across ratios, and participants reported more relaxation, more stress
 reduction, more mindfulness and more positive energy with the longer exhale. Slowing the rate alone
 moved only one of those four. [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) points the
 same way over a month, on mood.
 
-So: **keep the recommendation, drop the mechanism.** A longer exhale is worth preferring because
-people report feeling better doing it, which is the outcome anyone installing exhale actually cares
-about. It should not be sold as a way to "engage the parasympathetic nervous system," because the
-cardiac measures that would show that are split. Note also
+So a longer exhale is worth preferring because people report feeling better doing it, which is the
+outcome anyone installing exhale actually cares about. Note also
 [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv)'s second finding: *every* slow pattern it
-tested increased relaxation over baseline. Rate is doing most of the work. Ratio is a preference
-with a modest, contested edge.
+tested increased relaxation over baseline. Rate does most of the work; ratio is a preference with a
+modest, contested edge.
 
 ### 5. Pacing someone slowly at a screen may push them further into over-breathing
 
-This one is a genuine tension between two entries and nobody has looked at it.
+A genuine tension between two entries that nobody has looked at.
 
 [`marchant2025-square-478-six`](#marchant2025-square-478-six) reports, as an unexpected finding, that
 breathing at 6 breaths per minute produced **mild over-breathing**: HRV went up and end-tidal CO2
 went down. Meanwhile [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2) and
-[`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work) show that a person
-at a keyboard is *already* mildly hypocapnic.
+[`schleifer2008-emg-gaps-computer-work`](#schleifer2008-emg-gaps-computer-work) show that a person at
+a keyboard is *already* mildly hypocapnic.
 
-exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while
-taking large breaths moves more air per minute, not less. The whole benefit of slow breathing is
-usually framed as calming, and the CO2 direction here runs the other way. No study in this corpus
-tests a slow pacer on an already-hypocapnic screen worker, which is exactly exhale's user.
+exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while taking
+large breaths moves more air per minute, not less. No study in this corpus tests a slow pacer on an
+already-hypocapnic screen worker, which is exactly exhale's user.
 
-Nothing actionable follows yet, and this is not a safety warning: the effect Marchant reports is
-mild and was measured in a single session. It is recorded because it is the most interesting
-unanswered question this corpus turned up, and because an app that paces breathing should know that
-pacing rate is not the same as pacing volume.
+This is not a safety warning: the effect Marchant reports is mild and was measured in a single
+session. It is recorded because it is the most interesting unanswered question this corpus turned up,
+and because an app that paces breathing should know that pacing rate is not the same as pacing
+volume. The one mitigation with evidence behind it is an instruction rather than a setting:
+[`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
+shows one sentence of anti-hyperventilation guidance cuts the end-tidal CO2 drop from 5.21 mmHg to
+2.7.
 
-### 6. `drift`: the tradition is uncontradicted, and the app should not pretend otherwise
+### 6. `drift` is an invention of this app
 
-**Two corrections in this entry, 2026-08-31.** Both were caught by the maintainer pushing back, and
-both are the same mistake in different clothes: treating the edge of the research literature as if it
-were the edge of legitimate practice.
+`drift` lengthens every cycle by a fixed percentage, compounding, so the breath extends gradually
+across a session. Graded extension of the breath is a long-standing pranayama practice
+([`satyananda2008-apmb`](#satyananda2008-apmb)), but **no study in this corpus examines a
+progressively lengthening pace at all.** [`szulczewski2019-training-relaxation`](#szulczewski2019-training-relaxation)
+trained at a fixed rate and found relaxation accrued over a week of practice, which supports "keep
+practising" rather than "keep slowing down within a session."
 
-**Correction 1 (the overclaim).** An earlier revision said the inverted-U relationship between
-breathing rate and HRV meant progressively slower breathing "moves away from the optimum."
-[`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment)
-describes a peak in **HRV amplitude**, not in relaxation, comfort or benefit. Sliding from one to the
-other is exactly what this corpus's tier-D rule forbids, and it was done here to justify a code
-change that had already been decided on.
+Nothing in this review contradicts the tradition either. The literature simply stops below about 5
+breaths a minute; it does not turn around and report worse outcomes there. What subjective evidence
+exists points the tradition's way:
+[`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
+produced more relaxation, stress reduction and positive energy;
+[`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found every slow pattern beat baseline on
+relaxation; and [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of
+practice lowered resting respiratory rate and lengthened breath-holding time. The inverted-U in
+[`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment) is worth
+reading alongside these, but it describes a peak in **HRV amplitude**, not in relaxation or comfort,
+and does not transfer to one.
 
-**Correction 2 (the cap).** On the strength of that overclaim, a ceiling was added capping `drift` at
-three breaths a minute. It has been **removed**. The argument against it is simple and correct: a
-10-second inhale with a 20-second exhale is unremarkable in pranayama, absence of research is not
-evidence of harm, and an app has no business preventing an advanced practitioner from configuring
-what they actually practise. The ceiling was paternalism wearing a citation.
+The one documented caution is about **depth, not rate**. See gap 5.
 
-**What actually counters the tradition on elongating the breath: nothing found in this review.**
+`drift` is therefore unbounded and **defaults to 0, off**. Off by default is a coverage argument
+rather than a claim of harm: on by default it would move every new user out of the region anyone has
+measured, within minutes, without asking. Unbounded because a 10-second inhale with a 20-second
+exhale is unremarkable in pranayama, and absence of research is not evidence of harm.
 
-- No study located here tests subjective relaxation below about 5 breaths a minute. The literature
-  stops; it does not turn around.
-- The subjective evidence that exists **supports** the tradition.
-  [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
-  produced more relaxation, stress reduction and positive energy;
-  [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found every slow pattern beat baseline on
-  relaxation; [`szulczewski2019-training-relaxation`](#szulczewski2019-training-relaxation) found
-  relaxation *accrued over a week of practice* rather than arriving on day one, which is the
-  tradition's own claim about training; and
-  [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of practice lowered
-  resting respiratory rate and lengthened breath-holding time.
-- The one real caution is about **depth, not rate**:
-  [`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
-  shows paced breathing at 6 a minute drops end-tidal CO2 by 5.21 mmHg, and that one sentence of
-  instruction cuts that to 2.7 mmHg. See gap 5.
-
-**What shipped instead of a cap.** `drift` compounds without limit, as it always did. Two changes
-address the real problem, which was never that slow breathing is bad but that the *control was too
-coarse to ask for anything gentle*:
-
-1. **The stepper step is now 0.1 percentage points, was 1.0.** Compounding makes whole percents
-   enormous. From a 15 s cycle, 1 % doubles the breath in 70 cycles (~25 min); 0.1 % takes 693 cycles
-   (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
-   drift a user could previously select was one that ran away inside a single sitting. Display is
-   capped at three decimals, so 0.001 % is the finest value the field round-trips, and anything
-   below the step is typed rather than clicked. The settings window reports the doubling point
-   whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen something
-   gentle or something that runs away before lunch.
-
-   **Counted in breaths, not minutes.** The doubling *time* depends on the cycle you start from, so
-   the same 1 % reads as 17 minutes from a 10 s cycle and 25 minutes from a 15 s one; the first
-   version of the readout said exactly that and looked like it could not do arithmetic. The doubling
-   *count* has no such dependence: cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at `k = ln2 / ln d` and the
-   starting length cancels. One per cent is 70 breaths from anywhere, 0.1 % is 693, 0.001 % is
-   69,315. It is also a true repeat interval rather than a first milestone, since the same count
-   takes the cycle from double to quadruple. The figures quoted in this entry are in minutes because
-   they are anchored to the 15 s shipped default; the app cannot assume that.
-2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
-   is harmful: on by default it moved every new user out of the region anyone has measured, within
-   minutes, without asking. It is one field away for anyone who wants it.
-
-**Still unsupported, and worth stating.** No study examines a *progressively lengthening* pace at
-all. `szulczewski2019-training-relaxation` trained at a fixed rate, so it supports "keep practising,"
-not "keep slowing down within a session." The compounding ramp remains an invention of this app. That
-is a reason to describe it honestly, which is what this entry is for, and not a reason to forbid it.
+The stepper moves in 0.1 percentage points, and values below that can be typed; display is capped at
+three decimals, so 0.001 % is the finest value the field round-trips. Compounding is steep enough
+that whole percents are unusable: from a 15 s cycle, 1 % doubles the breath in about 25 minutes,
+0.1 % in about 4.2 hours, 0.01 % in about 41. The settings panel reports the doubling point in
+**breaths** rather than minutes, because cycle `k` lasts `c · dᵏ` and so `dᵏ = 2` at
+`k = ln2 / ln d`, with the starting cycle length cancelling out: 1 % is 70 breaths from any starting
+pace, 0.1 % is 693, 0.001 % is 69,315. A doubling time would depend on where the user started and
+would disagree with the minute figures quoted above, which are anchored to the 15 s default.
 
 ### 7. Randomised timing has no literature behind it either
 
@@ -381,8 +308,8 @@ Reviews of breathwork note that only a minority of trials report on adverse even
 *slow* breathing specifically, which is the mode exhale is built around. exhale's sliders can also
 be set to fast, hold-heavy patterns that leave that evidence base entirely; those belong to the
 high-ventilation literature ([`fincham2024-high-ventilation-rct`](#fincham2024-high-ventilation-rct)),
-where transient tetany, light-headedness and distress are documented. This is the honest basis for
-the README's existing advice to take breaks if intense feelings arise, and for it staying there.
+where transient tetany, light-headedness and distress are documented. This is the basis for the
+README's advice to take breaks if intense feelings arise.
 
 ### 14. The tradition sources are lineage, not evidence, and are tiered accordingly
 
@@ -413,19 +340,9 @@ In rough order of value per unit effort:
    directly on gaps 4 and 11.
 2. Decide, deliberately, whether the shipped default should move from 4.0 breaths/min to
    `5` / `0` / `5` / `0`, which is 6 breaths/min and is what the head-to-head evidence in gap 3
-   points at. This is a release-note decision, not a silent one.
-3. Ship named presets with the citation attached to each, instead of asking users to invent numbers:
-   6 breaths/min (`5` / `0` / `5` / `0`), A52 (`5` / `0` / `5` / `2`), box (`4` / `4` / `4` / `4`),
-   and the current default as "extended exhale." A preset carrying its own evidence tier is more
-   honest than a slider that implies every value is equally supported.
-4. **Queued for the next release, no release needed of its own:** a "Research & Citations" item in
-   the tray menu that opens this file in the browser. Roughly ten lines: one `MenuItem` built and
-   appended in [`tray.rs`](../rust/crates/exhale-app/src/tray.rs) alongside `preferences_item`, and one
-   arm in the `MenuEvent` loop at [`main.rs:1066`](../rust/crates/exhale-app/src/main.rs). It rides
-   along with whatever is tagged next rather than justifying a build, re-sign and three store
-   resubmissions on its own. A link out is deliberately preferred over rendering this corpus inside
-   the settings window: exhale ships through Apple, Microsoft and Snap review, and putting prose about
-   parasympathetic activation inside a health-adjacent binary invites scrutiny that a repo link does
-   not.
-5. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+   points at. This is a release-note decision, not a silent one, because it would change the pace
+   under everyone who has never opened the settings panel.
+3. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
    real, publishable question that exhale is unusually well placed to ask.
+4. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
+   this corpus varies the pace *within* a session, so the question is open in both directions.

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -168,6 +168,28 @@ is genuinely easier for a beginner than box breathing, because holding the breat
 not the slow part. Box breathing remains a perfectly reasonable thing to want and exhale still
 supports it. It is just not the choice the evidence points at.
 
+**What shipped.** Both patterns are offered as one-click presets in the Timing card, `5` / `0` / `5`
+/ `0` first and `4` / `4` / `4` / `4` fourth, and neither carries a badge, a rank or a caption
+claiming anything. Ordering is the only editorial signal, and it is a weak one on purpose. What does
+the work instead is that selecting box breathing makes the readout directly below say *"Now: 3.8
+breaths a minute, a 16 s cycle"* and *"This one is slower than any of them"*, computed rather than
+written. A caption asserting the same thing would have to be maintained against the corpus; the
+arithmetic maintains itself, and it appears for every pattern rather than only the ones somebody
+remembered to annotate. The presets are listed in
+[`rust/crates/exhale-core/src/presets.rs`](../rust/crates/exhale-core/src/presets.rs), where each
+carries a citekey that never reaches the screen and exists only so
+[`scripts/generate-citations.py`](../scripts/generate-citations.py) can fail the build if the record
+behind a shipped pattern is retracted, downgraded to tier E, or marked `inAppCitable: false`.
+
+Four records carry that flag today: [`chaddha2019-slow-breathing-bp`](#chaddha2019-slow-breathing-bp),
+[`fincham2023-breathwork-meta`](#fincham2023-breathwork-meta),
+[`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) and
+[`little2025-a52-breath-method`](#little2025-a52-breath-method). The flag is not a quality judgement
+and reads oddly without that said out loud: `fincham2023` is one of the strongest warrants in this
+corpus. It marks records whose claims are about blood pressure, anxiety, depression or mood, which a
+store-reviewed binary should not be leaning on whatever their quality, because a claim compiled into
+a signed app cannot be withdrawn at the speed evidence changes.
+
 ### 4. The 1:2 ratio: what it does and does not support
 
 The README used to say to make the exhale twice as long as the inhale "to engage the parasympathetic

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -289,9 +289,18 @@ coarse to ask for anything gentle*:
    (~4.2 h); 0.01 % about 41 h. The entire useful range sat below the old minimum step, so the only
    drift a user could previously select was one that ran away inside a single sitting. Display is
    capped at three decimals, so 0.001 % is the finest value the field round-trips, and anything
-   below the step is typed rather than clicked. The settings window now reports the doubling time
-   directly whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen
-   something gentle or something that runs away before lunch.
+   below the step is typed rather than clicked. The settings window reports the doubling point
+   whenever drift is on, because "0.1 % per cycle" tells nobody whether they have chosen something
+   gentle or something that runs away before lunch.
+
+   **Counted in breaths, not minutes.** The doubling *time* depends on the cycle you start from, so
+   the same 1 % reads as 17 minutes from a 10 s cycle and 25 minutes from a 15 s one; the first
+   version of the readout said exactly that and looked like it could not do arithmetic. The doubling
+   *count* has no such dependence: cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at `k = ln2 / ln d` and the
+   starting length cancels. One per cent is 70 breaths from anywhere, 0.1 % is 693, 0.001 % is
+   69,315. It is also a true repeat interval rather than a first milestone, since the same count
+   takes the cycle from double to quadruple. The figures quoted in this entry are in minutes because
+   they are anchored to the 15 s shipped default; the app cannot assume that.
 2. **`drift` defaults to 1.0, off.** This is a coverage-and-consent argument, not a claim that drift
    is harmful: on by default it moved every new user out of the region anyone has measured, within
    minutes, without asking. It is one field away for anyone who wants it.

--- a/docs/citations.html
+++ b/docs/citations.html
@@ -1,0 +1,434 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>exhale citation corpus</title>
+<meta name="description" content="Every claim and default in exhale, with the published evidence behind it and a ledger of what the evidence does not support.">
+<meta name="color-scheme" content="light dark">
+<link rel="canonical" href="https://peterklingelhofer.github.io/exhale/citations.html">
+<style>
+  :root {
+    --bg: #fbfaf8;
+    --panel: #ffffff;
+    --ink: #1c1b19;
+    --ink-soft: #55524d;
+    --ink-faint: #807c75;
+    --rule: #e3e0d9;
+    --rule-soft: #efece6;
+    --accent: #0f6d68;
+    --accent-soft: #e6f1f0;
+    --warn-bg: #fdf6e7;
+    --warn-rule: #e8d7a8;
+    --code-bg: #f2efe9;
+    --measure: 68ch;
+    --sans: ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --serif: Charter, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #14161a;
+      --panel: #1a1d22;
+      --ink: #e7e4de;
+      --ink-soft: #b3aea6;
+      --ink-faint: #8a8781;
+      --rule: #2c3038;
+      --rule-soft: #23262c;
+      --accent: #6fd3c9;
+      --accent-soft: #16302f;
+      --warn-bg: #241f14;
+      --warn-rule: #4a3f22;
+      --code-bg: #22262c;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 17px;
+    line-height: 1.65;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  .skip {
+    position: absolute; left: -9999px; top: 0;
+    background: var(--accent); color: #fff;
+    padding: .6rem 1rem; z-index: 20; border-radius: 0 0 6px 0;
+  }
+  .skip:focus { left: 0; }
+
+  a { color: var(--accent); text-underline-offset: .15em; }
+  a:focus-visible, button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* ── Masthead ─────────────────────────────────────────── */
+  .masthead {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; flex-wrap: wrap; gap: .75rem 1.25rem;
+    align-items: baseline;
+    padding: .7rem clamp(1rem, 4vw, 2.5rem);
+    background: color-mix(in srgb, var(--bg) 88%, transparent);
+    backdrop-filter: saturate(1.4) blur(8px);
+    border-bottom: 1px solid var(--rule);
+    font-family: var(--sans);
+    font-size: .82rem;
+  }
+  .wordmark {
+    font-weight: 600; letter-spacing: .01em;
+    color: var(--ink); text-decoration: none;
+    font-size: .95rem;
+  }
+  .wordmark::before {
+    content: ""; display: inline-block;
+    width: .5rem; height: .5rem; margin-right: .5rem;
+    border: 1.5px solid var(--accent); border-radius: 50%;
+  }
+  .masthead nav { margin-left: auto; display: flex; gap: 1.1rem; flex-wrap: wrap; }
+  .masthead nav a { color: var(--ink-soft); text-decoration: none; }
+  .masthead nav a:hover { color: var(--accent); text-decoration: underline; }
+
+  /* ── Layout ───────────────────────────────────────────── */
+  .layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: clamp(1.5rem, 4vw, 3.5rem);
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 4vw, 2.5rem) 5rem;
+  }
+  @media (min-width: 62rem) {
+    .layout { grid-template-columns: 16.5rem minmax(0, 1fr); }
+    .toc { order: -1; }
+  }
+
+  /* ── Table of contents ────────────────────────────────── */
+  .toc {
+    font-family: var(--sans);
+    font-size: .84rem;
+    line-height: 1.45;
+  }
+  @media (min-width: 62rem) {
+    .toc { position: sticky; top: 4.2rem; max-height: calc(100vh - 6rem); overflow-y: auto; }
+  }
+  .toc h2 {
+    font-size: .72rem; text-transform: uppercase; letter-spacing: .09em;
+    color: var(--ink-faint); margin: 0 0 .75rem; font-weight: 600;
+  }
+  .toc ol { list-style: none; margin: 0; padding: 0; }
+  .toc li { margin: 0; }
+  .toc a {
+    display: block; padding: .3rem .6rem;
+    color: var(--ink-soft); text-decoration: none;
+    border-left: 2px solid var(--rule-soft);
+  }
+  .toc a:hover { color: var(--accent); background: var(--rule-soft); }
+  .toc a[aria-current="true"] {
+    color: var(--accent); border-left-color: var(--accent);
+    background: var(--accent-soft); font-weight: 600;
+  }
+  .toc .toc-gaps a { font-weight: 600; }
+
+  /* ── Document ─────────────────────────────────────────── */
+  #doc { min-width: 0; max-width: var(--measure); }
+  #doc > * { max-width: 100%; }
+
+  #doc h1, #doc h2, #doc h3, #doc h4 {
+    font-family: var(--sans);
+    line-height: 1.25;
+    scroll-margin-top: 4.5rem;
+  }
+  #doc h1 {
+    font-size: clamp(1.9rem, 5vw, 2.5rem);
+    letter-spacing: -.02em; margin: 0 0 1rem; font-weight: 650;
+  }
+  #doc h2 {
+    font-size: 1.4rem; font-weight: 620; margin: 3rem 0 .9rem;
+    padding-top: 1.6rem; border-top: 1px solid var(--rule);
+  }
+  #doc h3 { font-size: 1.12rem; font-weight: 620; margin: 2.1rem 0 .7rem; }
+  #doc h4 {
+    font-size: .95rem; font-weight: 600; margin: 2rem 0 .5rem;
+    color: var(--ink);
+  }
+  #doc h4 code {
+    background: var(--accent-soft); color: var(--accent);
+    padding: .18em .5em; border-radius: 4px; font-size: .95em;
+  }
+
+  #doc p { margin: 0 0 1.1rem; }
+  #doc ul, #doc ol { margin: 0 0 1.1rem; padding-left: 1.4rem; }
+  #doc li { margin-bottom: .35rem; }
+  #doc hr { border: 0; border-top: 1px solid var(--rule); margin: 2.5rem 0; }
+
+  #doc blockquote {
+    margin: 1.4rem 0; padding: .9rem 1.2rem;
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-rule);
+    border-left-width: 3px;
+    border-radius: 0 6px 6px 0;
+    font-size: .94rem;
+  }
+  #doc blockquote > :last-child { margin-bottom: 0; }
+
+  #doc code {
+    font-family: var(--mono); font-size: .86em;
+    background: var(--code-bg); padding: .15em .4em; border-radius: 4px;
+    overflow-wrap: break-word;
+  }
+  #doc pre {
+    background: var(--code-bg); padding: 1rem; border-radius: 6px;
+    overflow-x: auto; font-size: .85rem;
+  }
+  #doc pre code { background: none; padding: 0; }
+
+  .table-wrap {
+    overflow-x: auto; margin: 0 0 1.4rem;
+    border: 1px solid var(--rule); border-radius: 6px;
+    background: var(--panel);
+  }
+  #doc table {
+    border-collapse: collapse; width: 100%;
+    font-family: var(--sans); font-size: .86rem;
+  }
+  #doc th, #doc td {
+    text-align: left; padding: .6rem .85rem;
+    border-bottom: 1px solid var(--rule-soft);
+    vertical-align: top;
+  }
+  #doc th { font-weight: 600; background: var(--rule-soft); white-space: nowrap; }
+  #doc tr:last-child td { border-bottom: 0; }
+
+  /* ── Status / fallback ────────────────────────────────── */
+  .status {
+    font-family: var(--sans); font-size: .95rem;
+    color: var(--ink-soft);
+    border: 1px solid var(--rule); border-radius: 8px;
+    padding: 1.25rem 1.4rem; background: var(--panel);
+  }
+  .status h2 { font-size: 1.05rem; margin: 0 0 .5rem; color: var(--ink); }
+  .status p:last-child { margin-bottom: 0; }
+  .status[hidden] { display: none; }
+
+  .colophon {
+    margin-top: 3.5rem; padding-top: 1.2rem;
+    border-top: 1px solid var(--rule);
+    font-family: var(--sans); font-size: .8rem; color: var(--ink-faint);
+    max-width: var(--measure);
+  }
+  .colophon a { color: var(--ink-soft); }
+
+  @media print {
+    .masthead, .toc, .colophon { display: none; }
+    body { background: #fff; color: #000; font-size: 11pt; }
+    .layout { display: block; padding: 0; }
+    #doc { max-width: none; }
+  }
+</style>
+</head>
+<body>
+
+<a class="skip" href="#doc">Skip to the corpus</a>
+
+<header class="masthead">
+  <a class="wordmark" href="https://github.com/peterklingelhofer/exhale">exhale</a>
+  <nav aria-label="Related documents">
+    <a href="#gaps-and-unsupported-choices">Gaps ledger</a>
+    <a href="https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.csl.json">CSL-JSON</a>
+    <a href="https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md">View on GitHub</a>
+  </nav>
+</header>
+
+<div class="layout">
+  <aside class="toc" id="toc" hidden>
+    <h2>Contents</h2>
+    <ol id="toc-list"></ol>
+  </aside>
+
+  <div>
+    <div class="status" id="status" role="status" aria-live="polite">
+      <p>Loading the citation corpus from the repository&hellip;</p>
+    </div>
+
+    <main id="doc"></main>
+
+    <noscript>
+      <div class="status">
+        <h2>This page needs JavaScript</h2>
+        <p>It reads the corpus straight from the repository so it is never out of date with the
+        published evidence. Without scripting, read it on
+        <a href="https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md">GitHub</a>
+        instead.</p>
+      </div>
+    </noscript>
+
+    <p class="colophon">
+      Rendered live from
+      <a href="https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md"><code>docs/CITATIONS.md</code></a>
+      on the <code>main</code> branch, so a correction or a retraction reaches this page without a
+      release. exhale is a breathing overlay, not a medical device, and nothing here is medical advice.
+    </p>
+  </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/15.0.7/marked.min.js"
+        integrity="sha384-H+hy9ULve6xfxRkWIh/YOtvDdpXgV2fmAGQkIDTxIgZwNoaoBal14Di2YTMR6MzR"
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js"
+        integrity="sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu"
+        crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+(function () {
+  "use strict";
+
+  var REPO = "https://github.com/peterklingelhofer/exhale";
+  var RAW = "https://raw.githubusercontent.com/peterklingelhofer/exhale/main/docs/CITATIONS.md";
+  var BLOB = REPO + "/blob/main/docs/CITATIONS.md";
+  // Relative links in the markdown are written against docs/, so resolve them
+  // against the blob view of that directory rather than against this page
+  var LINK_BASE = REPO + "/blob/main/docs/";
+
+  var doc = document.getElementById("doc");
+  var status = document.getElementById("status");
+
+  /**
+   * GitHub's heading-anchor rule, kept byte-for-byte in step with
+   * `slugify()` in scripts/generate-citations.py. The tray menu's deep
+   * link into the gaps ledger is validated against that function, so a
+   * divergence here silently strands every shipped binary.
+   */
+  function slugify(text) {
+    return text.trim().toLowerCase().replace(/[^\p{L}\p{N} _-]/gu, "").replace(/ /g, "-");
+  }
+
+  function fail(message) {
+    status.hidden = false;
+    status.innerHTML = "";
+    var h = document.createElement("h2");
+    h.textContent = "The corpus could not be loaded";
+    var p1 = document.createElement("p");
+    p1.textContent = message;
+    var p2 = document.createElement("p");
+    var a = document.createElement("a");
+    a.href = BLOB;
+    a.textContent = "Read it on GitHub instead";
+    p2.appendChild(a);
+    status.append(h, p1, p2);
+  }
+
+  function addAnchors() {
+    var seen = Object.create(null);
+    doc.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach(function (h) {
+      var base = slugify(h.textContent);
+      if (!base) return;
+      var slug = base;
+      if (seen[base] !== undefined) { seen[base] += 1; slug = base + "-" + seen[base]; }
+      else { seen[base] = 0; }
+      h.id = slug;
+    });
+  }
+
+  function fixLinks() {
+    doc.querySelectorAll("a[href]").forEach(function (a) {
+      var href = a.getAttribute("href");
+      if (!href || href.charAt(0) === "#") return;
+      if (!/^[a-z][a-z0-9+.-]*:/i.test(href)) {
+        try { a.href = new URL(href, LINK_BASE).href; } catch (e) { return; }
+      }
+      if (a.hostname !== window.location.hostname) {
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+      }
+    });
+  }
+
+  function wrapTables() {
+    doc.querySelectorAll("table").forEach(function (table) {
+      var wrap = document.createElement("div");
+      wrap.className = "table-wrap";
+      table.parentNode.insertBefore(wrap, table);
+      wrap.appendChild(table);
+    });
+  }
+
+  function buildToc() {
+    var headings = Array.prototype.slice.call(doc.querySelectorAll("h2"));
+    if (!headings.length) return;
+
+    var list = document.getElementById("toc-list");
+    headings.forEach(function (h) {
+      var li = document.createElement("li");
+      if (h.id === "gaps-and-unsupported-choices") li.className = "toc-gaps";
+      var a = document.createElement("a");
+      a.href = "#" + h.id;
+      a.textContent = h.textContent;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+    document.getElementById("toc").hidden = false;
+
+    if (!("IntersectionObserver" in window)) return;
+    var links = {};
+    list.querySelectorAll("a").forEach(function (a) { links[a.hash.slice(1)] = a; });
+    var current = null;
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        if (current) current.removeAttribute("aria-current");
+        current = links[entry.target.id];
+        if (current) current.setAttribute("aria-current", "true");
+      });
+    }, { rootMargin: "-4.5rem 0px -75% 0px" });
+    headings.forEach(function (h) { observer.observe(h); });
+  }
+
+  // The browser resolved the hash before the document existed, so redo it
+  function jumpToHash() {
+    if (!window.location.hash) return;
+    var id = decodeURIComponent(window.location.hash.slice(1));
+    var target = document.getElementById(id);
+    if (!target) return;
+    target.scrollIntoView();
+    target.setAttribute("tabindex", "-1");
+    target.focus({ preventScroll: true });
+  }
+
+  if (!window.marked || !window.DOMPurify) {
+    fail("The rendering libraries did not load. A network filter or an offline connection will do this.");
+    return;
+  }
+
+  fetch(RAW, { cache: "no-cache" })
+    .then(function (res) {
+      if (!res.ok) throw new Error("GitHub returned " + res.status + " " + res.statusText);
+      return res.text();
+    })
+    .then(function (markdown) {
+      var html = window.marked.parse(markdown, { gfm: true, breaks: false });
+      doc.innerHTML = window.DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+      status.hidden = true;
+      addAnchors();
+      fixLinks();
+      wrapTables();
+      buildToc();
+      jumpToHash();
+      window.addEventListener("hashchange", jumpToHash);
+      var h1 = doc.querySelector("h1");
+      if (h1) document.title = h1.textContent + " · exhale";
+    })
+    .catch(function (err) {
+      fail("The request to GitHub failed: " + err.message);
+    });
+})();
+</script>
+</body>
+</html>

--- a/rust/crates/exhale-app/src/main.rs
+++ b/rust/crates/exhale-app/src/main.rs
@@ -1076,6 +1076,11 @@ impl ApplicationHandler<AppEvent> for App {
                     let _ = self.proxy.send_event(AppEvent::BeginCapturingShortcut(action));
                 }
                 else if id == &ids.preferences { let _ = self.proxy.send_event(AppEvent::ShowSettings); }
+                // Handled inline rather than through an `AppEvent`:
+                // opening a URL touches no app state, and
+                // `about_to_wait` already runs on the main thread,
+                // which is where `NSWorkspace` has to be called from
+                else if id == &ids.research { platform::open_url(tray::RESEARCH_URL); }
                 else if id == &ids.start  { let _ = self.proxy.send_event(AppEvent::StartAnimation); }
                 else if id == &ids.stop   { let _ = self.proxy.send_event(AppEvent::StopAnimation); }
                 else if id == &ids.reset  { let _ = self.proxy.send_event(AppEvent::ResetDefaults); }

--- a/rust/crates/exhale-app/src/platform.rs
+++ b/rust/crates/exhale-app/src/platform.rs
@@ -104,3 +104,90 @@ pub fn render_sf_symbol(_name: &str, _point_size: f64, _dark_mode: bool) -> Opti
 #[cfg(not(target_os = "windows"))]
 #[allow(dead_code)]
 pub fn reassert_overlay_topmost(_window: &winit::window::Window) {}
+
+// ─── Opening a URL in the user's browser ─────────────────────────────────────
+
+/// Hand `url` to the user's default browser.
+///
+/// This is the only outbound-link path in the app, so the scheme
+/// check lives here rather than at each call site: anything that
+/// isn't a plain `https://` URL is dropped with a log line and never
+/// reaches the platform API.  `ShellExecuteW` in particular will
+/// happily launch a local executable for a `file:` URL, and
+/// `xdg-open` will hand an arbitrary scheme to whatever handler
+/// claims it, so the allowlist is load-bearing rather than
+/// decorative — even though every current caller passes a
+/// compile-time constant.
+///
+/// Best-effort by design.  A machine with no browser, no
+/// `xdg-open`, or a refused `NSWorkspace` open is a fully working
+/// exhale; the documentation is on the web either way.  Failures
+/// log and return
+pub fn open_url(url: &str) {
+    if !is_openable(url) {
+        log::warn!("open_url: refusing non-https or malformed URL: {url:?}");
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    mac::open_url_impl(url);
+    #[cfg(target_os = "windows")]
+    win::open_url_impl(url);
+    #[cfg(all(unix, not(target_os = "macos")))]
+    linux::open_url_impl(url);
+}
+
+/// The allowlist [`open_url`] enforces, split out so it can be tested
+/// without launching a browser.
+///
+/// Rejecting on the whole `https://` prefix (rather than "starts with
+/// http") also rules out `https:/evil` and scheme-relative junk, and
+/// the control-character check keeps anything unprintable out of a
+/// command argument on the Linux path.  There is deliberately no
+/// `http://` escape hatch: every destination this app links to is a
+/// GitHub URL that redirects to TLS anyway
+fn is_openable(url: &str) -> bool {
+    url.starts_with("https://")
+        && url.len() > "https://".len()
+        && !url.chars().any(char::is_control)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_plain_https_urls_are_openable() {
+        assert!(is_openable("https://github.com/peterklingelhofer/exhale#a"));
+
+        // `ShellExecuteW` would resolve this through the shell
+        // association table and launch a local program
+        assert!(!is_openable("file:///etc/passwd"));
+        assert!(!is_openable("http://example.com"));
+        // Substring-of-scheme and scheme-relative near-misses
+        assert!(!is_openable("https:/example.com"));
+        assert!(!is_openable("//example.com"));
+        assert!(!is_openable(" https://example.com"));
+        // A bare scheme resolves to nothing; reject rather than
+        // hand an empty host to three different platform APIs
+        assert!(!is_openable("https://"));
+        assert!(!is_openable(""));
+        // Newline injection into the argument of a spawned process
+        assert!(!is_openable("https://example.com\nrm -rf /"));
+        assert!(!is_openable("https://example.com\u{0}"));
+    }
+
+    /// The tray constant is the only URL that actually ships, so the
+    /// allowlist it has to pass is asserted here rather than left to
+    /// the code review that introduced it
+    #[test]
+    fn shipped_research_url_passes_the_allowlist() {
+        assert!(is_openable(crate::tray::RESEARCH_URL));
+        assert!(
+            crate::tray::RESEARCH_URL.ends_with("#gaps-and-unsupported-choices"),
+            "the anchor is the feature: pointing at the top of CITATIONS.md \
+             lands the reader in 48 references instead of the fourteen \
+             things they do not support"
+        );
+    }
+}

--- a/rust/crates/exhale-app/src/platform/linux.rs
+++ b/rust/crates/exhale-app/src/platform/linux.rs
@@ -179,3 +179,32 @@ use super::*;
         x.set_wm_state(b"_NET_WM_STATE_SKIP_TASKBAR", hide);
         x.set_wm_state(b"_NET_WM_STATE_SKIP_PAGER",   hide);
     }
+
+    /// Linux half of [`super::open_url`].  Scheme validation happens
+    /// in the caller.
+    ///
+    /// `xdg-open` is the desktop-agnostic handler every target
+    /// desktop ships, and `snapcraft.yaml` already plugs `desktop`,
+    /// which is what makes it reachable from inside the snap
+    /// confinement.  The URL goes through `Command::arg`, not a
+    /// shell, so it is never word-split or expanded.
+    ///
+    /// We `spawn` rather than `status` so a browser cold-start can't
+    /// stall the event loop.  That leaves the child unreaped until
+    /// exhale exits; `xdg-open` returns almost immediately after
+    /// handing off, and this only runs on an explicit menu click, so
+    /// the zombie count is bounded by how many times the user clicks
+    pub(super) fn open_url_impl(url: &str) {
+        use std::process::{Command, Stdio};
+
+        match Command::new("xdg-open")
+            .arg(url)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(_)  => {}
+            Err(e) => log::warn!("open_url: xdg-open failed for {url:?}: {e}"),
+        }
+    }

--- a/rust/crates/exhale-app/src/platform/mac.rs
+++ b/rust/crates/exhale-app/src/platform/mac.rs
@@ -215,7 +215,7 @@ use super::*;
         INIT.call_once(|| unsafe {
             // Allocate `ExhaleMenuTracker` NSObject subclass — same
             // pattern as `ExhaleAEHandler` (dock reopen) and
-            // `ExhaleAboutHandler` (about-panel options), avoiding
+            // `ExhaleMenuHandler` (about-panel options), avoiding
             // any swizzle of system classes for MAS-review safety
             let super_cls = objc2::class!(NSObject);
             let name = c"ExhaleMenuTracker";
@@ -976,7 +976,7 @@ use super::*;
             // empty.  Passing the version from
             // `env!("CARGO_PKG_VERSION")` at compile time keeps the
             // panel populated in both bundled and unbundled builds
-            ensure_about_handler_registered();
+            ensure_menu_handler_registered();
             let about_title = NSString::from_str(&format!("About {app_name}"));
             let about = NSMenuItem::initWithTitle_action_keyEquivalent(
                 mtm.alloc::<NSMenuItem>(),
@@ -984,10 +984,28 @@ use super::*;
                 Some(sel!(exhaleShowAbout:)),
                 &NSString::from_str(""),
             );
-            if let Some(handler) = about_handler_instance() {
+            if let Some(handler) = menu_handler_instance() {
                 let _: () = msg_send![&*about, setTarget: handler];
             }
             apple_menu.addItem(&about);
+
+            // Directly under About, which is where a macOS app puts the
+            // things that describe itself rather than operate on
+            // anything.  The tray menu carries the same item; this is
+            // the one a keyboard or VoiceOver user reaches without
+            // knowing the tray exists, and NSMenu items are exposed to
+            // the accessibility tree even though nothing inside the
+            // egui settings window is
+            let research = NSMenuItem::initWithTitle_action_keyEquivalent(
+                mtm.alloc::<NSMenuItem>(),
+                &NSString::from_str(crate::tray::RESEARCH_LABEL),
+                Some(sel!(exhaleShowResearch:)),
+                &NSString::from_str(""),
+            );
+            if let Some(handler) = menu_handler_instance() {
+                let _: () = msg_send![&*research, setTarget: handler];
+            }
+            apple_menu.addItem(&research);
             apple_menu.addItem(&NSMenuItem::separatorItem(mtm));
 
             // Services submenu: AppKit wires this up automatically if we
@@ -1235,15 +1253,15 @@ use super::*;
     // `"ApplicationName"`, `"ApplicationVersion"`, …).  The version
     // string comes from `env!("CARGO_PKG_VERSION")` so it tracks
     // `Cargo.toml` at compile time without any runtime plist lookup
-    static ABOUT_HANDLER: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
+    static MENU_HANDLER: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
         std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
-    /// Return the leaked `ExhaleAboutHandler` instance set up by
-    /// [`ensure_about_handler_registered`].  Returns `None` only when
+    /// Return the leaked `ExhaleMenuHandler` instance set up by
+    /// [`ensure_menu_handler_registered`].  Returns `None` only when
     /// the class registration step failed (extremely unlikely; would
     /// imply objc runtime allocation failure)
-    pub(super) fn about_handler_instance() -> Option<&'static objc2::runtime::AnyObject> {
-        let p = ABOUT_HANDLER.load(std::sync::atomic::Ordering::Acquire);
+    pub(super) fn menu_handler_instance() -> Option<&'static objc2::runtime::AnyObject> {
+        let p = MENU_HANDLER.load(std::sync::atomic::Ordering::Acquire);
         if p.is_null() {
             None
         } else {
@@ -1256,11 +1274,11 @@ use super::*;
         }
     }
 
-    /// Idempotently define the `ExhaleAboutHandler` NSObject
+    /// Idempotently define the `ExhaleMenuHandler` NSObject
     /// subclass, allocate one instance, and stash it in
-    /// `ABOUT_HANDLER`.  Safe to call multiple times — the inner
+    /// `MENU_HANDLER`.  Safe to call multiple times — the inner
     /// `Once` guards against double-registration
-    pub(super) fn ensure_about_handler_registered() {
+    pub(super) fn ensure_menu_handler_registered() {
         use objc2::msg_send;
         use objc2::runtime::AnyObject;
         use objc2_foundation::NSString;
@@ -1326,20 +1344,35 @@ use super::*;
             }
         }
 
+        // The second menu-item action. Same class, because both items
+        // live in the app menu and a second leaked NSObject to hold one
+        // more selector would be ceremony for nothing.
+        //
+        // Sends the URL through `super::open_url`, so the macOS menu bar
+        // and the tray menu go through one `https://`-only allowlist
+        // rather than two
+        extern "C" fn show_research(
+            _this:   &AnyObject,
+            _cmd:    objc2::runtime::Sel,
+            _sender: *mut AnyObject,
+        ) {
+            super::open_url(crate::tray::RESEARCH_URL);
+        }
+
         static INIT: Once = Once::new();
         INIT.call_once(|| unsafe {
             // 1. Allocate a new NSObject subclass.  Naming matches
             //    the existing AppleEvent handler pattern in
             //    `register_reopen_handler` for consistency
             let super_cls = objc2::class!(NSObject);
-            let name      = c"ExhaleAboutHandler";
+            let name      = c"ExhaleMenuHandler";
             let new_cls   = objc2::ffi::objc_allocateClassPair(
                 (super_cls as *const _) as *const _,
                 name.as_ptr(),
                 0,
             );
             if new_cls.is_null() {
-                log::warn!("about handler: objc_allocateClassPair returned null");
+                log::warn!("menu handler: objc_allocateClassPair returned null");
                 return;
             }
 
@@ -1353,8 +1386,21 @@ use super::*;
                 new_cls as *mut _, sel, imp, c"v@:@".as_ptr(),
             );
             if !added.as_bool() {
-                log::warn!("about handler: class_addMethod returned NO");
+                log::warn!("menu handler: class_addMethod returned NO");
             }
+
+            // Same encoding, same target/action protocol, for the
+            // Research item alongside About
+            let research_sel = objc2::sel!(exhaleShowResearch:);
+            let research_imp: objc2::runtime::Imp =
+                std::mem::transmute(show_research as *const ());
+            let research_added = objc2::ffi::class_addMethod(
+                new_cls as *mut _, research_sel, research_imp, c"v@:@".as_ptr(),
+            );
+            if !research_added.as_bool() {
+                log::warn!("menu handler: class_addMethod returned NO for research");
+            }
+
             objc2::ffi::objc_registerClassPair(new_cls as *mut _);
 
             // 3. Allocate one instance; leak it for the app's
@@ -1365,10 +1411,10 @@ use super::*;
             let instance: *mut AnyObject = msg_send![new_cls, alloc];
             let instance: *mut AnyObject = msg_send![instance, init];
             if instance.is_null() {
-                log::warn!("about handler: failed to alloc ExhaleAboutHandler");
+                log::warn!("menu handler: failed to alloc ExhaleMenuHandler");
                 return;
             }
-            ABOUT_HANDLER.store(instance, std::sync::atomic::Ordering::Release);
+            MENU_HANDLER.store(instance, std::sync::atomic::Ordering::Release);
         });
     }
 

--- a/rust/crates/exhale-app/src/platform/mac.rs
+++ b/rust/crates/exhale-app/src/platform/mac.rs
@@ -1780,14 +1780,19 @@ use super::*;
             assert_eq!(read_activation_policy(), 0,
                 "Both should map to NSApplicationActivationPolicyRegular (0)");
 
-            // Restore.
-            use objc2::{class, msg_send};
-            use objc2::runtime::AnyObject;
-            unsafe {
-                let app: *mut AnyObject =
-                    msg_send![class!(NSApplication), sharedApplication];
-                let _: () = msg_send![app, setActivationPolicy: original];
-            }
+            // Restore through the same typed binding the production
+            // path uses.  `setActivationPolicy:` returns `BOOL`, so a
+            // hand-written `msg_send!` declaring `()` trips objc2's
+            // runtime encoding check and panics the test
+            use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
+            use objc2_foundation::MainThreadMarker;
+
+            // SAFETY: same looser guarantee `apply_app_visibility`
+            // documents, which this test has already exercised three
+            // times above
+            let mtm = unsafe { MainThreadMarker::new_unchecked() };
+            let _ = NSApplication::sharedApplication(mtm)
+                .setActivationPolicy(NSApplicationActivationPolicy(original as isize));
         }
 
         #[test]

--- a/rust/crates/exhale-app/src/platform/mac.rs
+++ b/rust/crates/exhale-app/src/platform/mac.rs
@@ -1535,6 +1535,39 @@ use super::*;
         app.setActivationPolicy(policy);
     }
 
+    /// macOS half of [`super::open_url`].  Scheme validation happens
+    /// in the caller.
+    ///
+    /// `NSWorkspace` and `NSURL` are public, unentitled APIs, so this
+    /// works unchanged inside the App Sandbox — `bundle-mas.sh` ships
+    /// only app-sandbox + user-selected read-only and needs no new
+    /// entitlement for it.  Reached via `class!` + `msg_send!` rather
+    /// than the typed `objc2-app-kit` bindings so no new cargo
+    /// feature is needed, matching [`activate_running_exhale`] above.
+    ///
+    /// `URLWithString:` returns nil for a string AppKit can't parse;
+    /// we null-check rather than passing nil into `openURL:`
+    pub(super) fn open_url_impl(url: &str) {
+        use objc2::msg_send;
+        use objc2::runtime::AnyObject;
+        use objc2_foundation::NSString;
+
+        let s = NSString::from_str(url);
+        unsafe {
+            let ns_url: *mut AnyObject = msg_send![objc2::class!(NSURL), URLWithString: &*s];
+            if ns_url.is_null() {
+                log::warn!("open_url: NSURL rejected {url:?}");
+                return;
+            }
+            let workspace: *mut AnyObject = msg_send![objc2::class!(NSWorkspace), sharedWorkspace];
+            if workspace.is_null() { return; }
+            let opened: bool = msg_send![workspace, openURL: ns_url];
+            if !opened {
+                log::warn!("open_url: NSWorkspace declined to open {url:?}");
+            }
+        }
+    }
+
     // ─── Regression tests for AppKit FFI ──────────────────────────────────
     //
     // Cover the parts of the AppKit surface that can be verified without

--- a/rust/crates/exhale-app/src/platform/win.rs
+++ b/rust/crates/exhale-app/src/platform/win.rs
@@ -269,3 +269,37 @@ use super::*;
             SetWindowLongPtrW(h, GWL_EXSTYLE, ex);
         }
     }
+
+    /// Windows half of [`super::open_url`].  Scheme validation
+    /// happens in the caller, which matters more here than
+    /// elsewhere: `ShellExecuteW` resolves whatever it is handed
+    /// through the shell association table, so a `file:` URL would
+    /// launch a local program.
+    ///
+    /// `Win32_UI_Shell` is already enabled for this crate, so this
+    /// costs no new feature and no new dependency.  The return value
+    /// is an `HINSTANCE`-shaped error code by legacy convention:
+    /// anything `> 32` is success
+    pub(super) fn open_url_impl(url: &str) {
+        use windows_sys::Win32::UI::{
+            Shell::ShellExecuteW,
+            WindowsAndMessaging::SW_SHOWNORMAL,
+        };
+
+        // Both strings have to outlive the call, hence the bindings
+        let file: Vec<u16> = url.encode_utf16().chain(std::iter::once(0)).collect();
+        let verb: Vec<u16> = "open\0".encode_utf16().collect();
+        let rc = unsafe {
+            ShellExecuteW(
+                std::ptr::null_mut(),
+                verb.as_ptr(),
+                file.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                SW_SHOWNORMAL,
+            )
+        };
+        if (rc as isize) <= 32 {
+            log::warn!("open_url: ShellExecuteW failed ({}) for {url:?}", rc as isize);
+        }
+    }

--- a/rust/crates/exhale-app/src/settings_window.rs
+++ b/rust/crates/exhale-app/src/settings_window.rs
@@ -213,24 +213,22 @@ impl SettingsWindow {
         // later (once egui has measured the natural content size) so the
         // window can never extend past the last visible setting.
         //
-        // Default height shows Controls + Appearance + Timing + Randomization
-        // comfortably; the Timers section lives just below the fold so the
-        // user has to scroll to reach it, giving a compact settings surface
-        // without hiding the commonly-tweaked rows.  Saved height (when
-        // present) wins over the default — the user's own resize is always
-        // respected on relaunch.
+        // Default height shows Controls + Appearance + Timing whole, with
+        // the top of Randomization visible so it is obvious there is more
+        // below.  Saved height (when present) wins over the default — the
+        // user's own resize is always respected on relaunch.
         //
-        // Was 796 before the Timing card grew its pacing readout: two
-        // `TextStyle::Small` lines at the default 9 pt, the second of
-        // which wraps to two rows in a 308 pt card, plus the 2 pt lead-in
-        // and the tightened 2 pt inter-line spacing.  ~52 pt, estimated
-        // rather than measured, which is safe in both directions: this
-        // value only picks the FIRST-RUN height, a saved height always
-        // wins, and `set_max_inner_size` clamps the window down to the
-        // content egui actually laid out on the very first frame.  The
-        // property being preserved is the one documented above, that
-        // Randomization is not cut off out of the box
-        const INITIAL_PREFERRED_H: u32 = 848;
+        // The number is unchanged, but what it frames is not.  Measured at
+        // the shipped 308 pt card width, the Timing card went 160 pt ->
+        // 202 pt with the pacing readout -> 324 pt with the preset chips.
+        // Preserving the old fold, which sat below Randomization, would
+        // mean 960 pt: taller than the usable height of a 13-inch display,
+        // so the window would open with its own bottom edge off-screen.
+        // Between "Randomization stays above the fold" and "the window
+        // fits on the machine it opens on", the second wins, and Timing is
+        // now the card worth keeping whole anyway — it is where the
+        // presets, the steppers and the coverage line all live.
+        const INITIAL_PREFERRED_H: u32 = 796;
         // Sanity ceiling on the saved height: no real monitor is taller
         // than this in logical points, so anything above is corrupt
         // (typically from older builds that mistakenly persisted
@@ -1364,6 +1362,11 @@ fn settings_ui(
 
             // ── Timing ───────────────────────────────────────────────────────
             section(ui, "Timing", |ui| {
+                // Above the steppers, not below: the whole point of a
+                // chip is that clicking it visibly moves all four rows
+                // under it, which is not something the user has to be
+                // told if they can watch it happen
+                if preset_chips(ui, settings) { dirty = true; }
                 if duration_row(ui, "Inhale Duration (s)",  "Duration of the inhale phase, in seconds.",             &mut settings.inhale_duration) { dirty = true; }
                 if duration_row(ui, "Post-Inhale Hold (s)", "Hold/pause duration at the end of inhale, in seconds.", &mut settings.post_inhale_hold_duration) { dirty = true; }
                 if duration_row(ui, "Exhale Duration (s)",  "Duration of the exhale phase, in seconds.",             &mut settings.exhale_duration) { dirty = true; }
@@ -1650,6 +1653,201 @@ mod tests {
         let click_pos = target.center();
         run_stepper_frame(ctx, click_input(click_pos), value, "Test")
     }
+
+    /// Content width inside a section card: `SETTINGS_WIDTH` minus the
+    /// outer gutters and the card padding. The chips have to wrap
+    /// against the real number, not a convenient one
+    const CARD_CONTENT_W: f32 = SETTINGS_WIDTH as f32 - 2.0 * OUTER_PAD - 2.0 * CARD_PAD;
+
+    /// Run one frame of `preset_chips` inside a real `section` card.
+    ///
+    /// The card, not a bare `ui.set_width`, because `set_width` on a
+    /// `CentralPanel`'s own `Ui` is silently undone: `Placer::set_max_width`
+    /// unions the result back with `min_rect`, which for a panel is already
+    /// the full panel. The first version of this harness therefore laid the
+    /// chips out at 384 pt and would have passed while the shipped card is
+    /// 308. Going through `section` measures what the app actually renders
+    fn run_chips_frame(
+        ctx:      &Context,
+        raw_in:   RawInput,
+        settings: &mut exhale_core::settings::Settings,
+    ) -> bool {
+        let mut changed = false;
+        let _ = ctx.run(raw_in, |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                section(ui, "Timing", |ui| {
+                    changed = preset_chips(ui, settings);
+                });
+            });
+        });
+        changed
+    }
+
+    fn blank_input() -> RawInput {
+        RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(400.0, 800.0))),
+            ..Default::default()
+        }
+    }
+
+    fn key_input(key: egui::Key) -> RawInput {
+        RawInput {
+            events: vec![egui::Event::Key {
+                key,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: Default::default(),
+            }],
+            ..blank_input()
+        }
+    }
+
+    /// Warm-up frame to register the chip rects, then hand them back.
+    fn chip_rects(ctx: &Context, settings: &mut exhale_core::settings::Settings) -> Vec<Rect> {
+        let mut probe = settings.clone();
+        let _ = run_chips_frame(ctx, blank_input(), &mut probe);
+        super::widgets::test_hooks::take_chip_rects()
+            .expect("preset_chips should record its rects every frame")
+    }
+
+    #[test]
+    fn clicking_a_chip_moves_all_four_durations() {
+        let ctx = Context::default();
+        let mut settings = exhale_core::settings::Settings::default();
+        // The default is the last chip; pick the first, which is a
+        // different pattern in all four fields but one
+        let rects = chip_rects(&ctx, &mut settings);
+        let target = rects[0].center();
+
+        let changed = run_chips_frame(&ctx, click_input(target), &mut settings);
+
+        assert!(changed, "clicking a chip should mark settings dirty");
+        let want = exhale_core::presets::PRESETS[0];
+        assert_eq!(settings.inhale_duration, want.inhale);
+        assert_eq!(settings.post_inhale_hold_duration, want.post_inhale_hold);
+        assert_eq!(settings.exhale_duration, want.exhale);
+        assert_eq!(settings.post_exhale_hold_duration, want.post_exhale_hold);
+        assert_eq!(exhale_core::presets::selected(&settings), Some(0));
+    }
+
+    #[test]
+    fn space_activates_a_focused_chip() {
+        // The handoff flagged this as unverified: it was not known
+        // whether egui 0.29 synthesises a click from Space on a focused
+        // `ui.interact` response the way it does for `Button`. It does
+        // (`Context::create_widget` sets `fake_primary_click`), and
+        // without it the whole feature would be mouse-only, so the
+        // behaviour is pinned here rather than trusted to survive an
+        // egui upgrade
+        let ctx = Context::default();
+        let mut settings = exhale_core::settings::Settings::default();
+
+        // Frame 1 registers the widgets so Tab has somewhere to go
+        let _ = run_chips_frame(&ctx, blank_input(), &mut settings);
+        // Frame 2: Tab focuses the first chip
+        let _ = run_chips_frame(&ctx, key_input(egui::Key::Tab), &mut settings);
+        // Frame 3: Space on the focused chip
+        let changed = run_chips_frame(&ctx, key_input(egui::Key::Space), &mut settings);
+
+        assert!(changed, "Space on a focused chip should activate it");
+        assert_eq!(exhale_core::presets::selected(&settings), Some(0));
+    }
+
+    #[test]
+    fn enter_also_activates_a_focused_chip() {
+        let ctx = Context::default();
+        let mut settings = exhale_core::settings::Settings::default();
+        let _ = run_chips_frame(&ctx, blank_input(), &mut settings);
+        let _ = run_chips_frame(&ctx, key_input(egui::Key::Tab), &mut settings);
+        let changed = run_chips_frame(&ctx, key_input(egui::Key::Enter), &mut settings);
+        assert!(changed);
+        assert_eq!(exhale_core::presets::selected(&settings), Some(0));
+    }
+
+    #[test]
+    fn every_chip_is_reachable_by_tab_in_display_order() {
+        // Focus order follows creation order, so tabbing N times lands
+        // on chip N. A chip that could be clicked but not reached is
+        // half a control
+        for want in 0..exhale_core::presets::PRESETS.len() {
+            let ctx = Context::default();
+            let mut settings = exhale_core::settings::Settings::default();
+            let _ = run_chips_frame(&ctx, blank_input(), &mut settings);
+            for _ in 0..=want {
+                let _ = run_chips_frame(&ctx, key_input(egui::Key::Tab), &mut settings);
+            }
+            let changed = run_chips_frame(&ctx, key_input(egui::Key::Space), &mut settings);
+            assert!(changed, "chip {want} was not reachable in {} tabs", want + 1);
+            assert_eq!(
+                exhale_core::presets::selected(&settings), Some(want),
+                "tabbing {} times activated the wrong chip", want + 1
+            );
+        }
+    }
+
+    #[test]
+    fn chips_wrap_inside_the_card_and_never_overlap() {
+        let ctx = Context::default();
+        let mut settings = exhale_core::settings::Settings::default();
+        let rects = chip_rects(&ctx, &mut settings);
+        assert_eq!(rects.len(), exhale_core::presets::PRESETS.len());
+
+        let left = rects[0].min.x;
+        for (i, r) in rects.iter().enumerate() {
+            // Wrapping, not clipping. A chip wider than the card would
+            // be a label that no longer describes its own pattern
+            assert!(
+                r.width() <= CARD_CONTENT_W + 0.5,
+                "chip {i} is {} wide in a {CARD_CONTENT_W} card", r.width()
+            );
+            assert!(
+                r.max.x <= left + CARD_CONTENT_W + 0.5,
+                "chip {i} overflows the card right edge by {}",
+                r.max.x - (left + CARD_CONTENT_W)
+            );
+        }
+        for (i, a) in rects.iter().enumerate() {
+            for (j, b) in rects.iter().enumerate().skip(i + 1) {
+                assert!(!a.intersects(*b), "chips {i} and {j} overlap");
+            }
+        }
+    }
+
+    #[test]
+    fn nudging_one_stepper_unselects_every_chip() {
+        // Derived selection, stated as a behaviour. There is no
+        // "Custom" chip to light up instead: custom is the absence of
+        // a lit pill
+        let ctx = Context::default();
+        let mut settings = exhale_core::settings::Settings::default();
+        assert!(exhale_core::presets::selected(&settings).is_some());
+
+        settings.exhale_duration += 1.0;
+        assert_eq!(exhale_core::presets::selected(&settings), None);
+
+        // And the frame still renders with nothing selected
+        let _ = run_chips_frame(&ctx, blank_input(), &mut settings);
+    }
+
+    #[test]
+    fn clicking_a_chip_leaves_drift_and_jitter_where_the_user_put_them() {
+        let ctx = Context::default();
+        let mut settings = exhale_core::settings::Settings {
+            drift: 1.001,
+            randomized_timing_exhale: 0.25,
+            ..Default::default()
+        };
+
+        let rects = chip_rects(&ctx, &mut settings);
+        let _ = run_chips_frame(&ctx, click_input(rects[3].center()), &mut settings);
+
+        assert_eq!(exhale_core::presets::selected(&settings), Some(3));
+        assert_eq!(settings.drift, 1.001);
+        assert_eq!(settings.randomized_timing_exhale, 0.25);
+    }
+
+
 
     #[test]
     fn stepper_up_increments() {

--- a/rust/crates/exhale-app/src/settings_window.rs
+++ b/rust/crates/exhale-app/src/settings_window.rs
@@ -1370,10 +1370,23 @@ fn settings_ui(
                 // as a percentage above 1.0 so "1" reads as "+1 % per cycle".
                 // Swift's stepper has no upper limit (`max: nil`).  Minimum
                 // stays at 0 % (drift = 1.0) per the `defaultMin` clamp.
+                //
+                // Step is 0.1 percentage points, not 1: compounding makes whole
+                // percents enormous. From a 15 s cycle, 1 % doubles the breath in
+                // 70 cycles (~25 min), which runs away inside one sitting; 0.1 %
+                // takes 693 cycles (~4.2 h), which is a working day. The useful
+                // range sat entirely below the old minimum step, so whole percents
+                // offered no gentle setting at all. Finer values can still be
+                // typed: `format_num` caps display at three decimals, so 0.001 %
+                // is the finest value the field round-trips.
+                //
+                // Display is `(stored - 1) * 100`, so the user reads 0 for "off"
+                // and never sees the multiplier. One step up from off is 0.1 %,
+                // stored as 1.001. See `ValueScale::DriftPercent`.
                 if stepper_row(
                     ui, "Drift (%)",
-                    "Multiplicative drift per cycle. 1-5% recommended for gradually lengthening breath.",
-                    None, &mut settings.drift, 1.0, 0.0, None,
+                    "Lengthens every cycle by this much, compounding, for pranayama-style graded extension. Off by default. Type a value for finer control than the arrows give.",
+                    None, &mut settings.drift, 0.1, 0.0, None,
                     ValueScale::DriftPercent,
                 ) { dirty = true; }
             });

--- a/rust/crates/exhale-app/src/settings_window.rs
+++ b/rust/crates/exhale-app/src/settings_window.rs
@@ -1812,6 +1812,20 @@ mod tests {
                 assert!(!a.intersects(*b), "chips {i} and {j} overlap");
             }
         }
+
+        // The five shipped labels fit one row on macOS with 11 pt to
+        // spare, but text metrics differ per platform, so the assertion
+        // is the property worth keeping rather than the exact result: a
+        // sixth preset, or a label long enough to need three rows, turns
+        // the block back into the four-line stack this was tightened to
+        // avoid. Wrapping to a second row is fine; wrapping past it is a
+        // design decision that should be made on purpose
+        let rows = rects.iter().map(|r| r.min.y as i32).collect::<std::collections::BTreeSet<_>>();
+        assert!(
+            rows.len() <= 2,
+            "preset chips need {} rows; the Timing card was tuned for one or two",
+            rows.len()
+        );
     }
 
     #[test]
@@ -1846,6 +1860,9 @@ mod tests {
         assert_eq!(settings.drift, 1.001);
         assert_eq!(settings.randomized_timing_exhale, 0.25);
     }
+
+
+
 
 
 

--- a/rust/crates/exhale-app/src/settings_window.rs
+++ b/rust/crates/exhale-app/src/settings_window.rs
@@ -219,7 +219,18 @@ impl SettingsWindow {
         // without hiding the commonly-tweaked rows.  Saved height (when
         // present) wins over the default — the user's own resize is always
         // respected on relaunch.
-        const INITIAL_PREFERRED_H: u32 = 796;
+        //
+        // Was 796 before the Timing card grew its pacing readout: two
+        // `TextStyle::Small` lines at the default 9 pt, the second of
+        // which wraps to two rows in a 308 pt card, plus the 2 pt lead-in
+        // and the tightened 2 pt inter-line spacing.  ~52 pt, estimated
+        // rather than measured, which is safe in both directions: this
+        // value only picks the FIRST-RUN height, a saved height always
+        // wins, and `set_max_inner_size` clamps the window down to the
+        // content egui actually laid out on the very first frame.  The
+        // property being preserved is the one documented above, that
+        // Randomization is not cut off out of the box
+        const INITIAL_PREFERRED_H: u32 = 848;
         // Sanity ceiling on the saved height: no real monitor is taller
         // than this in logical points, so anything above is corrupt
         // (typically from older builds that mistakenly persisted
@@ -1357,6 +1368,14 @@ fn settings_ui(
                 if duration_row(ui, "Post-Inhale Hold (s)", "Hold/pause duration at the end of inhale, in seconds.", &mut settings.post_inhale_hold_duration) { dirty = true; }
                 if duration_row(ui, "Exhale Duration (s)",  "Duration of the exhale phase, in seconds.",             &mut settings.exhale_duration) { dirty = true; }
                 if duration_row(ui, "Post-Exhale Hold (s)", "Hold/pause duration at the end of exhale, in seconds.", &mut settings.post_exhale_hold_duration) { dirty = true; }
+                // Computed from the four rows above, every frame.  A
+                // rate stored anywhere else would be wrong the moment
+                // one stepper moves, and wrong from the first cycle
+                // whenever Drift is on.  Drift lives in the
+                // Randomization card below, so its projection is
+                // reported here where the cycle it lengthens is
+                // defined, rather than duplicated under the stepper
+                pacing_readout(ui, settings);
             });
 
             // ── Randomization ────────────────────────────────────────────────

--- a/rust/crates/exhale-app/src/settings_window.rs
+++ b/rust/crates/exhale-app/src/settings_window.rs
@@ -1394,10 +1394,12 @@ fn settings_ui(
                 // stays at 0 % (drift = 1.0) per the `defaultMin` clamp.
                 //
                 // Step is 0.1 percentage points, not 1: compounding makes whole
-                // percents enormous. From a 15 s cycle, 1 % doubles the breath in
-                // 70 cycles (~25 min), which runs away inside one sitting; 0.1 %
-                // takes 693 cycles (~4.2 h), which is a working day. The useful
-                // range sat entirely below the old minimum step, so whole percents
+                // percents enormous. 1 % doubles the breath in 70 breaths, which
+                // runs away inside one sitting; 0.1 % takes 693, which is a
+                // working day. Counted in breaths rather than minutes because
+                // `d^k = 2` has no cycle length in it, so the figure holds
+                // whatever the four steppers above are set to. The useful range
+                // sat entirely below the old minimum step, so whole percents
                 // offered no gentle setting at all. Finer values can still be
                 // typed: `format_num` caps display at three decimals, so 0.001 %
                 // is the finest value the field round-trips.
@@ -1715,20 +1717,26 @@ mod tests {
     fn clicking_a_chip_moves_all_four_durations() {
         let ctx = Context::default();
         let mut settings = exhale_core::settings::Settings::default();
-        // The default is the last chip; pick the first, which is a
-        // different pattern in all four fields but one
+        // Deliberately NOT chip 0: that is the shipped default, so
+        // clicking it would leave every field at the value it already
+        // had and the test would pass without proving anything moved.
+        // Chip 3 is box breathing, which differs in all four
+        const TARGET: usize = 3;
         let rects = chip_rects(&ctx, &mut settings);
-        let target = rects[0].center();
+        assert_eq!(
+            exhale_core::presets::selected(&settings), Some(0),
+            "this test assumes the default is chip 0 and the target is not"
+        );
 
-        let changed = run_chips_frame(&ctx, click_input(target), &mut settings);
+        let changed = run_chips_frame(&ctx, click_input(rects[TARGET].center()), &mut settings);
 
         assert!(changed, "clicking a chip should mark settings dirty");
-        let want = exhale_core::presets::PRESETS[0];
+        let want = exhale_core::presets::PRESETS[TARGET];
         assert_eq!(settings.inhale_duration, want.inhale);
         assert_eq!(settings.post_inhale_hold_duration, want.post_inhale_hold);
         assert_eq!(settings.exhale_duration, want.exhale);
         assert_eq!(settings.post_exhale_hold_duration, want.post_exhale_hold);
-        assert_eq!(exhale_core::presets::selected(&settings), Some(0));
+        assert_eq!(exhale_core::presets::selected(&settings), Some(TARGET));
     }
 
     #[test]

--- a/rust/crates/exhale-app/src/settings_window/widgets.rs
+++ b/rust/crates/exhale-app/src/settings_window/widgets.rs
@@ -743,6 +743,50 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 
 /// Duration row (seconds). Swift's CombinedStepperTextField with `limits: (0, nil)`
 /// and step 1.0 — so the ±-button step matches the Stepper control on macOS.
+/// The pacing readout: what the current timing settings actually work
+/// out to, and how that sits against the range with direct
+/// experimental support.
+///
+/// Every string comes from [`exhale_core::pacing::readout_lines`],
+/// which is where the copy is tested. This function only paints.
+///
+/// Rendered unprompted, never behind a hover or a disclosure triangle.
+/// The reason is specific rather than stylistic: exhale's shipped
+/// default is 4.0 breaths a minute, below the tested range, and a
+/// disclosure only reaches the people who go looking. The default is
+/// imposed on everyone who never opens this panel at all, so the one
+/// place it can honestly be qualified is the first place it is shown.
+///
+/// A tooltip could not carry this either. `egui`'s tooltip width
+/// clamps to `ctx.screen_rect()`, which here is a 360 pt window, so
+/// anything this long truncates
+pub(super) fn pacing_readout(ui: &mut egui::Ui, settings: &exhale_core::settings::Settings) {
+    let lines = exhale_core::pacing::readout_lines(settings);
+    if lines.is_empty() {
+        return;
+    }
+    ui.add_space(2.0);
+    // Scoped so the tighter spacing does not leak into the rest of the
+    // card. `section` sets `item_spacing.y = ROW_GAP` for control rows,
+    // which is right between a slider and the next slider and wrong
+    // between two sentences: at 8 pt these read as three unrelated
+    // statements rather than one paragraph
+    ui.scope(|ui| {
+        ui.spacing_mut().item_spacing.y = 2.0;
+        for line in lines {
+            // Wrapping, not truncating. `paint_label_with_width` sets
+            // `max_rows: 1` with an ellipsis, which is right for a
+            // control label in a fixed column and wrong for a sentence
+            // whose second half is the qualification
+            ui.label(
+                egui::RichText::new(line)
+                    .small()
+                    .color(ui.visuals().weak_text_color()),
+            );
+        }
+    });
+}
+
 pub(super) fn duration_row(ui: &mut egui::Ui, label: &str, help: &str, value: &mut f64) -> bool {
     stepper_row(ui, label, help, None, value, 1.0, 0.0, None, ValueScale::Identity)
 }

--- a/rust/crates/exhale-app/src/settings_window/widgets.rs
+++ b/rust/crates/exhale-app/src/settings_window/widgets.rs
@@ -796,14 +796,31 @@ pub(super) fn preset_chips(
     let current     = selected(settings);
     let font_id     = egui::TextStyle::Button.resolve(ui.style());
 
-    const CHIP_PAD_X:  f32 = 10.0;
-    const CHIP_GAP:    f32 = 6.0;
+    // 7 and 5, which look arbitrary and are not. Measured at the shipped
+    // 308 pt card width with the four-number labels, the five chips come
+    // to 297 pt at these values and 331 pt at a roomier 10 and 6, so the
+    // difference between them is whether the last chip sits in the row or
+    // alone underneath it. Nothing breaks if a future label pushes past
+    // the width: the wrap below is the fallback and simply gives back the
+    // second row
+    const CHIP_PAD_X:  f32 = 7.0;
+    const CHIP_GAP:    f32 = 5.0;
     const CHIP_ROW_GAP: f32 = 6.0;
     const INSET:       f32 = 2.0;
     const ROUNDING:    f32 = 5.0;
 
+    // Heading and caption share one line. Two separate lines put four
+    // rows of chrome above four steppers, and the caption's line
+    // appearing and vanishing as the selection changed made the whole
+    // card jump. Merged, the row is a fixed height and reads as one
+    // caption for the group
+    let mut heading = String::from("Presets");
+    if let Some(note) = current.and_then(|i| PRESETS[i].note) {
+        heading.push(' ');
+        heading.push_str(note);
+    }
     ui.label(
-        egui::RichText::new("Presets")
+        egui::RichText::new(heading)
             .small()
             .color(ui.visuals().weak_text_color()),
     );
@@ -934,17 +951,6 @@ pub(super) fn preset_chips(
         egui::Rect::from_min_size(origin, egui::vec2(avail, total_h)),
         egui::Sense::hover(),
     );
-
-    // A name, never a claim. What the pattern DOES is answered live by
-    // `pacing_readout` a few rows down, for whichever chip is lit, which
-    // is why no chip carries an evidentiary caption of its own
-    if let Some(note) = current.and_then(|i| PRESETS[i].note) {
-        ui.label(
-            egui::RichText::new(note)
-                .small()
-                .color(ui.visuals().weak_text_color()),
-        );
-    }
 
     #[cfg(test)]
     test_hooks::record_chip_rects(rects);

--- a/rust/crates/exhale-app/src/settings_window/widgets.rs
+++ b/rust/crates/exhale-app/src/settings_window/widgets.rs
@@ -25,11 +25,7 @@ pub(super) fn section(ui: &mut egui::Ui, header: &str, add_contents: impl FnOnce
     // NSVisualEffectView's popover/hudWindow material, this gives
     // Swift's "dark dark gray" card in dark mode and a translucent
     // white card in light mode.
-    let fill = if dark_mode {
-        egui::Color32::from_rgba_unmultiplied(30, 30, 30, 140)
-    } else {
-        egui::Color32::from_rgba_unmultiplied(255, 255, 255, 140)
-    };
+    let fill = card_fill(dark_mode);
     // Constrain the card to exactly the scroll area's viewport width so every
     // section (Controls, Appearance, Timing, Randomization, Timers) aligns at
     // the same left and right gutters.
@@ -409,6 +405,42 @@ pub(super) const BUTTON_RADIUS:    f32 = 7.0;
 // `visuals_for_theme` and nothing else, no reason to expose it here)
 pub(super) const STEPPER_FIELD_W:  f32 = 56.0;
 
+/// macOS-native selection pill: a slightly inset rounded rect filled in
+/// gray (lighter than the container in dark mode, near-white in light
+/// mode), matching AppKit's `NSSegmentedControl`
+/// `.selectedContentBackground`.
+///
+/// Shared by the segmented pickers and the preset chips so there is one
+/// selected colour in the window rather than two that drift apart, and
+/// so the contrast test in this file covers both. It is measured rather
+/// than eyeballed: see `selected_pill_text_meets_wcag_aa`
+/// Translucent `SectionCard` fill, composited over the platform
+/// vibrancy backdrop. Hoisted out of [`section`] so the contrast test
+/// can composite against the real value rather than a guess at it
+pub(super) fn card_fill(dark_mode: bool) -> egui::Color32 {
+    if dark_mode {
+        egui::Color32::from_rgba_unmultiplied(30, 30, 30, 140)
+    } else {
+        egui::Color32::from_rgba_unmultiplied(255, 255, 255, 140)
+    }
+}
+
+pub(super) fn selected_pill_fill(dark_mode: bool) -> egui::Color32 {
+    if dark_mode {
+        // ~rgb(110,110,110) at 90% — reads as a clear lighter gray over
+        // the dark vibrancy without going washed-out.
+        egui::Color32::from_rgba_unmultiplied(110, 110, 110, 230)
+    } else {
+        // Near-white selection on a light translucent backdrop.
+        egui::Color32::from_rgba_unmultiplied(255, 255, 255, 235)
+    }
+}
+
+/// Text painted on top of [`selected_pill_fill`].
+pub(super) fn selected_pill_text(dark_mode: bool) -> egui::Color32 {
+    if dark_mode { egui::Color32::WHITE } else { egui::Color32::BLACK }
+}
+
 
 /// Measure every segmented picker in a single frame and return the largest
 /// natural column width across them.  Buttons within a single picker get
@@ -593,19 +625,7 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
             }
             ui.spacing_mut().button_padding = egui::vec2(0.0, 0.0);
 
-            // macOS-native segmented picker selection: a slightly inset
-            // rounded rect filled in gray (lighter than the picker container
-            // in dark mode, near-white in light mode) — matches AppKit's
-            // NSSegmentedControl `.selectedContentBackground`.
-            let selected_fill = if dark_mode {
-                // ~rgb(110,110,110) at 90% — reads as a clear lighter gray
-                // over the dark vibrancy without going washed-out.
-                egui::Color32::from_rgba_unmultiplied(110, 110, 110, 230)
-            } else {
-                // Near-white selection on a light translucent backdrop —
-                // matches the macOS native picker "selected" pill.
-                egui::Color32::from_rgba_unmultiplied(255, 255, 255, 235)
-            };
+            let selected_fill = selected_pill_fill(dark_mode);
             const SELECTED_INSET:    f32 = 2.0;
             const SELECTED_ROUNDING: f32 = 5.0;
 
@@ -691,7 +711,7 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 
                 // Selected text flips to primary; unselected uses default text color.
                 let label_color = if is_selected {
-                    if dark_mode { egui::Color32::WHITE } else { egui::Color32::BLACK }
+                    selected_pill_text(dark_mode)
                 } else {
                     ui.visuals().text_color()
                 };
@@ -743,6 +763,195 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 
 /// Duration row (seconds). Swift's CombinedStepperTextField with `limits: (0, nil)`
 /// and step 1.0 — so the ±-button step matches the Stepper control on macOS.
+/// Preset chips: one click that moves all four Timing steppers at once.
+///
+/// Lives inside the Timing card, directly above the steppers it writes,
+/// so the effect of a click is visible in the same glance rather than
+/// having to be believed.
+///
+/// **Selection is derived, never stored.** Which chip is lit comes from
+/// comparing the four durations in `Settings` against each preset, with
+/// the epsilon `SettingsDiff::from` uses on those same fields. There is
+/// no sixth "selected preset" field, so there is nothing to migrate,
+/// nothing to desync, and nothing that can be stale after the user
+/// nudges a stepper by hand: the chip simply goes out.
+///
+/// **There is no "Custom" chip.** Custom is the absence of a lit pill.
+/// A chip that does nothing when clicked is still a Tab stop, and this
+/// file already documents that hazard twice.
+///
+/// Laid out by hand rather than with `ui.horizontal_wrapped` because
+/// the pill chrome has to be painted UNDER the label, which means every
+/// rect has to be known before anything is drawn. Same technique as
+/// `segmented_row`, which is also why the focus halo, the hover fill
+/// and the selected colour are literally the same code
+pub(super) fn preset_chips(
+    ui:       &mut egui::Ui,
+    settings: &mut exhale_core::settings::Settings,
+) -> bool {
+    use exhale_core::presets::{selected, PRESETS};
+
+    let mut changed = false;
+    let dark_mode   = ui.visuals().dark_mode;
+    let current     = selected(settings);
+    let font_id     = egui::TextStyle::Button.resolve(ui.style());
+
+    const CHIP_PAD_X:  f32 = 10.0;
+    const CHIP_GAP:    f32 = 6.0;
+    const CHIP_ROW_GAP: f32 = 6.0;
+    const INSET:       f32 = 2.0;
+    const ROUNDING:    f32 = 5.0;
+
+    ui.label(
+        egui::RichText::new("Presets")
+            .small()
+            .color(ui.visuals().weak_text_color()),
+    );
+
+    // Lay the text out once, with `PLACEHOLDER` so the same galley can be
+    // painted in either the selected or the unselected colour: egui
+    // substitutes the fallback colour passed to `Painter::galley` for
+    // every `PLACEHOLDER` glyph
+    let galleys: Vec<_> = PRESETS
+        .iter()
+        .map(|p| {
+            ui.painter().layout_no_wrap(
+                p.label.to_string(),
+                font_id.clone(),
+                egui::Color32::PLACEHOLDER,
+            )
+        })
+        .collect();
+
+    // Wrap into rows. Never truncate: a clipped pattern label is a
+    // different pattern, and `paint_label_with_width`'s single-row
+    // ellipsis is exactly the wrong tool here
+    let avail  = ui.available_width();
+    let origin = ui.cursor().min;
+    let mut rects: Vec<egui::Rect> = Vec::with_capacity(PRESETS.len());
+    let (mut x, mut y) = (origin.x, origin.y);
+    for galley in &galleys {
+        let w = galley.size().x + 2.0 * CHIP_PAD_X;
+        if x > origin.x && x + w > origin.x + avail {
+            x = origin.x;
+            y += ROW_H + CHIP_ROW_GAP;
+        }
+        rects.push(egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(w, ROW_H)));
+        x += w + CHIP_GAP;
+    }
+    let total_h = (y + ROW_H) - origin.y;
+
+    for (i, preset) in PRESETS.iter().enumerate() {
+        let rect = rects[i];
+        let is_selected = current == Some(i);
+
+        // Interact before painting, so hover and press states are known
+        // by the time the pill goes down under the text
+        let resp = ui.interact(
+            rect,
+            ui.id().with("preset").with(preset.id),
+            egui::Sense::click(),
+        );
+        // Tab landing on a chip scrolled out of view would otherwise
+        // look like the key did nothing. Same nudge as `segmented_row`
+        if resp.gained_focus() {
+            resp.scroll_to_me(None);
+        }
+
+        let pill_fill: Option<egui::Color32> = if is_selected {
+            Some(selected_pill_fill(dark_mode))
+        } else if resp.is_pointer_button_down_on() {
+            Some(if dark_mode {
+                egui::Color32::from_white_alpha(36)
+            } else {
+                egui::Color32::from_black_alpha(30)
+            })
+        } else if resp.hovered() {
+            Some(if dark_mode {
+                egui::Color32::from_white_alpha(22)
+            } else {
+                egui::Color32::from_black_alpha(18)
+            })
+        } else {
+            None
+        };
+        let pill = rect.shrink(INSET);
+        if let Some(fill) = pill_fill {
+            ui.painter().rect_filled(pill, ROUNDING, fill);
+        } else {
+            // Unselected chips need a visible edge. The pickers get one
+            // from the container outline around the whole control; a
+            // wrapped chip row has no container, so without this an
+            // unselected chip is bare text and does not read as
+            // clickable at all
+            ui.painter().rect_stroke(
+                pill,
+                ROUNDING,
+                egui::Stroke::new(1.0, ui.visuals().widgets.noninteractive.bg_stroke.color),
+            );
+        }
+
+        if resp.has_focus() {
+            let primary = if dark_mode { egui::Color32::WHITE } else { egui::Color32::BLACK };
+            let with_alpha = |a: u8| egui::Color32::from_rgba_unmultiplied(
+                primary.r(), primary.g(), primary.b(), a,
+            );
+            for (offset, alpha) in [(0.0_f32, 140_u8), (1.5_f32, 70_u8), (3.0_f32, 28_u8)] {
+                ui.painter().rect_stroke(
+                    pill.expand(offset),
+                    ROUNDING + offset,
+                    egui::Stroke::new(1.0, with_alpha(alpha)),
+                );
+            }
+        }
+
+        let label_color = if is_selected {
+            selected_pill_text(dark_mode)
+        } else {
+            ui.visuals().text_color()
+        };
+        let galley = galleys[i].clone();
+        let text_pos = egui::pos2(
+            rect.center().x - galley.size().x * 0.5,
+            rect.center().y - galley.size().y * 0.5,
+        );
+        ui.painter().galley(text_pos, galley, label_color);
+
+        // Space and Enter reach here too: egui 0.29 sets
+        // `fake_primary_click` on any focused `Sense::click` response,
+        // and `clicked()` folds that in. Covered by
+        // `space_activates_a_focused_chip`
+        if resp.clicked() {
+            preset.apply(settings);
+            changed = true;
+        }
+    }
+
+    // Reserve the space the chips occupy. `ui.painter()` draws without
+    // advancing the cursor, so without this the duration rows below
+    // would be laid out on top of them
+    let _ = ui.allocate_rect(
+        egui::Rect::from_min_size(origin, egui::vec2(avail, total_h)),
+        egui::Sense::hover(),
+    );
+
+    // A name, never a claim. What the pattern DOES is answered live by
+    // `pacing_readout` a few rows down, for whichever chip is lit, which
+    // is why no chip carries an evidentiary caption of its own
+    if let Some(note) = current.and_then(|i| PRESETS[i].note) {
+        ui.label(
+            egui::RichText::new(note)
+                .small()
+                .color(ui.visuals().weak_text_color()),
+        );
+    }
+
+    #[cfg(test)]
+    test_hooks::record_chip_rects(rects);
+
+    changed
+}
+
 /// The pacing readout: what the current timing settings actually work
 /// out to, and how that sits against the range with direct
 /// experimental support.
@@ -1354,6 +1563,25 @@ pub(super) mod test_hooks {
     pub fn take_stepper_rects() -> Option<(egui::Rect, egui::Rect)> {
         LAST.with(|c| c.borrow_mut().take())
     }
+
+    // Unlike the stepper hook above, the chip hook is `cfg(test)`: it is
+    // written on every frame the chips are laid out, and a thread-local
+    // borrow plus a Vec clone per frame is not worth paying for in a
+    // release build to support a test
+    #[cfg(test)]
+    thread_local! {
+        static CHIPS: RefCell<Option<Vec<egui::Rect>>> = const { RefCell::new(None) };
+    }
+
+    #[cfg(test)]
+    pub fn record_chip_rects(rects: Vec<egui::Rect>) {
+        CHIPS.with(|c| *c.borrow_mut() = Some(rects));
+    }
+
+    #[cfg(test)]
+    pub fn take_chip_rects() -> Option<Vec<egui::Rect>> {
+        CHIPS.with(|c| c.borrow_mut().take())
+    }
 }
 
 #[cfg(test)]
@@ -1373,6 +1601,135 @@ mod tests {
             ValueScale::Identity     => "Identity",
             ValueScale::Percent      => "Percent",
             ValueScale::DriftPercent => "DriftPercent",
+        }
+    }
+
+    /// sRGB relative luminance, WCAG 2.1 definition.
+    fn luminance(c: egui::Color32) -> f64 {
+        let f = |v: u8| {
+            let v = v as f64 / 255.0;
+            if v <= 0.040_45 { v / 12.92 } else { ((v + 0.055) / 1.055).powf(2.4) }
+        };
+        0.2126 * f(c.r()) + 0.7152 * f(c.g()) + 0.0722 * f(c.b())
+    }
+
+    fn contrast(a: egui::Color32, b: egui::Color32) -> f64 {
+        let (x, y) = (luminance(a), luminance(b));
+        let (hi, lo) = if x > y { (x, y) } else { (y, x) };
+        (hi + 0.05) / (lo + 0.05)
+    }
+
+    /// Source-over composite of `fg` (with alpha) onto opaque `bg`.
+    fn over(fg: egui::Color32, bg: egui::Color32) -> egui::Color32 {
+        // `Color32::from_rgba_unmultiplied` stores premultiplied bytes, so
+        // read the alpha back out and un-premultiply before compositing,
+        // or the result is wrong in exactly the direction that flatters
+        let a = fg.a() as f64 / 255.0;
+        let ch = |f: u8, b: u8| {
+            let straight = if a > 0.0 { (f as f64 / 255.0) / a } else { 0.0 };
+            ((straight * a + (b as f64 / 255.0) * (1.0 - a)) * 255.0).round() as u8
+        };
+        egui::Color32::from_rgb(ch(fg.r(), bg.r()), ch(fg.g(), bg.g()), ch(fg.b(), bg.b()))
+    }
+
+    #[test]
+    fn selected_pill_text_meets_wcag_aa_over_any_backdrop() {
+        // The handoff estimated the dark-mode selected pill at ~4.0:1,
+        // under the 4.5:1 AA threshold for body-size text, and asked for
+        // a measurement. Measured, it clears: the pill is drawn at alpha
+        // 230, so what shows through the card and the vibrancy behind it
+        // moves the result by less than a point of contrast.
+        //
+        // Swept across every possible backdrop rather than one assumed
+        // desktop grey, because the vibrancy material composites against
+        // whatever is behind the window and nobody controls that. Both
+        // segmented pickers and preset chips use these colours, so this
+        // covers both
+        for dark_mode in [true, false] {
+            let text = selected_pill_text(dark_mode);
+            let (mut worst, mut worst_bg) = (f64::INFINITY, 0u8);
+            for b in 0..=255u8 {
+                let backdrop = egui::Color32::from_gray(b);
+                let card = over(card_fill(dark_mode), backdrop);
+                let pill = over(selected_pill_fill(dark_mode), card);
+                let c = contrast(text, pill);
+                if c < worst {
+                    worst = c;
+                    worst_bg = b;
+                }
+            }
+            assert!(
+                worst >= 4.5,
+                "dark_mode={dark_mode}: selected pill text is {worst:.2}:1 over backdrop \
+                 gray {worst_bg}, below the 4.5:1 AA threshold"
+            );
+        }
+    }
+
+    #[test]
+    fn chip_text_meets_wcag_aa_on_the_backdrop_the_app_controls() {
+        // With blur unavailable (older Windows, GNOME, EXHALE_DISABLE_BLUR)
+        // the window is opaque and `clear_color_for_theme` picks the
+        // backdrop, so this is a contrast floor exhale can actually
+        // promise rather than one that depends on the wallpaper
+        for (dark_mode, clear) in [
+            (true,  egui::Color32::from_gray((0.12 * 255.0) as u8)),
+            (false, egui::Color32::from_gray((0.96 * 255.0) as u8)),
+        ] {
+            let card = over(card_fill(dark_mode), clear);
+            let body = if dark_mode {
+                egui::Color32::from_rgb(235, 235, 240)
+            } else {
+                egui::Color32::from_rgb(20, 20, 22)
+            };
+            assert!(
+                contrast(body, card) >= 4.5,
+                "dark_mode={dark_mode}: unselected chip text is {:.2}:1 on the opaque backdrop",
+                contrast(body, card)
+            );
+            let pill = over(selected_pill_fill(dark_mode), card);
+            assert!(
+                contrast(selected_pill_text(dark_mode), pill) >= 4.5,
+                "dark_mode={dark_mode}: selected chip text is {:.2}:1 on the opaque backdrop",
+                contrast(selected_pill_text(dark_mode), pill)
+            );
+        }
+    }
+
+    #[test]
+    fn unselected_chip_text_holds_up_wherever_the_vibrancy_can_land() {
+        // Unselected chips paint `visuals().text_color()` directly on the
+        // translucent card, so unlike the selected pill they inherit
+        // whatever the OS blur composites behind the window.
+        //
+        // The bound swept here is that the material does not invert: a
+        // dark material never renders lighter than mid-grey and a light
+        // one never renders darker. That is what "dark material" means,
+        // and it is the strongest honest assumption available from
+        // inside the process, since `NSVisualEffectView` gives back no
+        // sampled colour to test against.
+        //
+        // Past that bound the guarantee does lapse: near-white behind a
+        // dark-mode window measures about 3.0:1. That is a property of
+        // every `ui.label` in this window rather than anything the chips
+        // introduced, and it is the same accessibility debt as the
+        // missing AccessKit tree. Recorded here so it is a known number
+        // instead of a surprise
+        for (dark_mode, range) in [(true, 0..=128u8), (false, 128..=255u8)] {
+            let text = if dark_mode {
+                egui::Color32::from_rgb(235, 235, 240)
+            } else {
+                egui::Color32::from_rgb(20, 20, 22)
+            };
+            let mut worst = f64::INFINITY;
+            for b in range {
+                let card = over(card_fill(dark_mode), egui::Color32::from_gray(b));
+                worst = worst.min(contrast(text, card));
+            }
+            assert!(
+                worst >= 4.5,
+                "dark_mode={dark_mode}: unselected chip text bottoms out at {worst:.2}:1"
+            );
         }
     }
 

--- a/rust/crates/exhale-app/src/settings_window/widgets.rs
+++ b/rust/crates/exhale-app/src/settings_window/widgets.rs
@@ -966,11 +966,14 @@ pub(super) fn preset_chips(
 /// which is where the copy is tested. This function only paints.
 ///
 /// Rendered unprompted, never behind a hover or a disclosure triangle.
-/// The reason is specific rather than stylistic: exhale's shipped
-/// default is 4.0 breaths a minute, below the tested range, and a
-/// disclosure only reaches the people who go looking. The default is
-/// imposed on everyone who never opens this panel at all, so the one
-/// place it can honestly be qualified is the first place it is shown.
+/// The reason is specific rather than stylistic. A disclosure reaches
+/// only the people who go looking, and the settings most in need of a
+/// coverage note are the ones a user picks *without* reading anything:
+/// box breathing works out to 3.8 a minute, below the tested range, and
+/// looks gentler than it is because the holds hide the arithmetic.
+/// A line that appears only when the news is bad is a line nobody
+/// trusts, so it appears always, including for the default, which it
+/// reports as inside the range.
 ///
 /// A tooltip could not carry this either. `egui`'s tooltip width
 /// clamps to `ctx.screen_rect()`, which here is a 360 pt window, so

--- a/rust/crates/exhale-app/src/settings_window/widgets.rs
+++ b/rust/crates/exhale-app/src/settings_window/widgets.rs
@@ -1356,6 +1356,34 @@ mod tests {
         assert!((ValueScale::DriftPercent.from_display(0.0) - 1.0).abs() < 1e-9);
     }
 
+    /// The Drift row shows a percentage, never the multiplier it stores.
+    /// Zero must mean "no drift" so that "off" is legible without the user
+    /// knowing anything about how it is stored, and one 0.1 step up from off
+    /// must land on 1.001 rather than anything coarser.
+    #[test]
+    fn drift_zero_is_off_and_one_step_is_a_tenth_of_a_percent() {
+        const STEP: f64 = 0.1; // matches the Drift stepper_row in settings_window.rs
+
+        // Off: the user sees 0, the controller multiplies by 1.0, a no-op
+        assert_eq!(ValueScale::DriftPercent.from_display(0.0), 1.0);
+        assert_eq!(ValueScale::DriftPercent.to_display(1.0), 0.0);
+
+        // One press of the up arrow from off
+        let after_one = ValueScale::DriftPercent.from_display(0.0 + STEP);
+        assert!(
+            (after_one - 1.001).abs() < 1e-12,
+            "one 0.1 % step should store 1.001, got {after_one}"
+        );
+
+        // And it keeps stepping in tenths rather than snapping to whole percents
+        let after_two = ValueScale::DriftPercent.from_display(0.0 + STEP * 2.0);
+        assert!((after_two - 1.002).abs() < 1e-12, "two steps should store 1.002, got {after_two}");
+
+        // Ten steps reaches the old minimum, 1 %
+        let after_ten = ValueScale::DriftPercent.from_display(0.0 + STEP * 10.0);
+        assert!((after_ten - 1.01).abs() < 1e-12, "ten steps should store 1.01, got {after_ten}");
+    }
+
     #[test]
     fn round_trips_at_sample_points() {
         for stored in [0.0, 0.1, 0.5, 1.0, 1.01, 2.5, 5.0, 100.0] {

--- a/rust/crates/exhale-app/src/tray.rs
+++ b/rust/crates/exhale-app/src/tray.rs
@@ -24,9 +24,13 @@ pub const RESEARCH_URL: &str =
     "https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md#gaps-and-unsupported-choices";
 
 /// Named next to the URL because the wording and the anchor are one
-/// decision.  "Citations" would promise a bibliography; this promises
-/// the limits, which is what the destination actually leads with
-const RESEARCH_LABEL: &str = "Research, and what it doesn't support";
+/// decision.  The label is plain, so the anchor carries the whole
+/// intent: "Research" pointing at the gaps ledger lands the reader on
+/// the fourteen things the literature does not support, where the same
+/// word pointing at the top of `CITATIONS.md` would land them in a wall
+/// of 48 references.  Shared with the macOS app menu, which shows the
+/// same item, so the two can never disagree
+pub const RESEARCH_LABEL: &str = "Research";
 
 // ─── Menu item IDs ────────────────────────────────────────────────────────────
 

--- a/rust/crates/exhale-app/src/tray.rs
+++ b/rust/crates/exhale-app/src/tray.rs
@@ -5,10 +5,34 @@ use tray_icon::{
     TrayIcon, TrayIconBuilder,
 };
 
+// ─── Research link ────────────────────────────────────────────────────────────
+
+/// Deep link into the gaps ledger, not the top of the citation list.
+///
+/// Landing the reader on 48 references reads as a wall of authority;
+/// landing them on the fourteen things the literature does *not*
+/// support is the same click with the opposite effect.  The anchor is
+/// as much the feature as the menu item is, so both are pinned here
+/// together and `scripts/generate-citations.py` validates that this
+/// heading still exists.
+///
+/// Pinned to `main` rather than a release tag on purpose.  A binary
+/// stays installed long after its tag stops being the current state
+/// of the evidence, and a retraction has to reach the people running
+/// old builds.  A moved anchor is a CI failure; a stale claim is not
+pub const RESEARCH_URL: &str =
+    "https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md#gaps-and-unsupported-choices";
+
+/// Named next to the URL because the wording and the anchor are one
+/// decision.  "Citations" would promise a bibliography; this promises
+/// the limits, which is what the destination actually leads with
+const RESEARCH_LABEL: &str = "Research, and what it doesn't support";
+
 // ─── Menu item IDs ────────────────────────────────────────────────────────────
 
 pub struct TrayMenuIds {
     pub preferences: tray_icon::menu::MenuId,
+    pub research:    tray_icon::menu::MenuId,
     pub start:       tray_icon::menu::MenuId,
     pub stop:        tray_icon::menu::MenuId,
     pub reset:       tray_icon::menu::MenuId,
@@ -21,6 +45,10 @@ pub struct TrayMenuIds {
     // when the user changes a shortcut, instead of rebuilding the
     // whole tray
     pub preferences_item: MenuItem,
+    // No binding is embedded in this one's label, so `refresh_labels`
+    // never touches it; the handle is kept only so the menu owns it
+    // for as long as the tray lives
+    pub research_item:    MenuItem,
     pub reset_item:       MenuItem,
     pub quit_item:        MenuItem,
     // ── "Keyboard Shortcuts ▶" submenu ────────────────────────────────────────
@@ -140,6 +168,7 @@ pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuId
     let start_item = MenuItem::new(top_level_label("Start Animation",   shortcuts.get(ShortcutAction::Start)),       true, None);
     let stop_item  = MenuItem::new(top_level_label("Stop Animation",    shortcuts.get(ShortcutAction::Stop)),        true, None);
     let reset_item = MenuItem::new(top_level_label("Reset to Defaults", shortcuts.get(ShortcutAction::Reset)),       true, None);
+    let research_item = MenuItem::new(RESEARCH_LABEL, true, None);
     let quit_item  = MenuItem::new(top_level_label("Quit exhale",       shortcuts.get(ShortcutAction::Quit)),        true, None);
 
     // ── Keyboard Shortcuts submenu ────────────────────────────────────────────
@@ -159,6 +188,7 @@ pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuId
 
     let ids = TrayMenuIds {
         preferences: prefs_item.id().clone(),
+        research:    research_item.id().clone(),
         start:       start_item.id().clone(),
         stop:        stop_item.id().clone(),
         reset:       reset_item.id().clone(),
@@ -171,6 +201,7 @@ pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuId
         start_item,
         stop_item,
         preferences_item:    prefs_item,
+        research_item,
         reset_item,
         quit_item,
         kb_start_item:       kb_start,
@@ -182,6 +213,7 @@ pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuId
 
     let menu = Menu::new();
     menu.append(&ids.preferences_item)?;
+    menu.append(&ids.research_item)?;
     menu.append(&PredefinedMenuItem::separator())?;
     menu.append(&ids.start_item)?;
     menu.append(&ids.stop_item)?;

--- a/rust/crates/exhale-app/src/tray.rs
+++ b/rust/crates/exhale-app/src/tray.rs
@@ -20,8 +20,14 @@ use tray_icon::{
 /// stays installed long after its tag stops being the current state
 /// of the evidence, and a retraction has to reach the people running
 /// old builds.  A moved anchor is a CI failure; a stale claim is not
+///
+/// Points at `docs/citations.html` rather than the file itself.  That
+/// page fetches `docs/CITATIONS.md` from `main` at load, so it stays
+/// as current as the blob view did, but a reader who followed a menu
+/// item called "Research" arrives at a document instead of at a code
+/// host's file browser
 pub const RESEARCH_URL: &str =
-    "https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md#gaps-and-unsupported-choices";
+    "https://peterklingelhofer.github.io/exhale/citations.html#gaps-and-unsupported-choices";
 
 /// Named next to the URL because the wording and the anchor are one
 /// decision.  The label is plain, so the anchor carries the whole

--- a/rust/crates/exhale-core/src/controller.rs
+++ b/rust/crates/exhale-core/src/controller.rs
@@ -581,7 +581,10 @@ mod tests {
 
     #[test]
     fn drift_accumulates_correctly() {
-        let settings = Settings::default(); // drift = 1.01
+        // Drift is off by default now, so set it explicitly: this test is
+        // about compounding, not about what ships
+        let mut settings = Settings::default();
+        settings.drift = 1.01;
         let now = Instant::now();
         let mut inner = Inner {
             phase:           BreathingPhase::HoldAfterExhale,
@@ -618,8 +621,10 @@ mod tests {
 
     #[test]
     fn drift_matches_pow() {
-        // current_drift should equal drift^cycle_count at every cycle boundary.
-        let settings = Settings::default();
+        // current_drift should equal drift^cycle_count at every cycle boundary,
+        // for as long as the ceiling has not been reached.
+        let mut settings = Settings::default();
+        settings.drift = 1.01;
         let now = Instant::now();
         let mut inner = Inner {
             phase:           BreathingPhase::HoldAfterExhale,
@@ -633,12 +638,22 @@ mod tests {
             last_drawn_progress: -1.0,
         };
 
-        for cycle in 0..10_u64 {
+        // Deliberately far more cycles than any plausible session: drift is
+        // unbounded by design, so this must hold arbitrarily far out. An
+        // earlier revision capped the compounding; that cap was removed
+        // because advanced pranayama practice legitimately reaches breaths
+        // far longer than the research literature happens to have studied.
+        // See docs/CITATIONS.md gaps ledger item 6
+        for cycle in 0..2_000_u64 {
             // advance one full cycle (4 phases)
             advance_n_phases(&mut inner, 4, &settings);
             let expected = settings.drift.powi((cycle + 1) as i32);
+            // Relative, not absolute: repeated multiplication and `powi` agree
+            // to ~13 significant figures, but drift is unbounded, so by cycle
+            // ~1200 the values are in the hundreds of thousands and a fixed
+            // 1e-9 epsilon compares the wrong thing entirely
             assert!(
-                (inner.current_drift - expected).abs() < 1e-9,
+                (inner.current_drift - expected).abs() <= expected * 1e-12,
                 "cycle={cycle}: drift={} pow={expected}",
                 inner.current_drift
             );

--- a/rust/crates/exhale-core/src/lib.rs
+++ b/rust/crates/exhale-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod controller;
 pub mod easing;
 pub mod pacing;
 pub mod poison;
+pub mod presets;
 pub mod settings;
 pub mod settings_manager;
 pub mod types;

--- a/rust/crates/exhale-core/src/lib.rs
+++ b/rust/crates/exhale-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod controller;
 pub mod easing;
+pub mod pacing;
 pub mod poison;
 pub mod settings;
 pub mod settings_manager;

--- a/rust/crates/exhale-core/src/pacing.rs
+++ b/rust/crates/exhale-core/src/pacing.rs
@@ -1,0 +1,337 @@
+//! The sentences the settings window is allowed to say about pacing.
+//!
+//! This module exists so that every user-visible statement about the
+//! research is derived, testable, and covered by CI. It lives in
+//! `exhale-core` rather than next to the widget that paints it for one
+//! blunt reason: CI runs `cargo test -p exhale-core` and does not
+//! compile `exhale-app`, which needs wgpu, winit and GTK. Copy that
+//! makes a coverage statement should not be the only text in the
+//! project with no test behind it.
+//!
+//! **What the binary is permitted to assert.** Numbers it computed
+//! itself, one range, and nothing else. No effect, no benefit, no
+//! condition, no outcome measure. The corpus contains far stronger
+//! warrants than anything here, and they stay out of the binary on
+//! purpose: a store-reviewed app carries a retraction latency measured
+//! in weeks, so a claim compiled into it cannot be withdrawn at the
+//! speed the evidence can change. Arithmetic has no such problem,
+//! because arithmetic cannot be retracted. See `docs/CITATIONS.md`.
+
+use crate::settings::Settings;
+
+/// Slowest rate with direct experimental support, in breaths per minute.
+///
+/// From `you2023-respiratory-frequency`, which tested 5, 5.5, 6, 6.5
+/// and 7 cycles per minute. The endpoints are the endpoints of what was
+/// actually run, not a recommendation and not a safe range: outside it
+/// means untested here, which is different from tested and found
+/// wanting. Gaps ledger item 2
+pub const TESTED_MIN_BPM: f64 = 5.0;
+/// Fastest rate with direct experimental support. See [`TESTED_MIN_BPM`]
+pub const TESTED_MAX_BPM: f64 = 7.0;
+
+/// Where a rate sits relative to the directly tested range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Coverage {
+    Slower,
+    Inside,
+    Faster,
+}
+
+impl Coverage {
+    /// Classify a rate that has ALREADY been rounded for display.
+    ///
+    /// Rounding first is deliberate. Classifying the raw value lets the
+    /// panel print "5.0 breaths a minute" directly above "slower than
+    /// any of them" for a true rate of 4.96, which reads as a bug and
+    /// costs the reader their trust in the rest of the line
+    pub fn of_displayed(bpm: f64) -> Self {
+        if bpm < TESTED_MIN_BPM {
+            Self::Slower
+        } else if bpm > TESTED_MAX_BPM {
+            Self::Faster
+        } else {
+            Self::Inside
+        }
+    }
+
+    fn phrase(self) -> &'static str {
+        match self {
+            Self::Slower => "slower than any of them",
+            Self::Inside => "one of them",
+            Self::Faster => "faster than any of them",
+        }
+    }
+
+    fn short_phrase(self) -> &'static str {
+        match self {
+            Self::Slower => "slower than all of them",
+            Self::Inside => "inside it",
+            Self::Faster => "faster than all of them",
+        }
+    }
+}
+
+/// One decimal place, which is the resolution the arithmetic deserves
+/// and the resolution a person can act on
+fn round_bpm(bpm: f64) -> f64 {
+    (bpm * 10.0).round() / 10.0
+}
+
+/// Render a count of minutes at the coarsest unit that still says
+/// something. The drift stepper spans four orders of magnitude, so a
+/// single unit is either meaningless at one end or unreadable at the
+/// other
+fn humanize_minutes(minutes: f64) -> String {
+    const HOUR: f64 = 60.0;
+    const DAY:  f64 = 24.0 * HOUR;
+    if minutes < 1.0 {
+        "under a minute".to_string()
+    } else if minutes < 90.0 {
+        format!("{:.0} minutes", minutes)
+    } else if minutes < 2.0 * DAY {
+        format!("{:.1} hours", minutes / HOUR)
+    } else {
+        format!("{:.0} days", minutes / DAY)
+    }
+}
+
+/// Minutes of continuous running before the cycle takes twice as long
+/// as it does now, or `None` when drift is off or shortening.
+///
+/// Doubling is the honest unit for a compounding setting. "0.1 % per
+/// cycle" tells nobody anything; "the breath is twice as long after
+/// four hours" tells them whether the number they just typed is gentle
+/// or runaway, which is the only question the stepper actually raises
+pub fn minutes_to_double(settings: &Settings) -> Option<f64> {
+    let cycle = settings.cycle_secs();
+    if cycle <= 0.0 || settings.drift <= 1.0 {
+        return None;
+    }
+    // From `Settings::breaths_per_min_after`: the projected cycle is
+    // `c + 60·T·(d − 1)`, so it reaches `2c` at `T = c / (60·(d − 1))`
+    Some(cycle / (60.0 * (settings.drift - 1.0)))
+}
+
+/// The horizon the drift line projects to. An hour is long enough that
+/// a gentle drift has visibly moved and short enough to be a session
+/// somebody might actually sit through
+const PROJECTION_MINUTES: f64 = 60.0;
+
+/// Build the readout, one string per line, in display order.
+///
+/// Returns empty when no phase has a duration, which is not a rate of
+/// anything and not a state worth narrating
+pub fn readout_lines(settings: &Settings) -> Vec<String> {
+    let Some(bpm) = settings.breaths_per_min() else {
+        return Vec::new();
+    };
+    let now = round_bpm(bpm);
+    let mut lines = vec![format!(
+        "Now: {now:.1} breaths a minute, a {} cycle.",
+        format_secs(settings.cycle_secs()),
+    )];
+
+    let projected = settings
+        .drift_is_active()
+        .then(|| settings.breaths_per_min_after(PROJECTION_MINUTES))
+        .flatten()
+        .map(round_bpm);
+
+    if let Some(later) = projected {
+        let mut drift_line = format!("Drift: about {later:.1} a minute after an hour");
+        if let Some(double_at) = minutes_to_double(settings) {
+            drift_line.push_str(&format!(
+                ", and twice this cycle length after {}",
+                humanize_minutes(double_at),
+            ));
+        }
+        drift_line.push('.');
+        lines.push(drift_line);
+    }
+
+    lines.push(coverage_line(now, projected));
+    lines
+}
+
+/// The one range the binary is allowed to name, and where the current
+/// setting falls against it.
+///
+/// Phrased about the literature throughout. It reports what was
+/// measured and whether this number was among it; it does not tell the
+/// user their breathing is wrong, because the corpus does not support
+/// that and the app is in no position to say so
+fn coverage_line(now: f64, projected: Option<f64>) -> String {
+    let base = format!(
+        "Rates from {TESTED_MIN_BPM:.0} to {TESTED_MAX_BPM:.0} a minute are the ones tested directly. "
+    );
+    let start = Coverage::of_displayed(now);
+    match projected.map(Coverage::of_displayed) {
+        // Drift that carries the pace out of the tested range within
+        // the projection window is exactly the thing a static label
+        // would hide, so it gets said rather than implied
+        Some(end) if end != start => format!(
+            "{base}This one starts {} and is {} within an hour.",
+            match start {
+                Coverage::Inside => "inside it",
+                Coverage::Slower => "below it",
+                Coverage::Faster => "above it",
+            },
+            end.short_phrase(),
+        ),
+        _ => format!("{base}This one is {}.", start.phrase()),
+    }
+}
+
+/// Whole seconds when the cycle is whole, one decimal when it is not.
+/// Timing steppers move in whole seconds, so "15 s" is the normal case
+/// and "15.5 s" only shows up for a typed value
+fn format_secs(secs: f64) -> String {
+    if (secs - secs.round()).abs() < 1e-9 {
+        format!("{secs:.0} s")
+    } else {
+        format!("{secs:.1} s")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_shipped_default_volunteers_that_it_is_untested() {
+        // The point of the readout. exhale's own default is 4.0 a
+        // minute, below the band, and the panel says so on first open
+        // without being asked. Gaps ledger item 2
+        let lines = readout_lines(&Settings::default());
+        assert_eq!(lines.len(), 2, "{lines:#?}");
+        assert_eq!(lines[0], "Now: 4.0 breaths a minute, a 15 s cycle.");
+        assert!(lines[1].ends_with("This one is slower than any of them."), "{}", lines[1]);
+    }
+
+    #[test]
+    fn box_breathing_is_reported_as_slower_than_it_looks() {
+        // 4/4/4/4 is 3.75 a minute. The holds hide that from anyone
+        // doing the arithmetic in their head. Gaps ledger item 3
+        let mut s = Settings::default();
+        s.inhale_duration           = 4.0;
+        s.post_inhale_hold_duration = 4.0;
+        s.exhale_duration           = 4.0;
+        s.post_exhale_hold_duration = 4.0;
+        let lines = readout_lines(&s);
+        assert_eq!(lines[0], "Now: 3.8 breaths a minute, a 16 s cycle.");
+        assert!(lines[1].contains("slower than any of them"));
+    }
+
+    #[test]
+    fn an_in_band_pace_is_named_as_one_of_the_tested_rates() {
+        let mut s = Settings::default();
+        s.exhale_duration = 5.0; // 5/0/5/0 = 6 a minute
+        let lines = readout_lines(&s);
+        assert_eq!(lines[0], "Now: 6.0 breaths a minute, a 10 s cycle.");
+        assert!(lines[1].ends_with("This one is one of them."), "{}", lines[1]);
+    }
+
+    #[test]
+    fn drift_that_leaves_the_band_says_so_rather_than_reporting_the_start() {
+        // Starts at 6 a minute, inside the range, and 1 % drift takes
+        // it out within the hour. A line computed only from the
+        // starting pace would read "one of them" and be misleading
+        let mut s = Settings::default();
+        s.exhale_duration = 5.0;
+        s.drift           = 1.01;
+        let lines = readout_lines(&s);
+        assert_eq!(lines.len(), 3, "{lines:#?}");
+        assert!(lines[1].starts_with("Drift: about "), "{}", lines[1]);
+        assert!(
+            lines[2].ends_with("This one starts inside it and is slower than all of them within an hour."),
+            "{}", lines[2]
+        );
+    }
+
+    #[test]
+    fn drift_off_produces_no_drift_line() {
+        let lines = readout_lines(&Settings::default());
+        assert!(!lines.iter().any(|l| l.contains("Drift")), "{lines:#?}");
+    }
+
+    #[test]
+    fn the_doubling_time_separates_gentle_drift_from_runaway_drift() {
+        // The contrast gaps ledger item 6 turns on, and the reason the
+        // stepper moves in tenths of a percentage point rather than
+        // whole ones
+        let mut gentle = Settings::default();
+        gentle.drift = 1.001;
+        assert_eq!(humanize_minutes(minutes_to_double(&gentle).unwrap()), "4.2 hours");
+
+        let mut steep = Settings::default();
+        steep.drift = 1.01;
+        assert_eq!(humanize_minutes(minutes_to_double(&steep).unwrap()), "25 minutes");
+
+        let mut barely = Settings::default();
+        barely.drift = 1.00001;
+        assert_eq!(humanize_minutes(minutes_to_double(&barely).unwrap()), "17 days");
+
+        assert_eq!(minutes_to_double(&Settings::default()), None);
+    }
+
+    #[test]
+    fn the_rate_shown_and_the_range_named_never_contradict_each_other() {
+        // A true rate of 4.96 displays as 5.0. Classifying the raw
+        // value would print "5.0 breaths a minute" above "slower than
+        // any of them"
+        let mut s = Settings::default();
+        s.inhale_duration = 5.0;
+        s.exhale_duration = 7.096_774; // ≈ 4.96 a minute
+        let lines = readout_lines(&s);
+        assert!(lines[0].contains("5.0 breaths a minute"), "{}", lines[0]);
+        assert!(lines[1].ends_with("This one is one of them."), "{}", lines[1]);
+    }
+
+    #[test]
+    fn a_zero_length_cycle_says_nothing_at_all() {
+        let mut s = Settings::default();
+        s.inhale_duration           = 0.0;
+        s.post_inhale_hold_duration = 0.0;
+        s.exhale_duration           = 0.0;
+        s.post_exhale_hold_duration = 0.0;
+        assert!(readout_lines(&s).is_empty());
+    }
+
+    #[test]
+    fn no_line_names_an_effect_a_benefit_or_a_condition() {
+        // A denylist, not a style rule. `scripts/generate-citations.py`
+        // keeps retracted phrasing out of the store listings; this
+        // keeps outcome vocabulary out of the binary, which is the
+        // constraint that rules out quoting `custom.backsClaims`
+        // verbatim however well-sourced those strings are.
+        // `docs/CITATIONS.md` may say all of this; the app may not
+        const BANNED: &[&str] = &[
+            "anxiety", "depress", "stress", "calm", "relax", "vagal", "parasympathetic",
+            "blood pressure", "heart rate variability", "hrv", "mood", "sleep",
+            "benefit", "improve", "treat", "therapy", "symptom", "health",
+            "recommend", "should", "optimal", "best", "correct",
+        ];
+        let mut cases = vec![Settings::default()];
+        for drift in [1.001, 1.01] {
+            for exhale in [5.0, 10.0, 1.0] {
+                let mut s = Settings::default();
+                s.drift = drift;
+                s.exhale_duration = exhale;
+                cases.push(s);
+            }
+        }
+        for s in cases {
+            for line in readout_lines(&s) {
+                let lowered = line.to_lowercase();
+                for word in BANNED {
+                    assert!(
+                        !lowered.contains(word),
+                        "readout line asserts {word:?}, which the binary may not say: {line:?}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/rust/crates/exhale-core/src/pacing.rs
+++ b/rust/crates/exhale-core/src/pacing.rs
@@ -227,14 +227,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_shipped_default_volunteers_that_it_is_untested() {
-        // The point of the readout. exhale's own default is 4.0 a
-        // minute, below the band, and the panel says so on first open
-        // without being asked. Gaps ledger item 2
+    fn the_shipped_default_reports_itself_as_inside_the_tested_band() {
+        // exhale defaults to 5 / 0 / 5 / 0, six a minute, and the panel
+        // says so on first open without being asked. The readout is not
+        // here to flatter the default: `box_breathing_is_reported_as_
+        // slower_than_it_looks` is the same code volunteering bad news
         let lines = readout_lines(&Settings::default());
         assert_eq!(lines.len(), 2, "{lines:#?}");
-        assert_eq!(lines[0], "Now: 4.0 breaths a minute, a 15 s cycle.");
-        assert!(lines[1].ends_with("This one is slower than any of them."), "{}", lines[1]);
+        assert_eq!(lines[0], "Now: 6.0 breaths a minute, a 10 s cycle.");
+        assert!(lines[1].ends_with("This one is one of them."), "{}", lines[1]);
     }
 
     #[test]
@@ -252,11 +253,11 @@ mod tests {
     }
 
     #[test]
-    fn an_in_band_pace_is_named_as_one_of_the_tested_rates() {
+    fn an_in_band_pace_that_is_not_the_default_is_also_named() {
         let mut s = Settings::default();
-        s.exhale_duration = 5.0; // 5/0/5/0 = 6 a minute
+        s.post_exhale_hold_duration = 2.0; // 5/0/5/2 = 5 a minute
         let lines = readout_lines(&s);
-        assert_eq!(lines[0], "Now: 6.0 breaths a minute, a 10 s cycle.");
+        assert_eq!(lines[0], "Now: 5.0 breaths a minute, a 12 s cycle.");
         assert!(lines[1].ends_with("This one is one of them."), "{}", lines[1]);
     }
 
@@ -314,11 +315,11 @@ mod tests {
         // arithmetic. Both were right; the unit was wrong
         let mut ten = Settings::default();
         ten.drift = 1.01;
-        ten.exhale_duration = 5.0;
         assert_eq!(ten.cycle_secs(), 10.0);
 
         let mut fifteen = Settings::default();
         fifteen.drift = 1.01;
+        fifteen.exhale_duration = 10.0;
         assert_eq!(fifteen.cycle_secs(), 15.0);
 
         assert_eq!(breaths_to_double(&ten), breaths_to_double(&fifteen));
@@ -357,6 +358,7 @@ mod tests {
         s.drift = 1.00001;
         let lines = readout_lines(&s);
         assert_eq!(lines[1], "Drift: the cycle doubles every 69,315 breaths.");
+        assert_eq!(lines.len(), 3, "{lines:#?}");
     }
 
     #[test]

--- a/rust/crates/exhale-core/src/pacing.rs
+++ b/rust/crates/exhale-core/src/pacing.rs
@@ -78,39 +78,44 @@ fn round_bpm(bpm: f64) -> f64 {
     (bpm * 10.0).round() / 10.0
 }
 
-/// Render a count of minutes at the coarsest unit that still says
-/// something. The drift stepper spans four orders of magnitude, so a
-/// single unit is either meaningless at one end or unreadable at the
-/// other
-fn humanize_minutes(minutes: f64) -> String {
-    const HOUR: f64 = 60.0;
-    const DAY:  f64 = 24.0 * HOUR;
-    if minutes < 1.0 {
-        "under a minute".to_string()
-    } else if minutes < 90.0 {
-        format!("{:.0} minutes", minutes)
-    } else if minutes < 2.0 * DAY {
-        format!("{:.1} hours", minutes / HOUR)
-    } else {
-        format!("{:.0} days", minutes / DAY)
+/// Group a count with thousands separators. Drift spans four orders of
+/// magnitude, so this routinely renders numbers like 69,315 where an
+/// ungrouped 69315 is a smear
+fn grouped(n: u64) -> String {
+    let digits = n.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
     }
+    out
 }
 
-/// Minutes of continuous running before the cycle takes twice as long
+/// Breaths of continuous running before one cycle takes twice as long
 /// as it does now, or `None` when drift is off or shortening.
 ///
-/// Doubling is the honest unit for a compounding setting. "0.1 % per
-/// cycle" tells nobody anything; "the breath is twice as long after
-/// four hours" tells them whether the number they just typed is gentle
-/// or runaway, which is the only question the stepper actually raises
-pub fn minutes_to_double(settings: &Settings) -> Option<f64> {
-    let cycle = settings.cycle_secs();
-    if cycle <= 0.0 || settings.drift <= 1.0 {
+/// **Counted in breaths, not minutes, and that is the whole point.**
+/// Cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at `k = ln2 / ln d`: the
+/// starting cycle length cancels out entirely. One per cent doubles the
+/// breath in 70 breaths whether the user started at 10 s or at 15 s.
+///
+/// Quoting a doubling *time* instead made the panel look broken. The
+/// same 1 % setting reads as 17 minutes from a 10 s cycle and 25
+/// minutes from a 15 s one, which invites the reader to conclude the
+/// arithmetic is unreliable when in fact both are correct and the
+/// question was ambiguous. A count of breaths is a property of the
+/// drift value alone, so it is stable, and it is also the thing the
+/// user is about to sit through.
+///
+/// It is a true repeat rate, not just a first milestone: the same `k`
+/// takes the cycle from `2c` to `4c`
+pub fn breaths_to_double(settings: &Settings) -> Option<f64> {
+    if settings.cycle_secs() <= 0.0 || settings.drift <= 1.0 {
         return None;
     }
-    // From `Settings::breaths_per_min_after`: the projected cycle is
-    // `c + 60·T·(d − 1)`, so it reaches `2c` at `T = c / (60·(d − 1))`
-    Some(cycle / (60.0 * (settings.drift - 1.0)))
+    Some(std::f64::consts::LN_2 / settings.drift.ln())
 }
 
 /// The horizon the drift line projects to. An hour is long enough that
@@ -138,15 +143,37 @@ pub fn readout_lines(settings: &Settings) -> Vec<String> {
         .flatten()
         .map(round_bpm);
 
-    if let Some(later) = projected {
-        let mut drift_line = format!("Drift: about {later:.1} a minute after an hour");
-        if let Some(double_at) = minutes_to_double(settings) {
+    if projected.is_some() {
+        // Seconds, not breaths per minute. "About 1.3 a minute after an
+        // hour" is arithmetically correct and unreadable: nobody holds a
+        // mental picture of 1.3 breaths a minute, whereas everybody can
+        // picture a breath that has gone from 10 seconds to 46. Seconds
+        // are also the unit the four steppers directly above are set in,
+        // so the sentence lands in the units the user just typed
+        let mut drift_line = String::from("Drift: ");
+        match breaths_to_double(settings) {
+            Some(n) => drift_line.push_str(&format!(
+                "the cycle doubles every {} breaths.",
+                grouped(n.round().max(1.0) as u64),
+            )),
+            // Reachable only from a hand-edited settings file, where
+            // drift below 1.0 shortens the breath instead
+            None => drift_line.push_str("the cycle shortens every breath."),
+        }
+
+        let now  = settings.cycle_secs();
+        let then = 60.0 / settings.breaths_per_min_after(PROJECTION_MINUTES).unwrap_or(f64::MAX);
+        // Suppress the second clause when an hour does not move the
+        // number a person could read off the screen. At 0.001 % a 15 s
+        // cycle reaches 15.04 s, and "after an hour it is 15 s, not
+        // 15 s" reads as a bug rather than as a very gentle setting
+        if (then - now).abs() >= 0.5 {
             drift_line.push_str(&format!(
-                ", and twice this cycle length after {}",
-                humanize_minutes(double_at),
+                " After an hour it is {}, not {}.",
+                format_secs(then),
+                format_secs(now),
             ));
         }
-        drift_line.push('.');
         lines.push(drift_line);
     }
 
@@ -243,7 +270,10 @@ mod tests {
         s.drift           = 1.01;
         let lines = readout_lines(&s);
         assert_eq!(lines.len(), 3, "{lines:#?}");
-        assert!(lines[1].starts_with("Drift: about "), "{}", lines[1]);
+        assert_eq!(
+            lines[1],
+            "Drift: the cycle doubles every 70 breaths. After an hour it is 46 s, not 10 s."
+        );
         assert!(
             lines[2].ends_with("This one starts inside it and is slower than all of them within an hour."),
             "{}", lines[2]
@@ -257,23 +287,76 @@ mod tests {
     }
 
     #[test]
-    fn the_doubling_time_separates_gentle_drift_from_runaway_drift() {
+    fn the_doubling_count_separates_gentle_drift_from_runaway_drift() {
         // The contrast gaps ledger item 6 turns on, and the reason the
         // stepper moves in tenths of a percentage point rather than
         // whole ones
         let mut gentle = Settings::default();
         gentle.drift = 1.001;
-        assert_eq!(humanize_minutes(minutes_to_double(&gentle).unwrap()), "4.2 hours");
+        assert_eq!(breaths_to_double(&gentle).unwrap().round(), 693.0);
 
         let mut steep = Settings::default();
         steep.drift = 1.01;
-        assert_eq!(humanize_minutes(minutes_to_double(&steep).unwrap()), "25 minutes");
+        assert_eq!(breaths_to_double(&steep).unwrap().round(), 70.0);
 
         let mut barely = Settings::default();
         barely.drift = 1.00001;
-        assert_eq!(humanize_minutes(minutes_to_double(&barely).unwrap()), "17 days");
+        assert_eq!(breaths_to_double(&barely).unwrap().round(), 69_315.0);
 
-        assert_eq!(minutes_to_double(&Settings::default()), None);
+        assert_eq!(breaths_to_double(&Settings::default()), None);
+    }
+
+    #[test]
+    fn the_doubling_count_does_not_depend_on_the_starting_cycle() {
+        // The bug this replaced. Quoted as a doubling *time*, one per
+        // cent read as 17 minutes from a 10 s cycle and 25 minutes from
+        // a 15 s one, and the panel looked like it could not do
+        // arithmetic. Both were right; the unit was wrong
+        let mut ten = Settings::default();
+        ten.drift = 1.01;
+        ten.exhale_duration = 5.0;
+        assert_eq!(ten.cycle_secs(), 10.0);
+
+        let mut fifteen = Settings::default();
+        fifteen.drift = 1.01;
+        assert_eq!(fifteen.cycle_secs(), 15.0);
+
+        assert_eq!(breaths_to_double(&ten), breaths_to_double(&fifteen));
+    }
+
+    #[test]
+    fn doubling_is_a_repeat_rate_not_a_one_off_milestone() {
+        // "Every N breaths" claims the interval repeats. It does: the
+        // same count takes the cycle from 2c to 4c, because `dᵏ = 2`
+        // has no `c` in it
+        let mut s = Settings::default();
+        s.drift = 1.01;
+        let k = breaths_to_double(&s).unwrap();
+        let c = s.cycle_secs();
+        for doublings in 1..=4 {
+            let cycle = c * s.drift.powf(k * doublings as f64);
+            let want  = c * 2f64.powi(doublings);
+            assert!((cycle - want).abs() < 1e-6, "after {doublings} doublings: {cycle} vs {want}");
+        }
+    }
+
+    #[test]
+    fn thousands_are_grouped() {
+        assert_eq!(grouped(7), "7");
+        assert_eq!(grouped(70), "70");
+        assert_eq!(grouped(693), "693");
+        assert_eq!(grouped(69_315), "69,315");
+        assert_eq!(grouped(6_931_472), "6,931,472");
+    }
+
+    #[test]
+    fn a_drift_too_slow_to_see_within_an_hour_says_only_what_it_can() {
+        // 0.001 % moves a 15 s cycle to 15.04 s in an hour. "After an
+        // hour it is 15 s, not 15 s" would read as a bug
+        let mut s = Settings::default();
+        s.drift = 1.00001;
+        let lines = readout_lines(&s);
+        assert_eq!(lines[1], "Drift: the cycle doubles every 69,315 breaths.");
     }
 
     #[test]

--- a/rust/crates/exhale-core/src/presets.rs
+++ b/rust/crates/exhale-core/src/presets.rs
@@ -99,7 +99,7 @@ pub const PRESETS: &[Preset] = &[
     Preset {
         id: "even-5",
         label: "5/0/5/0",
-        note: None,
+        note: Some("· exhale's default."),
         inhale: 5.0,
         post_inhale_hold: 0.0,
         exhale: 5.0,
@@ -141,9 +141,13 @@ pub const PRESETS: &[Preset] = &[
         citekey: "marchant2025-square-478-six",
     },
     Preset {
-        id: "shipped-default",
+        // Kept in the list because it was the default before 5/0/5/0 and
+        // is still what every existing settings.toml holds. Removing it
+        // from the offered set would not remove it from anyone's machine,
+        // it would just make their own configuration unnameable
+        id: "long-exhale-5-10",
         label: "5/0/10/0",
-        note: Some("· exhale's shipped default."),
+        note: None,
         inhale: 5.0,
         post_inhale_hold: 0.0,
         exhale: 10.0,
@@ -169,13 +173,24 @@ mod tests {
     use crate::pacing;
 
     #[test]
-    fn the_shipped_default_is_one_of_the_offered_patterns() {
-        // If it were not, the panel would show no selection out of the
-        // box, which reads as "your configuration is unrecognised"
-        // on first ever launch
+    fn the_shipped_default_is_the_first_offered_pattern() {
+        // If the default matched no preset, the panel would show no
+        // selection out of the box, which reads as "your configuration
+        // is unrecognised" on first ever launch
         let s = Settings::default();
         let i = selected(&s).expect("default settings match no preset");
-        assert_eq!(PRESETS[i].id, "shipped-default");
+        assert_eq!(PRESETS[i].id, "even-5");
+        assert_eq!(i, 0, "the default should be the first chip, not buried mid-row");
+    }
+
+    #[test]
+    fn the_previous_default_is_still_offered() {
+        // 5/0/10/0 shipped as the default for years, so it is what every
+        // existing settings.toml holds. It has to stay nameable
+        let p = PRESETS.iter().find(|p| p.id == "long-exhale-5-10").unwrap();
+        let mut s = Settings::default();
+        p.apply(&mut s);
+        assert!((s.breaths_per_min().unwrap() - 4.0).abs() < 1e-9);
     }
 
     #[test]
@@ -293,7 +308,7 @@ mod tests {
             ("long-exhale-4-6", true),
             ("a52", true),
             ("box", false),
-            ("shipped-default", false),
+            ("long-exhale-5-10", false),
         ] {
             let p = PRESETS.iter().find(|p| p.id == id).unwrap();
             let mut s = Settings::default();

--- a/rust/crates/exhale-core/src/presets.rs
+++ b/rust/crates/exhale-core/src/presets.rs
@@ -15,8 +15,12 @@
 //!
 //! **Labels name the pattern, never the rate.** A chip reading "6 a
 //! minute" would be a claim about which rate is worth choosing; a chip
-//! reading "5 s in, 5 s out" is a description of what the four
-//! steppers below it are about to say. The rate, and how it sits
+//! reading "5/0/5/0" is a description of what the four steppers below
+//! it are about to say, in their own order: inhale, post-inhale hold,
+//! exhale, post-exhale hold. It is the notation the README already
+//! uses, and it is terse enough that all five chips fit a single row
+//! of a 308 pt card, where the spelled-out form took three. The rate,
+//! and how it sits
 //! against the range anyone has tested, is computed live by
 //! [`crate::pacing::readout_lines`] for whichever pattern is active.
 //! That is why no preset carries its own evidentiary caption: the
@@ -94,7 +98,7 @@ impl Preset {
 pub const PRESETS: &[Preset] = &[
     Preset {
         id: "even-5",
-        label: "5 s in, 5 s out",
+        label: "5/0/5/0",
         note: None,
         inhale: 5.0,
         post_inhale_hold: 0.0,
@@ -104,7 +108,7 @@ pub const PRESETS: &[Preset] = &[
     },
     Preset {
         id: "long-exhale-4-6",
-        label: "4 s in, 6 s out",
+        label: "4/0/6/0",
         note: None,
         inhale: 4.0,
         post_inhale_hold: 0.0,
@@ -114,12 +118,12 @@ pub const PRESETS: &[Preset] = &[
     },
     Preset {
         id: "a52",
-        label: "5 s in, 5 s out, 2 s pause",
+        label: "5/0/5/2",
         // The name is the reason anyone would look for this pattern,
         // and naming it costs nothing. The review that popularised the
         // name is blocklisted from the binary, so the citekey points
         // at the study that tested this rate instead
-        note: Some("Sometimes called A52."),
+        note: Some("· sometimes called A52."),
         inhale: 5.0,
         post_inhale_hold: 0.0,
         exhale: 5.0,
@@ -128,8 +132,8 @@ pub const PRESETS: &[Preset] = &[
     },
     Preset {
         id: "box",
-        label: "4 / 4 / 4 / 4",
-        note: Some("Sometimes called box breathing."),
+        label: "4/4/4/4",
+        note: Some("· sometimes called box breathing."),
         inhale: 4.0,
         post_inhale_hold: 4.0,
         exhale: 4.0,
@@ -138,8 +142,8 @@ pub const PRESETS: &[Preset] = &[
     },
     Preset {
         id: "shipped-default",
-        label: "5 s in, 10 s out",
-        note: Some("exhale's shipped default."),
+        label: "5/0/10/0",
+        note: Some("· exhale's shipped default."),
         inhale: 5.0,
         post_inhale_hold: 0.0,
         exhale: 10.0,

--- a/rust/crates/exhale-core/src/presets.rs
+++ b/rust/crates/exhale-core/src/presets.rs
@@ -1,0 +1,312 @@
+//! The breathing patterns the settings window offers as one click.
+//!
+//! Five entries, hand-written, in `exhale-core` rather than in the UI
+//! crate for the same reason [`crate::pacing`] is: CI compiles and
+//! tests this crate and does not compile `exhale-app`.
+//!
+//! **A preset sets the four durations and nothing else.** Not drift,
+//! not the randomisation sliders. Clicking one can therefore never
+//! discard a value the user tuned by hand, which is the property that
+//! lets selection be *derived* by comparing four numbers instead of
+//! stored in a sixth settings field that could fall out of sync with
+//! the five it summarises. Drift and jitter keep whatever the user set,
+//! and the pacing readout underneath already reports what drift does
+//! to the rate, so nothing about the resulting pace goes unsaid.
+//!
+//! **Labels name the pattern, never the rate.** A chip reading "6 a
+//! minute" would be a claim about which rate is worth choosing; a chip
+//! reading "5 s in, 5 s out" is a description of what the four
+//! steppers below it are about to say. The rate, and how it sits
+//! against the range anyone has tested, is computed live by
+//! [`crate::pacing::readout_lines`] for whichever pattern is active.
+//! That is why no preset carries its own evidentiary caption: the
+//! panel already volunteers "slower than any of them" the instant box
+//! breathing is selected, for every pattern rather than only the ones
+//! someone remembered to annotate.
+//!
+//! `citekey` is provenance, not display. It never reaches the screen.
+//! It exists so `scripts/generate-citations.py` can refuse to build
+//! when a shipped preset points at a record that has been retracted,
+//! downgraded to tier E, or marked as one the binary may not lean on.
+
+use crate::settings::Settings;
+
+/// One offered pattern. Four durations, a label describing them, and a
+/// corpus record that has to still hold up for the preset to ship.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Preset {
+    /// Stable identifier. Not shown; used by tests and by any future
+    /// telemetry-free bookkeeping. Never renamed casually, because a
+    /// rename is invisible in the UI and silent in the diff
+    pub id: &'static str,
+    /// What the chip says. Describes the pattern, never the rate
+    pub label: &'static str,
+    /// A name or a fact about identity, never about effect. `None`
+    /// when the pattern has nothing to add that the readout below does
+    /// not already say better
+    pub note: Option<&'static str>,
+    pub inhale: f64,
+    pub post_inhale_hold: f64,
+    pub exhale: f64,
+    pub post_exhale_hold: f64,
+    /// Corpus entry backing this pattern's presence in the list. See
+    /// the module comment: provenance, not display
+    pub citekey: &'static str,
+}
+
+impl Preset {
+    /// True when `settings` currently holds exactly this pattern.
+    ///
+    /// The epsilon is the one `SettingsDiff::from` uses on these same
+    /// four fields. Sharing it is deliberate: "this chip looks
+    /// selected" and "changing this field marks settings dirty" must
+    /// agree, or a chip can appear selected while a save is pending
+    /// that will unselect it
+    pub fn matches(&self, settings: &Settings) -> bool {
+        const EPS: f64 = 1e-9;
+        (settings.inhale_duration - self.inhale).abs() < EPS
+            && (settings.post_inhale_hold_duration - self.post_inhale_hold).abs() < EPS
+            && (settings.exhale_duration - self.exhale).abs() < EPS
+            && (settings.post_exhale_hold_duration - self.post_exhale_hold).abs() < EPS
+    }
+
+    /// Write this pattern's four durations into `settings`, leaving
+    /// every other field alone. See the module comment for why the
+    /// omission is the point
+    pub fn apply(&self, settings: &mut Settings) {
+        settings.inhale_duration = self.inhale;
+        settings.post_inhale_hold_duration = self.post_inhale_hold;
+        settings.exhale_duration = self.exhale;
+        settings.post_exhale_hold_duration = self.post_exhale_hold;
+    }
+}
+
+/// The offered set, in display order.
+///
+/// Ordered gentlest-first by the standard the corpus actually
+/// supports, which is the tested range rather than apparent
+/// simplicity. The two patterns that fall outside it come last and are
+/// still offered: `4 / 4 / 4 / 4` because people arrive looking for it
+/// by name, and `5 s in, 10 s out` because it is what exhale has
+/// shipped for years and removing it from the list would not remove it
+/// from anybody's installed configuration. A list that quietly omitted
+/// its own default would be the least honest version of this feature
+pub const PRESETS: &[Preset] = &[
+    Preset {
+        id: "even-5",
+        label: "5 s in, 5 s out",
+        note: None,
+        inhale: 5.0,
+        post_inhale_hold: 0.0,
+        exhale: 5.0,
+        post_exhale_hold: 0.0,
+        citekey: "you2023-respiratory-frequency",
+    },
+    Preset {
+        id: "long-exhale-4-6",
+        label: "4 s in, 6 s out",
+        note: None,
+        inhale: 4.0,
+        post_inhale_hold: 0.0,
+        exhale: 6.0,
+        post_exhale_hold: 0.0,
+        citekey: "vandiest2014-ie-ratio-relaxation",
+    },
+    Preset {
+        id: "a52",
+        label: "5 s in, 5 s out, 2 s pause",
+        // The name is the reason anyone would look for this pattern,
+        // and naming it costs nothing. The review that popularised the
+        // name is blocklisted from the binary, so the citekey points
+        // at the study that tested this rate instead
+        note: Some("Sometimes called A52."),
+        inhale: 5.0,
+        post_inhale_hold: 0.0,
+        exhale: 5.0,
+        post_exhale_hold: 2.0,
+        citekey: "you2023-respiratory-frequency",
+    },
+    Preset {
+        id: "box",
+        label: "4 / 4 / 4 / 4",
+        note: Some("Sometimes called box breathing."),
+        inhale: 4.0,
+        post_inhale_hold: 4.0,
+        exhale: 4.0,
+        post_exhale_hold: 4.0,
+        citekey: "marchant2025-square-478-six",
+    },
+    Preset {
+        id: "shipped-default",
+        label: "5 s in, 10 s out",
+        note: Some("exhale's shipped default."),
+        inhale: 5.0,
+        post_inhale_hold: 0.0,
+        exhale: 10.0,
+        post_exhale_hold: 0.0,
+        citekey: "vandiest2014-ie-ratio-relaxation",
+    },
+];
+
+/// Index of the preset the current settings match, if any.
+///
+/// `None` is a first-class answer and renders as no chip selected.
+/// There is deliberately no "Custom" chip to fall back on: a chip that
+/// cannot be clicked to any effect is still a Tab stop, and this
+/// window already documents that hazard twice
+pub fn selected(settings: &Settings) -> Option<usize> {
+    PRESETS.iter().position(|p| p.matches(settings))
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod tests {
+    use super::*;
+    use crate::pacing;
+
+    #[test]
+    fn the_shipped_default_is_one_of_the_offered_patterns() {
+        // If it were not, the panel would show no selection out of the
+        // box, which reads as "your configuration is unrecognised"
+        // on first ever launch
+        let s = Settings::default();
+        let i = selected(&s).expect("default settings match no preset");
+        assert_eq!(PRESETS[i].id, "shipped-default");
+    }
+
+    #[test]
+    fn every_preset_round_trips_through_apply_and_matches() {
+        for p in PRESETS {
+            let mut s = Settings::default();
+            p.apply(&mut s);
+            assert!(p.matches(&s), "{} does not match itself after apply", p.id);
+            assert_eq!(selected(&s), Some(PRESETS.iter().position(|q| q.id == p.id).unwrap()));
+        }
+    }
+
+    #[test]
+    fn no_two_presets_share_a_pattern_or_an_id() {
+        // Two chips matching the same four numbers would both light up
+        // and `selected` would silently pick the first
+        for (i, a) in PRESETS.iter().enumerate() {
+            for b in &PRESETS[i + 1..] {
+                assert_ne!(a.id, b.id);
+                assert_ne!(a.label, b.label);
+                let mut s = Settings::default();
+                a.apply(&mut s);
+                assert!(!b.matches(&s), "{} and {} are the same pattern", a.id, b.id);
+            }
+        }
+    }
+
+    #[test]
+    fn applying_a_preset_leaves_drift_and_jitter_alone() {
+        // The property that makes derived selection safe. A preset
+        // that also zeroed these would discard tuning the user did on
+        // purpose, and the chip would then be describing a pattern the
+        // app had just silently changed out from under them
+        let mut s = Settings::default();
+        s.drift = 1.001;
+        s.randomized_timing_inhale = 0.2;
+        s.randomized_timing_post_inhale_hold = 0.1;
+        s.randomized_timing_exhale = 0.3;
+        s.randomized_timing_post_exhale_hold = 0.05;
+        let before = s.clone();
+
+        PRESETS[0].apply(&mut s);
+
+        assert_eq!(s.drift, before.drift);
+        assert_eq!(s.randomized_timing_inhale, before.randomized_timing_inhale);
+        assert_eq!(s.randomized_timing_post_inhale_hold, before.randomized_timing_post_inhale_hold);
+        assert_eq!(s.randomized_timing_exhale, before.randomized_timing_exhale);
+        assert_eq!(s.randomized_timing_post_exhale_hold, before.randomized_timing_post_exhale_hold);
+        assert!(selected(&s).is_some(), "drift and jitter must not affect which chip is selected");
+    }
+
+    #[test]
+    fn a_hand_tuned_pattern_selects_nothing() {
+        let mut s = Settings::default();
+        s.exhale_duration = 7.0;
+        assert_eq!(selected(&s), None);
+    }
+
+    #[test]
+    fn no_label_or_note_states_a_rate_an_effect_or_a_recommendation() {
+        // Same denylist discipline as `pacing`, for the same reason.
+        // "a minute", "bpm" and "breaths per" are here because a rate
+        // baked into a label is a claim about which rate to choose,
+        // and because it would go stale against the live readout the
+        // moment either changed
+        const BANNED: &[&str] = &[
+            "a minute", "per minute", "bpm", "breaths per",
+            "anxiety", "stress", "calm", "relax", "vagal", "parasympathetic",
+            "blood pressure", "hrv", "mood", "sleep",
+            "benefit", "improve", "treat", "therapy", "symptom", "health",
+            "recommend", "should", "optimal", "best", "beginner", "advanced",
+            "tested", "evidence", "study", "studies", "research", "proven",
+        ];
+        for p in PRESETS {
+            for text in [Some(p.label), p.note].into_iter().flatten() {
+                let lowered = text.to_lowercase();
+                for word in BANNED {
+                    assert!(
+                        !lowered.contains(word),
+                        "{}: {text:?} states {word:?}, which a chip may not say",
+                        p.id
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_preset_names_a_corpus_entry() {
+        // The Rust half of the gate. The other half lives in
+        // `scripts/generate-citations.py`, which resolves these
+        // against the corpus and rejects a retracted, tier-E or
+        // non-in-app-citable record. This side only proves the field
+        // is populated and plausibly shaped, so a typo'd empty string
+        // fails here rather than being silently skipped there
+        for p in PRESETS {
+            assert!(!p.citekey.is_empty(), "{} has no citekey", p.id);
+            assert!(
+                p.citekey.contains('-') && p.citekey.chars().any(|c| c.is_ascii_digit()),
+                "{}: {:?} is not shaped like a citekey", p.id, p.citekey
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_out_of_band_presets_are_the_ones_that_announce_it() {
+        // The list ships two patterns outside the range with direct
+        // support, and neither hides it: selecting either makes the
+        // readout say so. This test is the link between the two
+        // modules, so deleting the coverage line from `pacing` fails
+        // here rather than quietly making the chip list a
+        // recommendation
+        for (id, expect_in_band) in [
+            ("even-5", true),
+            ("long-exhale-4-6", true),
+            ("a52", true),
+            ("box", false),
+            ("shipped-default", false),
+        ] {
+            let p = PRESETS.iter().find(|p| p.id == id).unwrap();
+            let mut s = Settings::default();
+            p.apply(&mut s);
+            let coverage = pacing::Coverage::of_displayed(
+                (s.breaths_per_min().unwrap() * 10.0).round() / 10.0,
+            );
+            let in_band = coverage == pacing::Coverage::Inside;
+            assert_eq!(in_band, expect_in_band, "{id} coverage was {coverage:?}");
+
+            let lines = pacing::readout_lines(&s);
+            if !in_band {
+                assert!(
+                    lines.last().unwrap().contains("slower than any of them"),
+                    "{id}: readout does not disclose it is outside the range: {lines:#?}"
+                );
+            }
+        }
+    }
+}

--- a/rust/crates/exhale-core/src/settings.rs
+++ b/rust/crates/exhale-core/src/settings.rs
@@ -337,9 +337,20 @@ impl Default for Settings {
             // via Preferences once is easy.
             app_visibility:      AppVisibility::Both,
 
+            // 5 / 0 / 5 / 0, six breaths a minute, no holds.
+            //
+            // Inside the 5-to-7 band `you2023-respiratory-frequency` tested
+            // directly, and the condition that won the four-way head-to-head in
+            // `marchant2025-square-478-six`. The previous default was 5 / 0 / 10 / 0,
+            // four a minute, which nobody has measured; it is still one click away
+            // as a preset.
+            //
+            // These fields carry no `#[serde(default)]`, so a settings.toml that
+            // predates this change keeps every value it already has. The move
+            // reaches fresh installs and Reset to Defaults, and nobody else.
             inhale_duration:           5.0,
             post_inhale_hold_duration: 0.0,
-            exhale_duration:           10.0,
+            exhale_duration:           5.0,
             post_exhale_hold_duration: 0.0,
             drift:                     1.0,
 
@@ -642,7 +653,7 @@ mod tests {
     fn defaults_match_swift_app() {
         let s = Settings::default();
         assert_eq!(s.inhale_duration, 5.0);
-        assert_eq!(s.exhale_duration, 10.0);
+        assert_eq!(s.exhale_duration, 5.0);
         assert_eq!(s.post_inhale_hold_duration, 0.0);
         assert_eq!(s.post_exhale_hold_duration, 0.0);
         assert!((s.drift - 1.0).abs() < 1e-9);
@@ -665,13 +676,14 @@ mod tests {
     }
 
     #[test]
-    fn shipped_default_is_four_breaths_a_minute() {
+    fn shipped_default_is_six_breaths_a_minute() {
         let s = Settings::default();
-        assert_eq!(s.cycle_secs(), 15.0);
-        assert!((s.breaths_per_min().unwrap() - 4.0).abs() < 1e-9);
-        // Pinned because gaps ledger item 2 is about this exact
-        // number sitting below the 5-to-7 band anyone has tested.
-        // If the default moves, that entry has to move with it
+        assert_eq!(s.cycle_secs(), 10.0);
+        assert!((s.breaths_per_min().unwrap() - 6.0).abs() < 1e-9);
+        // Pinned deliberately. Six a minute is inside the 5-to-7 band
+        // `you2023-respiratory-frequency` tested and is the condition
+        // that won `marchant2025-square-478-six`; gaps ledger item 2
+        // rests on this number, so moving it means moving that entry
         assert!(!s.drift_is_active());
     }
 
@@ -746,19 +758,23 @@ mod tests {
         // on this contrast: at 1 % the breath doubles inside a
         // sitting, at 0.1 % it takes most of a working day. Both are
         // allowed; the app just has to be able to say which is which
+        // From the 10 s default: 0.1 % reaches 13.6 s after an hour,
+        // still a pace someone would sit through
         let mut gentle = Settings::default();
         gentle.drift = 1.001;
         let after_an_hour = gentle.breaths_per_min_after(60.0).unwrap();
         assert!(
-            (3.0..4.0).contains(&after_an_hour),
+            (4.0..5.0).contains(&after_an_hour),
             "0.1 % for an hour gave {after_an_hour} a minute"
         );
 
+        // 1 % reaches 25 s in the same hour, and has more than doubled
+        // inside 17 minutes
         let mut steep = Settings::default();
         steep.drift = 1.01;
         let after_25_min = steep.breaths_per_min_after(25.0).unwrap();
         assert!(
-            after_25_min < 2.0,
+            after_25_min < 3.0,
             "1 % for 25 minutes gave {after_25_min} a minute"
         );
     }
@@ -770,7 +786,7 @@ mod tests {
         let mut s = Settings::default();
         s.drift = 0.99;
         assert!(s.drift_is_active());
-        assert!(s.breaths_per_min_after(1.0).unwrap() > 4.0);
+        assert!(s.breaths_per_min_after(1.0).unwrap() > 6.0);
         // Far enough out, the projected cycle passes through zero
         assert_eq!(s.breaths_per_min_after(10_000.0), None);
     }

--- a/rust/crates/exhale-core/src/settings.rs
+++ b/rust/crates/exhale-core/src/settings.rs
@@ -523,6 +523,85 @@ impl Settings {
         self.settings_window_screen  = win_screen;
     }
 
+    // ── Derived pacing arithmetic ────────────────────────────────────────
+    //
+    // These exist so the settings window can state what the current
+    // configuration actually does without storing a number that can go
+    // stale. Nothing here is a claim about the literature; it is
+    // division. That distinction is the reason the app can say it at
+    // all: an arithmetic statement cannot be retracted, so it carries
+    // none of the review risk that a health claim in a store-reviewed
+    // binary would.
+    //
+    // Deliberately computed from live `Settings` rather than attached
+    // to a preset. A rate cached alongside a preset is wrong the
+    // moment the user nudges one stepper, and wrong from the first
+    // cycle whenever `drift` is on.
+
+    /// Seconds in one full breath cycle at the current settings,
+    /// before any drift is applied.
+    ///
+    /// Ignores the randomisation sliders: they perturb individual
+    /// phases around these values without changing the mean, so the
+    /// jittered long-run rate is the same number with more variance
+    pub fn cycle_secs(&self) -> f64 {
+        self.inhale_duration
+            + self.post_inhale_hold_duration
+            + self.exhale_duration
+            + self.post_exhale_hold_duration
+    }
+
+    /// Breaths per minute at the start of a session.
+    ///
+    /// `None` when all four phases are zero, which is not a rate of
+    /// anything. Callers render nothing rather than an infinity
+    pub fn breaths_per_min(&self) -> Option<f64> {
+        let cycle = self.cycle_secs();
+        (cycle > 0.0).then(|| 60.0 / cycle)
+    }
+
+    /// Breaths per minute after `minutes` of continuous running, with
+    /// `drift` compounding.
+    ///
+    /// The closed form is exact at cycle boundaries and worth the
+    /// comment, because the obvious implementation is a loop. Cycle
+    /// `k` lasts `c · dᵏ`, so the elapsed time after `k` cycles is the
+    /// geometric sum `S = c·(dᵏ − 1)/(d − 1)`. Substituting the
+    /// current cycle length `D = c·dᵏ` gives `S = (D − c)/(d − 1)`,
+    /// and solving for `D` at `S = 60·minutes` collapses the whole
+    /// thing to a line with no `powi` and no logarithm:
+    ///
+    /// ```text
+    /// D = c + 60 · minutes · (d − 1)
+    /// ```
+    ///
+    /// The compounding is real; its *effect on elapsed wall time* is
+    /// simply linear. `d == 1` falls out as `D == c` with no special
+    /// case.
+    ///
+    /// `None` when the cycle is zero-length, and also when a drift
+    /// below 1.0 has shortened the projected cycle to nothing. Drift
+    /// cannot be set below 1.0 through the UI, but a hand-edited
+    /// settings file can, and a negative rate is not a thing to show
+    /// a user
+    pub fn breaths_per_min_after(&self, minutes: f64) -> Option<f64> {
+        let cycle = self.cycle_secs();
+        if cycle <= 0.0 {
+            return None;
+        }
+        let projected = cycle + 60.0 * minutes * (self.drift - 1.0);
+        (projected > 0.0).then(|| 60.0 / projected)
+    }
+
+    /// True when `drift` is doing anything at all.
+    ///
+    /// Uses the same `1e-9` epsilon `SettingsDiff::from` uses on this
+    /// field, so "the UI shows a drift line" and "a drift change marks
+    /// settings dirty" can never disagree
+    pub fn drift_is_active(&self) -> bool {
+        (self.drift - 1.0).abs() > 1e-9
+    }
+
     /// Returns true when inhale and exhale colors are perceptually
     /// identical, used to skip unnecessary redraws in the fullscreen shape
     pub fn inhale_exhale_colors_match(&self) -> bool {
@@ -583,6 +662,117 @@ mod tests {
         assert_eq!(deserialized.inhale_duration, original.inhale_duration);
         assert_eq!(deserialized.shape, original.shape);
         assert_eq!(deserialized.hold_ripple_mode, original.hold_ripple_mode);
+    }
+
+    #[test]
+    fn shipped_default_is_four_breaths_a_minute() {
+        let s = Settings::default();
+        assert_eq!(s.cycle_secs(), 15.0);
+        assert!((s.breaths_per_min().unwrap() - 4.0).abs() < 1e-9);
+        // Pinned because gaps ledger item 2 is about this exact
+        // number sitting below the 5-to-7 band anyone has tested.
+        // If the default moves, that entry has to move with it
+        assert!(!s.drift_is_active());
+    }
+
+    #[test]
+    fn box_breathing_is_slower_than_it_looks() {
+        // 4+4+4+4 reads like a beginner pattern and is 3.75 a minute,
+        // slower than the 5-to-7 band. The holds hide it, which is
+        // the whole reason the settings window does this division
+        // for the user. See gaps ledger item 3
+        let mut s = Settings::default();
+        s.inhale_duration           = 4.0;
+        s.post_inhale_hold_duration = 4.0;
+        s.exhale_duration           = 4.0;
+        s.post_exhale_hold_duration = 4.0;
+        assert!((s.breaths_per_min().unwrap() - 3.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_length_cycle_has_no_rate() {
+        let mut s = Settings::default();
+        s.inhale_duration           = 0.0;
+        s.post_inhale_hold_duration = 0.0;
+        s.exhale_duration           = 0.0;
+        s.post_exhale_hold_duration = 0.0;
+        assert_eq!(s.breaths_per_min(), None);
+        assert_eq!(s.breaths_per_min_after(10.0), None);
+    }
+
+    #[test]
+    fn drift_projection_matches_a_cycle_by_cycle_simulation() {
+        // The closed form in `breaths_per_min_after` replaces a loop
+        // with a line. This is the loop, kept as the oracle: walk
+        // real cycles, each `drift` times the last, until the clock
+        // passes the target, and compare the cycle actually in
+        // progress against what the formula predicted
+        for &drift in &[1.0, 1.0001, 1.001, 1.01] {
+            for &minutes in &[1.0, 10.0, 60.0, 300.0] {
+                let mut s = Settings::default();
+                s.drift = drift;
+
+                let mut cycle   = s.cycle_secs();
+                let mut elapsed = 0.0_f64;
+                while elapsed + cycle <= minutes * 60.0 {
+                    elapsed += cycle;
+                    cycle   *= drift;
+                }
+
+                let predicted = 60.0 / s.breaths_per_min_after(minutes).unwrap();
+                // The simulation reports the cycle in progress, so it
+                // lags the continuous formula by at most one cycle
+                assert!(
+                    predicted >= cycle - 1e-9 && predicted <= cycle * drift + 1e-9,
+                    "drift={drift} minutes={minutes}: formula {predicted} \
+                     outside simulated cycle [{cycle}, {}]",
+                    cycle * drift,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn drift_off_projects_a_flat_rate() {
+        let s = Settings::default();
+        for &minutes in &[0.0, 1.0, 1_000.0] {
+            assert_eq!(s.breaths_per_min_after(minutes), s.breaths_per_min());
+        }
+    }
+
+    #[test]
+    fn one_step_of_drift_is_gentle_and_one_percent_is_not() {
+        // The stepper's smallest increment. Gaps ledger item 6 turns
+        // on this contrast: at 1 % the breath doubles inside a
+        // sitting, at 0.1 % it takes most of a working day. Both are
+        // allowed; the app just has to be able to say which is which
+        let mut gentle = Settings::default();
+        gentle.drift = 1.001;
+        let after_an_hour = gentle.breaths_per_min_after(60.0).unwrap();
+        assert!(
+            (3.0..4.0).contains(&after_an_hour),
+            "0.1 % for an hour gave {after_an_hour} a minute"
+        );
+
+        let mut steep = Settings::default();
+        steep.drift = 1.01;
+        let after_25_min = steep.breaths_per_min_after(25.0).unwrap();
+        assert!(
+            after_25_min < 2.0,
+            "1 % for 25 minutes gave {after_25_min} a minute"
+        );
+    }
+
+    #[test]
+    fn a_shortening_drift_never_reports_a_negative_rate() {
+        // Not reachable through the UI, which clamps display at 0 %,
+        // but a hand-edited settings file can hold drift < 1.0
+        let mut s = Settings::default();
+        s.drift = 0.99;
+        assert!(s.drift_is_active());
+        assert!(s.breaths_per_min_after(1.0).unwrap() > 4.0);
+        // Far enough out, the projected cycle passes through zero
+        assert_eq!(s.breaths_per_min_after(10_000.0), None);
     }
 
     #[test]

--- a/rust/crates/exhale-core/src/settings.rs
+++ b/rust/crates/exhale-core/src/settings.rs
@@ -34,6 +34,14 @@ pub struct Settings {
     pub post_exhale_hold_duration: f64,
 
     /// Per-cycle duration multiplier. 1.01 = each cycle 1 % longer (drift).
+    ///
+    /// Defaults to 1.0 (off). Pranayama's graded extension is the reason this
+    /// exists and it is a reasonable thing to turn on, but it should not be
+    /// imposed: heart-rate-variability amplitude peaks at 4.5-6.5 breaths a
+    /// minute rather than rising without limit, and exhale's default cadence
+    /// already sits below that band, so drifting slower from cycle one moves
+    /// every new user further from the studied range. When it IS on, the
+    /// compounding is bounded by [`crate::controller::DRIFT_MAX_CYCLE_SECS`].
     pub drift: f64,
 
     // ── Randomisation (±seconds of jitter per phase) ─────────────────────────
@@ -333,7 +341,7 @@ impl Default for Settings {
             post_inhale_hold_duration: 0.0,
             exhale_duration:           10.0,
             post_exhale_hold_duration: 0.0,
-            drift:                     1.01,
+            drift:                     1.0,
 
             randomized_timing_inhale:             0.0,
             randomized_timing_post_inhale_hold:   0.0,
@@ -558,7 +566,7 @@ mod tests {
         assert_eq!(s.exhale_duration, 10.0);
         assert_eq!(s.post_inhale_hold_duration, 0.0);
         assert_eq!(s.post_exhale_hold_duration, 0.0);
-        assert!((s.drift - 1.01).abs() < 1e-9);
+        assert!((s.drift - 1.0).abs() < 1e-9);
         assert!((s.overlay_opacity - 0.25).abs() < 1e-6);
         assert_eq!(s.shape, AnimationShape::Rectangle);
         assert_eq!(s.color_fill_gradient, ColorFillGradient::On);

--- a/rust/packaging/windows/store-listing.md
+++ b/rust/packaging/windows/store-listing.md
@@ -1,0 +1,109 @@
+# Microsoft Store listing copy
+
+The Partner Center form field values for the exhale listing (Store ID `9P79Z1NJMZB3`).
+
+**Why this is tracked.** These strings are promotional copy, and under MDR/FTC reasoning promotional
+copy is what establishes a product's intended purpose. They are also the surface that has already
+rotted once: this listing and `snap/snapcraft.yaml` went on asserting two claims for a further two
+days after [`docs/citations-notes.md`](../../../docs/citations-notes.md) retracted them, in gaps
+ledger items 1 and 4. Living in an untracked scratch file, they were invisible to CI and to review.
+
+(Those phrases are deliberately not quoted here. This file is a surface the denylist scans for
+assertions, and it cannot tell a quotation from a claim; only `docs/` and `README.md` are exempt,
+because they are the retraction record itself.)
+
+`scripts/generate-citations.py --check` scans this file against the retracted-phrase denylist, so a
+withdrawn claim surviving here now fails the build. Keep it that way: if the listing copy moves,
+move the entry in `ASSERTING_SURFACES` with it.
+
+Build and upload mechanics are in [DEPLOYMENT.md](../../../DEPLOYMENT.md#windows--microsoft-store),
+not here. This file is only the words.
+
+---
+
+## Description
+
+```
+A minimal cross-platform breathing overlay: a friendly indicator and reminder to take full, deep breaths while looking at screens. Screen work measurably changes how you breathe: at a keyboard, people breathe faster and higher in the chest, and slumped screen posture reduces how much the diaphragm can do. Slow paced breathing is the countermeasure with the most evidence behind it, and exhale is a way to run one with no sensor, no account and no telemetry.
+
+The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable. A good place to start is 5 seconds in and 5 seconds out, which is 6 breaths a minute. Rates from 5 to 7 a minute are the ones that have been tested directly. Box breathing (4 / 4 / 4 / 4) is also supported.
+
+Every claim above is sourced, alongside a ledger of what the research does not support, at https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md
+
+Every action (Start, Stop, Reset, Quit, Preferences) is rebindable to a global keyboard shortcut. Fully keyboard-navigable Preferences panel. Runs as a menu-bar / system-tray app; the overlay itself is click-through so it never interrupts whatever you're doing.
+
+Take breaks if intense feelings arise; it's important not to overdo it.
+
+---
+Disclaimer: The information and guidance provided by this app are intended for general informational purposes only and are not medical advice. The creator is not a medical professional. Always seek the advice of a qualified healthcare provider with any questions about your health, and do not disregard or delay professional medical advice because of this app. Use is at your own risk.
+```
+
+## Short description (150 char max)
+
+```
+A translucent breathing overlay that gently expands on inhale and contracts on exhale: a friendly reminder to breathe fully while staring at screens.
+```
+
+## Search terms (keywords)
+
+```
+breathing, mindfulness, focus, breath, reminder, meditation, productivity, calm, relaxation, mental health, box breathing, pranayama, wellness, overlay, screen, blink
+```
+
+## What's new in this version
+
+Per-release, so it is **not** pinned here. Take it from the release notes for the tag being
+submitted. The v2.0.21 text, kept as a shape reference:
+
+```
+Rebuilt from the ground up in Rust. ~36% lower CPU vs the prior build. Every action has a customizable global keyboard shortcut, full keyboard navigation in Preferences, inline reset confirmation, smoother Start/Stop transitions, near-zero CPU when all four breath durations are set to zero (treated as a static tint).
+```
+
+## Copyright and trademark info
+
+```
+© Peter Klingelhofer
+```
+
+## Support contact info
+
+- **Support email**: `peterklingelhofer@gmail.com`
+- **Support URL**: `https://github.com/peterklingelhofer/exhale/issues`
+- **Website**: `https://github.com/peterklingelhofer/exhale`
+
+## Privacy policy URL
+
+```
+https://github.com/peterklingelhofer/exhale/blob/main/PRIVACY.md
+```
+
+## Category / Subcategory
+
+- Primary category: **Health & fitness** (matches the Mac App Store category)
+- Subcategory: **Fitness**
+
+## System requirements
+
+- **Minimum OS**: Windows 10 version 1809 (build 17763), matching `MinVersion` in
+  [AppxManifest.xml](AppxManifest.xml)
+- **Recommended architecture**: x64
+- No special hardware requirements
+
+## Pricing and availability
+
+- **Markets**: All (default for free apps)
+- **Price**: Free
+- **Visibility**: Public
+- **Schedule**: Release as soon as possible after certification
+
+## Age ratings
+
+Every answer for exhale is **No**: violence, sexual content, controlled substances, gambling,
+in-app purchases, user-generated content. Result should come back everyone-friendly
+(ESRB "Everyone" / PEGI 3 / USK 0).
+
+**Re-check this if a research surface ever ships inside the binary.** The questionnaire asks whether
+the app contains medical or treatment information, and today the honest answer is no: the binary
+carries no health claims and no disclaimer, only a wordless overlay and four numeric sliders. Adding
+in-app evidentiary text could change that answer and re-trigger review. See
+[RESEARCH-SURFACE-HANDOFF.md](../../../RESEARCH-SURFACE-HANDOFF.md).

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -141,27 +141,28 @@ def check_cross_references(records: list[dict]) -> None:
         raise CorpusError("\n".join("  - " + p for p in problems))
 
 
-# Claims this project has retracted. The gaps ledger records WHY each was
-# withdrawn; this list is what stops a withdrawn claim surviving somewhere the
-# ledger has no jurisdiction.
+# Claims the corpus does not support, kept out of the surfaces that assert them.
 #
 # Scope is deliberate. Only surfaces that ASSERT are scanned: store listings and
-# anything compiled into the binary. `docs/` and `README.md` are exempt because
-# they are the retraction record itself and have to be able to quote what they
-# withdraw. snapcraft.yaml went on shipping the parasympathetic claim to the
-# Snap Store for two days after the README retracted it, which is the exact
-# failure this catches
-RETRACTED_PHRASES: list[tuple[str, str]] = [
-    ("engage the parasympathetic nervous system", "gaps ledger 4: split 2-for / 1-against / 1-null"),
-    ("engages the parasympathetic nervous system", "gaps ledger 4: split 2-for / 1-against / 1-null"),
-    ("breathe more shallowly", "gaps ledger 1: unsupported as stated; the finding is faster and chest-high"),
-    ("screen apnea", "gaps ledger 1: no peer-reviewed source"),
-    ("email apnea", "gaps ledger 1: no peer-reviewed source"),
+# anything compiled into the binary. `docs/` and `README.md` are exempt, because
+# the gaps ledger has to be able to name a claim in order to explain what the
+# evidence actually says about it.
+#
+# This is not hypothetical. `snapcraft.yaml` went on shipping the parasympathetic
+# claim to the Snap Store for two days after the README had stopped making it,
+# because a store listing is edited in a different place from a README and
+# nothing connected the two
+UNSUPPORTED_PHRASES: list[tuple[str, str]] = [
+    ("engage the parasympathetic nervous system", "gaps ledger 4: the cardiac evidence splits 2-for / 1-against / 1-null"),
+    ("engages the parasympathetic nervous system", "gaps ledger 4: the cardiac evidence splits 2-for / 1-against / 1-null"),
+    ("breathe more shallowly", "gaps ledger 1: the measured finding is faster and chest-high, not shallower"),
+    ("screen apnea", "gaps ledger 1: no peer-reviewed source; the measured effect points the other way"),
+    ("email apnea", "gaps ledger 1: no peer-reviewed source; the measured effect points the other way"),
 ]
 
 # Surfaces where one of the phrases above would be an assertion rather than a
-# citation of one. Missing files are skipped: the Microsoft handoff is untracked,
-# so it is present locally and absent in CI
+# discussion of one. Missing files are skipped: the Microsoft handoff is
+# untracked, so it is present locally and absent in CI
 ASSERTING_SURFACES: list[str] = [
     "snap/snapcraft.yaml",
     "rust/packaging/windows/AppxManifest.xml",
@@ -172,8 +173,8 @@ ASSERTING_SURFACES: list[str] = [
 ASSERTING_GLOBS: list[str] = ["rust/crates/**/*.rs"]
 
 
-def check_retracted_phrases() -> None:
-    """Fail if a withdrawn claim survives on a surface that asserts it."""
+def check_unsupported_phrases() -> None:
+    """Fail if an unsupported claim survives on a surface that asserts it."""
     targets = [ROOT / rel for rel in ASSERTING_SURFACES]
     for pattern in ASSERTING_GLOBS:
         targets.extend(sorted(ROOT.glob(pattern)))
@@ -187,11 +188,11 @@ def check_retracted_phrases() -> None:
         except (UnicodeDecodeError, OSError):
             continue
         lowered = text.lower()
-        for phrase, why in RETRACTED_PHRASES:
+        for phrase, why in UNSUPPORTED_PHRASES:
             if phrase in lowered:
                 line = lowered[: lowered.index(phrase)].count("\n") + 1
                 rel = path.relative_to(ROOT)
-                problems.append(f"{rel}:{line} still asserts \"{phrase}\" ({why})")
+                problems.append(f"{rel}:{line} asserts \"{phrase}\" ({why})")
 
     if problems:
         raise CorpusError("\n".join("  - " + p for p in problems))
@@ -454,18 +455,30 @@ def render_corpus(records: list[dict]) -> str:
     return "\n".join(out).rstrip()
 
 
+# How each verification status is named in the one-line summary. Driven off the
+# same enum the validator uses, so adding a source verified some new way is a
+# KeyError here rather than a source that silently vanishes from the count. The
+# previous hand-written version added up to 47 of 48 for exactly that reason
+VERIFICATION_LABELS = {
+    "crossref-verified":    "Crossref-verified",
+    "openlibrary-verified": "verified against Open Library",
+    "pubmed-verified":      "verified against PubMed",
+    "unverified":           "unverified",
+}
+
+
 def render_summary(records: list[dict]) -> str:
-    verified = sum(
-        1 for r in records if r["custom"]["verification"] == "crossref-verified"
-    )
-    catalogued = sum(
-        1 for r in records if r["custom"]["verification"] == "openlibrary-verified"
-    )
+    counts = collections.Counter(r["custom"]["verification"] for r in records)
+    parts = [
+        f"{counts[key]} {VERIFICATION_LABELS[key]}"
+        for key in VERIFICATION_LABELS
+        if counts[key]
+    ]
     unread = sum(1 for r in records if "NUMBERS NOT READ" in (r["custom"].get("caveat") or ""))
     tiered_out = sum(1 for r in records if r["custom"].get("evidenceTier") == "E")
     return (
-        f"{len(records)} sources: {verified} Crossref-verified, {catalogued} verified against "
-        f"Open Library. {unread} are cited from their abstract only and say so, and "
+        f"{len(records)} sources: {', '.join(parts)}. "
+        f"{unread} are cited from their abstract only and say so, and "
         f"{tiered_out} are not peer-reviewed and are tiered E so they can back lineage but "
         f"never a claim."
     )
@@ -478,7 +491,7 @@ def main() -> int:
         records = load_corpus()
         check_cross_references(records)
         check_preset_citekeys(records)
-        check_retracted_phrases()
+        check_unsupported_phrases()
         notes = NOTES.read_text(encoding="utf-8")
         check_note_links(records, notes, NOTES.name)
         if README.exists():

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -27,6 +27,8 @@ CORPUS = DOCS / "CITATIONS.csl.json"
 NOTES = DOCS / "citations-notes.md"
 OUT = DOCS / "CITATIONS.md"
 README = ROOT / "README.md"
+# The one place the shipped binary names this document. See check_binary_deep_link
+TRAY = ROOT / "rust/crates/exhale-app/src/tray.rs"
 
 # Section order in the rendered document. Each group answers one question the
 # app actually raises, rather than following the shape of the literature
@@ -205,6 +207,50 @@ def check_note_links(records: list[dict], text: str, where: str) -> None:
         )
 
 
+def slugify(heading: str) -> str:
+    """GitHub's heading-anchor rule, reduced to what these headings use.
+
+    Lowercase, drop everything that is not a word character, space or hyphen,
+    then spaces to hyphens. The corpus headings are plain prose, so the full
+    GitHub algorithm (duplicate suffixes, emoji, HTML) buys nothing here
+    """
+    slug = heading.strip().lower()
+    slug = re.sub(r"[^\w \-]", "", slug)
+    return slug.replace(" ", "-")
+
+
+def check_binary_deep_link(rendered: str) -> None:
+    """The tray menu's URL is the only reference to this document that ships.
+
+    Every other link into the corpus lives in a file the reader can see is
+    stale. This one is compiled into a binary that stays installed for months,
+    so a renamed heading strands a user on the top of a 48-entry list at the
+    exact moment they went looking for the limits. Renaming the heading is
+    allowed; renaming it silently is not
+    """
+    if not TRAY.exists():
+        return
+
+    m = re.search(r'RESEARCH_URL: &str =\s*\n?\s*"([^"]+)"', TRAY.read_text(encoding="utf-8"))
+    if not m:
+        raise CorpusError(
+            f"  - {TRAY.relative_to(ROOT)} no longer defines RESEARCH_URL; the shipped\n"
+            "    binary has lost its only pointer at the evidence"
+        )
+
+    url = m.group(1)
+    path, _, fragment = url.partition("#")
+    if not path.endswith("/docs/CITATIONS.md"):
+        raise CorpusError(f"  - RESEARCH_URL points outside the corpus: {url}")
+
+    anchors = {slugify(h) for h in re.findall(r"^#{1,6} +(.+)$", rendered, re.M)}
+    if fragment not in anchors:
+        raise CorpusError(
+            f"  - RESEARCH_URL anchor #{fragment} matches no heading in {OUT.name}.\n"
+            f"    The tray menu would drop the reader at the top of the file instead"
+        )
+
+
 def authors(rec: dict) -> str:
     people = rec.get("author") or []
     return "; ".join(
@@ -354,6 +400,12 @@ def main() -> int:
 
     if not rendered.endswith("\n"):
         rendered += "\n"
+
+    try:
+        check_binary_deep_link(rendered)
+    except CorpusError as exc:
+        print(f"{OUT.name}: broken deep link\n{exc}", file=sys.stderr)
+        return 1
 
     if check:
         current = OUT.read_text(encoding="utf-8") if OUT.exists() else ""

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -21,10 +21,12 @@ import re
 import sys
 from pathlib import Path
 
-DOCS = Path(__file__).resolve().parent.parent / "docs"
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs"
 CORPUS = DOCS / "CITATIONS.csl.json"
 NOTES = DOCS / "citations-notes.md"
 OUT = DOCS / "CITATIONS.md"
+README = ROOT / "README.md"
 
 # Section order in the rendered document. Each group answers one question the
 # app actually raises, rather than following the shape of the literature
@@ -39,7 +41,7 @@ GROUPS = [
 ]
 GROUP_IDS = {g for g, _ in GROUPS}
 
-VERIFICATIONS = {"crossref-verified", "openlibrary-verified", "unverified"}
+VERIFICATIONS = {"crossref-verified", "openlibrary-verified", "pubmed-verified", "unverified"}
 ACCESS_LEVELS = {"open-access", "paywalled"}
 TIERS = {"A", "B", "C", "D", "E", None}
 
@@ -127,18 +129,77 @@ def check_cross_references(records: list[dict]) -> None:
         raise CorpusError("\n".join("  - " + p for p in problems))
 
 
-def check_note_links(records: list[dict], notes: str) -> None:
-    """The gaps ledger links to entries by anchor. Catch the ones that rot."""
+# Claims this project has retracted. The gaps ledger records WHY each was
+# withdrawn; this list is what stops a withdrawn claim surviving somewhere the
+# ledger has no jurisdiction.
+#
+# Scope is deliberate. Only surfaces that ASSERT are scanned: store listings and
+# anything compiled into the binary. `docs/` and `README.md` are exempt because
+# they are the retraction record itself and have to be able to quote what they
+# withdraw. snapcraft.yaml went on shipping the parasympathetic claim to the
+# Snap Store for two days after the README retracted it, which is the exact
+# failure this catches
+RETRACTED_PHRASES: list[tuple[str, str]] = [
+    ("engage the parasympathetic nervous system", "gaps ledger 4: split 2-for / 1-against / 1-null"),
+    ("engages the parasympathetic nervous system", "gaps ledger 4: split 2-for / 1-against / 1-null"),
+    ("breathe more shallowly", "gaps ledger 1: unsupported as stated; the finding is faster and chest-high"),
+    ("screen apnea", "gaps ledger 1: no peer-reviewed source"),
+    ("email apnea", "gaps ledger 1: no peer-reviewed source"),
+]
+
+# Surfaces where one of the phrases above would be an assertion rather than a
+# citation of one. Missing files are skipped: the Microsoft handoff is untracked,
+# so it is present locally and absent in CI
+ASSERTING_SURFACES: list[str] = [
+    "snap/snapcraft.yaml",
+    "rust/packaging/windows/AppxManifest.xml",
+    "MICROSOFT_STORE_HANDOFF.md",
+]
+ASSERTING_GLOBS: list[str] = ["rust/crates/**/*.rs"]
+
+
+def check_retracted_phrases() -> None:
+    """Fail if a withdrawn claim survives on a surface that asserts it."""
+    targets = [ROOT / rel for rel in ASSERTING_SURFACES]
+    for pattern in ASSERTING_GLOBS:
+        targets.extend(sorted(ROOT.glob(pattern)))
+
+    problems: list[str] = []
+    for path in targets:
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        lowered = text.lower()
+        for phrase, why in RETRACTED_PHRASES:
+            if phrase in lowered:
+                line = lowered[: lowered.index(phrase)].count("\n") + 1
+                rel = path.relative_to(ROOT)
+                problems.append(f"{rel}:{line} still asserts \"{phrase}\" ({why})")
+
+    if problems:
+        raise CorpusError("\n".join("  - " + p for p in problems))
+
+
+def check_note_links(records: list[dict], text: str, where: str) -> None:
+    """Prose links to entries by anchor. Catch the ones that rot.
+
+    Both the gaps ledger and the README deep-link into the corpus by citekey.
+    A rename silently breaks every one of them, and the README is the project's
+    front door, so it is checked on exactly the same footing as the notes
+    """
     known = {r["id"] for r in records}
     # Only anchors shaped like a citekey are entry references; the rest are
     # ordinary intra-document links to headings in the notes
-    referenced = {
-        a for a in re.findall(r"\]\(#([a-z0-9-]+)\)", notes) if ID_RE.match(a)
-    }
+    # The notes link as (#citekey); the README links as (docs/CITATIONS.md#citekey)
+    anchors = re.findall(r"\]\((?:docs/CITATIONS\.md)?#([a-z0-9-]+)\)", text)
+    referenced = {a for a in anchors if ID_RE.match(a)}
     dangling = sorted(referenced - known)
     if dangling:
         raise CorpusError(
-            "\n".join(f"  - {NOTES.name} links to unknown entry #{d}" for d in dangling)
+            "\n".join(f"  - {where} links to unknown entry #{d}" for d in dangling)
         )
 
 
@@ -178,13 +239,18 @@ def render_entry(rec: dict) -> list[str]:
     source = rec.get("container-title") or ": ".join(
         p for p in (rec.get("publisher-place"), rec.get("publisher")) if p
     )
-    head = f'{authors(rec)}. ({year(rec)}). *{rec["title"]}*{tail} {source}'
+    who = authors(rec)
+    # An author list ending in an initial already supplies its own period
+    who_sep = "" if who.endswith(".") else "."
+    head = f'{who}{who_sep} ({year(rec)}). *{rec["title"]}*{tail} {source}'
     loc = locator(rec)
     lines.append(head + (f" {loc}" if loc else ""))
     lines.append("")
 
     if rec.get("DOI"):
         lines.append(f'- DOI: [{rec["DOI"]}](https://doi.org/{rec["DOI"]})')
+    elif rec.get("PMID"):
+        lines.append(f'- PMID: [{rec["PMID"]}]({rec["URL"]}) (no DOI exists)')
     elif rec.get("ISBN"):
         lines.append(f'- ISBN: {rec["ISBN"]} | [Open Library record]({rec["URL"]})')
     elif rec.get("URL"):
@@ -264,8 +330,11 @@ def main() -> int:
     try:
         records = load_corpus()
         check_cross_references(records)
+        check_retracted_phrases()
         notes = NOTES.read_text(encoding="utf-8")
-        check_note_links(records, notes)
+        check_note_links(records, notes, NOTES.name)
+        if README.exists():
+            check_note_links(records, README.read_text(encoding="utf-8"), README.name)
     except CorpusError as exc:
         print(f"{CORPUS.name}: invalid corpus\n{exc}", file=sys.stderr)
         return 1

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -153,6 +153,8 @@ RETRACTED_PHRASES: list[tuple[str, str]] = [
 ASSERTING_SURFACES: list[str] = [
     "snap/snapcraft.yaml",
     "rust/packaging/windows/AppxManifest.xml",
+    "rust/packaging/windows/store-listing.md",
+    # Untracked scratch file: present locally, absent in CI, skipped either way
     "MICROSOFT_STORE_HANDOFF.md",
 ]
 ASSERTING_GLOBS: list[str] = ["rust/crates/**/*.rs"]

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -327,6 +327,11 @@ def check_binary_deep_link(rendered: str) -> None:
     so a renamed heading strands a user on the top of a 48-entry list at the
     exact moment they went looking for the limits. Renaming the heading is
     allowed; renaming it silently is not
+
+    The menu may point either at the file on GitHub or at docs/citations.html,
+    which fetches that same file from `main` and renders it. Both are the
+    corpus and both break identically when an anchor moves, so both are
+    accepted and the anchor is checked the same way either way
     """
     if not TRAY.exists():
         return
@@ -340,7 +345,7 @@ def check_binary_deep_link(rendered: str) -> None:
 
     url = m.group(1)
     path, _, fragment = url.partition("#")
-    if not path.endswith("/docs/CITATIONS.md"):
+    if not path.endswith(("/docs/CITATIONS.md", "/exhale/citations.html")):
         raise CorpusError(f"  - RESEARCH_URL points outside the corpus: {url}")
 
     anchors = {slugify(h) for h in re.findall(r"^#{1,6} +(.+)$", rendered, re.M)}

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -16,6 +16,7 @@ Stdlib only, so it runs anywhere the repo is checked out
 
 from __future__ import annotations
 
+import collections
 import json
 import re
 import sys
@@ -207,6 +208,40 @@ def check_note_links(records: list[dict], text: str, where: str) -> None:
         )
 
 
+def check_readme_counts(records: list[dict], text: str) -> None:
+    """The README states the size of the corpus. Make it prove it.
+
+    These numbers were wrong for the entire life of the previous commit: the
+    README advertised 42 sources verified 40 / 2 while the corpus held 48
+    verified 45 / 2 / 1. Nothing caught it, because a number in prose looks
+    exactly like a number in prose. Undercounting is the harmless direction and
+    it is still the project's front door claiming a provenance figure it had
+    not checked, which is the specific failure this whole apparatus exists to
+    prevent
+    """
+    counts = collections.Counter(r["custom"]["verification"] for r in records)
+    # Each phrase is matched wherever it appears, so the lede and the research
+    # section cannot drift apart from each other either
+    expected = [
+        (r"(\d+)\s+sources", len(records), "total sources"),
+        (r"(\d+)\s+verified references", len(records), "verified references"),
+        (r"(\d+)\s+verified against the Crossref REST API", counts["crossref-verified"], "Crossref"),
+        (r"(\d+)\s+against Open Library", counts["openlibrary-verified"], "Open Library"),
+        (r"(\d+)\s+against PubMed", counts["pubmed-verified"], "PubMed"),
+    ]
+    problems = []
+    for pattern, want, what in expected:
+        found = re.findall(pattern, text)
+        if not found:
+            problems.append(f"README.md no longer states the {what} count")
+            continue
+        for got in found:
+            if int(got) != want:
+                problems.append(f"README.md says {got} for {what}; the corpus holds {want}")
+    if problems:
+        raise CorpusError("\n".join("  - " + p for p in problems))
+
+
 def slugify(heading: str) -> str:
     """GitHub's heading-anchor rule, reduced to what these headings use.
 
@@ -382,7 +417,9 @@ def main() -> int:
         notes = NOTES.read_text(encoding="utf-8")
         check_note_links(records, notes, NOTES.name)
         if README.exists():
-            check_note_links(records, README.read_text(encoding="utf-8"), README.name)
+            readme = README.read_text(encoding="utf-8")
+            check_note_links(records, readme, README.name)
+            check_readme_counts(records, readme)
     except CorpusError as exc:
         print(f"{CORPUS.name}: invalid corpus\n{exc}", file=sys.stderr)
         return 1

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -30,6 +30,8 @@ OUT = DOCS / "CITATIONS.md"
 README = ROOT / "README.md"
 # The one place the shipped binary names this document. See check_binary_deep_link
 TRAY = ROOT / "rust/crates/exhale-app/src/tray.rs"
+# Patterns the binary offers as one click. See check_preset_citekeys
+PRESETS = ROOT / "rust/crates/exhale-core/src/presets.rs"
 
 # Section order in the rendered document. Each group answers one question the
 # app actually raises, rather than following the shape of the literature
@@ -98,6 +100,13 @@ def load_corpus() -> list[dict]:
             problems.append(f"{rid}: accessLevel must be one of {sorted(ACCESS_LEVELS)}")
         if custom.get("evidenceTier", "missing") not in TIERS:
             problems.append(f"{rid}: evidenceTier must be A-E or null")
+        # Absent means citable; only an explicit `false` blocks a record
+        # from backing something the binary ships. Written as an opt-OUT so
+        # the corpus does not need touching for the common case, and so the
+        # blocklist is greppable as four lines rather than inferred from
+        # forty-four omissions
+        if custom.get("inAppCitable", False) not in (True, False):
+            problems.append(f"{rid}: inAppCitable must be true or false")
 
         claims = custom.get("backsClaims")
         if not isinstance(claims, list) or not claims:
@@ -206,6 +215,61 @@ def check_note_links(records: list[dict], text: str, where: str) -> None:
         raise CorpusError(
             "\n".join(f"  - {where} links to unknown entry #{d}" for d in dangling)
         )
+
+
+def check_preset_citekeys(records: list[dict]) -> None:
+    """Every pattern the app offers has to be traceable to a live record.
+
+    The preset list is the one place the binary makes a *selection* from the
+    literature rather than a statement about it, and a selection is an
+    argument whether or not it is worded as one. Offering five patterns says
+    these five are worth a click, so each carries a citekey that never reaches
+    the screen and exists only to fail this check.
+
+    Four conditions, and the third and fourth are the ones that earn their
+    keep. A record downgraded to tier E is lineage-only and cannot license a
+    default. A record marked `inAppCitable: false` is one the professor
+    blocklisted from a store-reviewed binary, which is a different judgement
+    from whether it is good evidence: `fincham2023` is the strongest warrant
+    in the corpus and is on that list
+    """
+    if not PRESETS.exists():
+        return
+
+    text = PRESETS.read_text(encoding="utf-8")
+    # `citekey: "..."` inside the const table. Comments mention citekeys in
+    # prose, so anchor on the field name rather than scanning for the shape
+    found = re.findall(r'citekey:\s*"([^"]*)"', text)
+    if not found:
+        raise CorpusError(
+            f"  - {PRESETS.relative_to(ROOT)} defines no preset citekeys; the shipped\n"
+            "    patterns have lost their link to the corpus"
+        )
+
+    by_id = {r["id"]: r for r in records}
+    problems: list[str] = []
+    for key in sorted(set(found)):
+        rec = by_id.get(key)
+        if rec is None:
+            problems.append(f"preset citekey '{key}' matches no corpus entry")
+            continue
+        custom = rec["custom"]
+        if custom["group"] not in ("timing", "slow-breathing"):
+            problems.append(
+                f"preset citekey '{key}' is group '{custom['group']}'; a preset has to be "
+                "backed by a timing or slow-breathing record"
+            )
+        if custom.get("evidenceTier") == "E":
+            problems.append(
+                f"preset citekey '{key}' is tier E, which is citable for lineage only"
+            )
+        if custom.get("inAppCitable", True) is False:
+            problems.append(
+                f"preset citekey '{key}' is marked inAppCitable: false and may not back "
+                "anything the binary ships"
+            )
+    if problems:
+        raise CorpusError("\n".join("  - " + p for p in problems))
 
 
 def check_readme_counts(records: list[dict], text: str) -> None:
@@ -413,6 +477,7 @@ def main() -> int:
     try:
         records = load_corpus()
         check_cross_references(records)
+        check_preset_citekeys(records)
         check_retracted_phrases()
         notes = NOTES.read_text(encoding="utf-8")
         check_note_links(records, notes, NOTES.name)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,17 +5,24 @@ version: '2.0.22'
 summary: A full-screen breathing overlay for mindful breathing.
 description: |
   A minimal cross-platform breathing overlay, a friendly indicator and
-  reminder to take full, deep breaths while looking at screens. Research
-  indicates we blink less and breathe more shallowly when staring at
-  displays, and exhale is a small tool to help counter that.
+  reminder to take full, deep breaths while looking at screens. Screen work
+  measurably changes how you breathe: at a keyboard, people breathe faster
+  and higher in the chest, and slumped screen posture reduces how much the
+  diaphragm can do. Slow paced breathing is the countermeasure with the most
+  evidence behind it, and exhale is a way to run one with no sensor, no
+  account and no telemetry.
 
   The overlay is a translucent, always-on-top, click-through window that
   gently expands on inhale and contracts on exhale, so it never interrupts
   whatever you are doing. Inhale, post-inhale hold, exhale, and post-exhale
-  hold durations are all configurable. A good starting point is 4 seconds in
-  and 4 seconds out; eventually 6 and 8, with the exhale twice as long as the
-  inhale to engage the parasympathetic nervous system. Box breathing is
-  4 / 4 / 4 / 4.
+  hold durations are all configurable. A good place to start is 5 seconds in
+  and 5 seconds out, which is 6 breaths a minute. Rates from 5 to 7 a minute
+  are the ones that have been tested directly. Box breathing
+  (4 / 4 / 4 / 4) is also supported.
+
+  Every claim above is sourced, alongside a ledger of what the research does
+  not support, at
+  https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md
 
   Features:
   - Translucent, click-through overlay that expands on inhale and contracts


### PR DESCRIPTION
Eleven commits off `main`, no divergence to resolve.

## Settings and pacing
- Default pattern is now 5/0/5/0, six breaths a minute.
- Breathing patterns are offered as one-click presets, chips fitted to one row.
- The current pace is shown against the tested range, and drift is counted in breaths.

## Research surface
- The tray and the macOS app menu both link to the gaps ledger rather than the top of the corpus.
- `docs/citations.html` renders `docs/CITATIONS.md` for readers who should not have to land in a code host's file browser. It fetches the file from `main` at load, so a correction or a retraction reaches the page without a release. GitHub Pages serves it from `main` `/docs`.
- `RESEARCH_URL` now points at that page. `check_binary_deep_link` accepts either surface and validates the anchor identically for both, so a renamed heading is still a CI failure.
- Heading slugs are generated in the page with the same rule as `scripts/generate-citations.py`, verified identical across all 77 headings.

## Fixes
- The macOS activation-policy test restored `NSApp` through a hand-written `msg_send!` that declared `()` where AppKit returns `BOOL`, which tripped objc2's runtime encoding check and failed the test. It now uses the same typed binding the production path uses.

## Verification
- `cargo test --workspace`: 152 passed, 0 failed.
- `cargo clippy -p exhale-app --bins --tests`: clean.
- `uv run --no-project scripts/generate-citations.py --check`: passes.
- Not verified: how `citations.html` looks in a browser. It cannot be loaded until it is on `main` and Pages has built.
