### PR TITLE
fix(docs): keep a scrollspy failure from masking the rendered corpus

### DIFF
--- a/docs/citations.html
+++ b/docs/citations.html
@@ -7,6 +7,8 @@
 <meta name="description" content="Every claim and default in exhale, with the published evidence behind it and a ledger of what the evidence does not support.">
 <meta name="color-scheme" content="light dark">
 <link rel="canonical" href="https://peterklingelhofer.github.io/exhale/citations.html">
+<!-- Inline so the page stays one file and the browser stops asking for /favicon.ico -->
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Ccircle%20cx='16'%20cy='16'%20r='11'%20fill='none'%20stroke='%230f6d68'%20stroke-width='3'/%3E%3C/svg%3E">
 <style>
   :root {
     --bg: #fbfaf8;
@@ -387,7 +389,10 @@
         current = links[entry.target.id];
         if (current) current.setAttribute("aria-current", "true");
       });
-    }, { rootMargin: "-4.5rem 0px -75% 0px" });
+    // Pixels or percent only: `rootMargin` rejects rem, and the
+    // constructor throws rather than ignoring the unit.  72px is the
+    // 4.5rem the masthead occupies at the default root font size
+    }, { rootMargin: "-72px 0px -75% 0px" });
     headings.forEach(function (h) { observer.observe(h); });
   }
 
@@ -419,11 +424,16 @@
       addAnchors();
       fixLinks();
       wrapTables();
-      buildToc();
       jumpToHash();
       window.addEventListener("hashchange", jumpToHash);
       var h1 = doc.querySelector("h1");
       if (h1) document.title = h1.textContent + " · exhale";
+
+      // The contents rail is an enhancement, and the deep link into
+      // the gaps ledger is not.  Building the rail last, in its own
+      // guard, keeps a failure here from reporting a corpus that is
+      // sitting right there rendered as one that could not be loaded
+      try { buildToc(); } catch (err) { console.error("contents rail: " + err.message); }
     })
     .catch(function (err) {
       fail("The request to GitHub failed: " + err.message);


### PR DESCRIPTION
Found by loading the published page after #113 landed.

`IntersectionObserver` requires `rootMargin` in pixels or percent and throws on any other unit rather than ignoring it. The contents rail asked for `-4.5rem`, so the constructor threw, the fetch chain's `catch` caught it, and the page painted "The corpus could not be loaded: Failed to construct 'IntersectionObserver'" over a corpus that had rendered correctly. The same throw skipped `jumpToHash`, so the tray menu's deep link into the gaps ledger left the reader at the top of the document, which is the exact failure the anchor exists to prevent.

- `rootMargin` is now `-72px`, the same 4.5rem masthead offset at the default root font size.
- The contents rail is built last, inside its own guard. It is an enhancement; the deep link is not. A failure there now logs to the console instead of reporting a rendered corpus as an unreachable one.
- A missing `/favicon.ico` was the page's only other console error. The icon is now an inline SVG data URI, so the page stays one file.

Verified on the live page: 77 headings, 10 contents entries, 6 of 6 tables wrapped, all relative links resolved to the repo, citekey anchors present, no script survived sanitizing.
