### PR TITLE
chore: plain writing across docs, comments and store copy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# exhale — release credentials.  Copy this file to .env and fill in the
+# exhale: release credentials.  Copy this file to .env and fill in the
 # values as you acquire them.  .env is gitignored; never commit it.
 #
-# Values are what you'd paste into GitHub repo → Settings → Secrets and
-# variables → Actions (the names match the `secrets.` references in
-# .github/workflows/release.yml).
+# Values are what you'd paste into GitHub repo -> Settings -> Secrets and
+# variables -> Actions (the names match the `secrets.` references in
+# .github/workflows/release.yml)
 
 # ─── macOS / Mac App Store ────────────────────────────────────────────────
 # Base64 of the "Apple Distribution" (or "3rd Party Mac Developer
@@ -13,7 +13,7 @@ MACOS_APP_IDENT_P12=
 MACOS_APP_IDENT_PASSWORD=
 
 # Base64 of the "3rd Party Mac Developer Installer" .p12 exported from
-# Keychain Access (separate cert from the app-signing one above).
+# Keychain Access (separate cert from the app-signing one above)
 MACOS_INSTALLER_P12=
 MACOS_INSTALLER_PASSWORD=
 
@@ -22,7 +22,7 @@ MACOS_INSTALLER_PASSWORD=
 MACOS_PROVISION_PROFILE=
 
 # Any random string.  Used only to unlock the temporary keychain CI creates
-# during signing — never leaves the runner VM.
+# during signing; it never leaves the runner VM
 MACOS_KEYCHAIN_PASSWORD=
 
 # ─── Windows / Microsoft Store ────────────────────────────────────────────

--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -1,17 +1,17 @@
-# Pre-release dev builds for the Rust port — runs on every push to the
+# Pre-release dev builds for the Rust port: runs on every push to the
 # `rust-multiplatform` branch (and `main`) and uploads unsigned,
-# unpackaged binaries for Windows and Linux as workflow artifacts.
+# unpackaged binaries for Windows and Linux as workflow artifacts
 #
 # Lets a developer grab a fresh `exhale.exe` / Linux binary without
-# setting up the full local toolchain on the target platform — most
+# setting up the full local toolchain on the target platform, most
 # useful when iterating on cross-platform fixes from a macOS dev box,
-# or when a Windows ARM VM's MSVC toolchain isn't yet wired up.
+# or when a Windows ARM VM's MSVC toolchain isn't yet wired up
 #
 # Complements `release.yml`:
 #   - `release.yml` fires on `v*` tags, signs/packages everything as
 #     MSIX / .pkg / .deb / .snap / .AppImage for store submission.
 #   - This workflow fires every push, skips signing/packaging, dumps
-#     the raw release binary for direct execution / manual sideloading.
+#     the raw release binary for direct execution / manual sideloading
 
 name: Dev Builds
 
@@ -52,7 +52,7 @@ jobs:
       # ARM64 cross-compile: `windows-2025` ships with the ARM64
       # MSVC build tools as part of the default VS 2022 install, so
       # this should "just work."  Marked continue-on-error in case the
-      # runner image regresses on that — x64 stays available either way.
+      # runner image regresses on that; x64 stays available either way
       - name: Build (ARM64)
         working-directory: rust
         run: cargo build --release -p exhale-app --target aarch64-pc-windows-msvc
@@ -75,9 +75,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       # Same dependency set documented in docs/TESTING.md for local
-      # Linux dev — gtk + wayland + xkbcommon for winit, xdo for
+      # Linux dev: gtk + wayland + xkbcommon for winit, xdo for
       # global-hotkey, ssl for HTTP-using crates, appindicator for
-      # tray-icon's Linux backend.
+      # tray-icon's Linux backend
       - name: System deps
         run: |
           sudo apt-get update
@@ -100,10 +100,10 @@ jobs:
           name: exhale-linux-x64
           path: rust/target/release/exhale
 
-  # Native ARM64 Linux build — runs on GitHub's free `ubuntu-22.04-arm`
+  # Native ARM64 Linux build: runs on GitHub's free `ubuntu-22.04-arm`
   # runner so we don't need cross-compilation gymnastics for the system
   # dependencies (gtk3, wayland, etc.).  Targets the Ubuntu ARM64
-  # desktop VM used in docs/TESTING.md.
+  # desktop VM used in docs/TESTING.md
   linux-arm64:
     runs-on: ubuntu-22.04-arm
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,15 @@
 #
-# Cross-platform release pipeline for the Rust exhale binary.
+# Cross-platform release pipeline for the Rust exhale binary
 #
 # Fires on any `v*` tag push (e.g. `git tag v2.0.8 && git push --tags`) and
 # on manual `workflow_dispatch`.  Each platform job builds, packages, and
 # uploads its artefact; the `release` job gathers them and attaches them to
-# a GitHub Release.
+# a GitHub Release
 #
 # Store submission (Mac App Store / Microsoft Store / Snap Store) is NOT
-# automated here — those require interactive secret setup (Apple App-Store-
+# automated here: those require interactive secret setup (Apple App-Store-
 # Connect API key, Partner Center MSIX submission).  Snap Store upload is
-# manual: see the linux-snap job below for the one-line multipass command.
+# manual: see the linux-snap job below for the one-line multipass command
 #
 # Secrets referenced (all optional; jobs gracefully degrade if missing):
 #   MACOS_APP_IDENT_P12       base64 of the Mac App Distribution .p12
@@ -17,7 +17,7 @@
 #   MACOS_INSTALLER_P12       base64 of the Mac Installer Distribution .p12
 #   MACOS_INSTALLER_PASSWORD  password
 #   MACOS_PROVISION_PROFILE   base64 of exhale.provisionprofile
-#   MACOS_KEYCHAIN_PASSWORD   any string — used for the temporary CI keychain
+#   MACOS_KEYCHAIN_PASSWORD   any string, used for the temporary CI keychain
 #   WINDOWS_CERT_PFX          base64 of a Windows code-signing PFX
 #   WINDOWS_CERT_PASSWORD     password for the PFX
 #
@@ -38,9 +38,9 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Do NOT set `RUSTFLAGS: -D warnings` here — third-party macro crates
+  # Do NOT set `RUSTFLAGS: -D warnings` here: third-party macro crates
   # (e.g. `objc`) emit check-cfg warnings that we can't suppress from our
-  # side, and escalating those to errors breaks the macOS / Linux builds.
+  # side, and escalating those to errors breaks the macOS / Linux builds
 
 jobs:
   # ─── Derive one consistent version string for all downstream jobs ──────────
@@ -73,9 +73,9 @@ jobs:
   macos:
     needs: prepare
     runs-on: macos-latest
-    # `secrets` context is not allowed in step-level `if:` expressions, so
+    # `secrets` context isn't allowed in step-level `if:` expressions, so
     # hoist the availability check into job-level `env` (which *can* read
-    # secrets) and gate individual steps on `env.HAS_MAC_CERTS`.
+    # secrets) and gate individual steps on `env.HAS_MAC_CERTS`
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       BUILD:   ${{ needs.prepare.outputs.build }}
@@ -96,7 +96,7 @@ jobs:
         # bundle-mas.sh wraps codesign + productbuild in `gtimeout` so a
         # hang in Apple's TSA or installer-cert chain validation fails the
         # job in minutes instead of eating an hour-plus of runner time.
-        # gtimeout ships with GNU coreutils, not macOS by default
+        # gtimeout ships with GNU coreutils; macOS doesn't include it by default
         run: brew install coreutils
 
       - name: Import signing identities
@@ -127,7 +127,7 @@ jobs:
           # walks the chain more strictly; on a fresh CI keychain (no Xcode-
           # installed intermediates) it blocks indefinitely. Apple distribution
           # certs issued in different eras chain via different WWDR generations
-          # (G3 → ~2024, G6 current as of 2026); import all generations so the
+          # (G3 -> ~2024, G6 current as of 2026); import all generations so the
           # cert's actual issuer is present regardless of when it was issued
           for cer in \
               AppleWWDRCAG3.cer AppleWWDRCAG4.cer AppleWWDRCAG6.cer \
@@ -152,7 +152,7 @@ jobs:
           # Distribution-signed .app produces a binary that launchd refuses
           # to spawn outside the App Store (the embedded provisioning
           # profile + sandbox entitlements only validate via MAS delivery).
-          # Net: there is no shippable macOS artifact from CI today. The
+          # Net: there's no shippable macOS artifact from CI today. The
           # actual MAS submission is built locally and uploaded via
           # Transporter; this job's only purpose is verifying the macOS
           # build still compiles + signs cleanly on tag push
@@ -218,9 +218,9 @@ jobs:
   # Neither ubuntu-22.04 nor ubuntu-24.04 exposes it.  Workaround: run
   # `snapcraft pack --destructive-mode` directly on the runner (no LXD,
   # no Multipass) and pre-install the base/runtime build-snaps that the
-  # `gnome` extension pulls in, so snapcraft doesn't have to.
+  # `gnome` extension pulls in, so snapcraft doesn't have to
   #
-  # Upload is MANUAL — every snapcraft path we tried (snap @ latest/7.x/8.x,
+  # Upload is MANUAL: every snapcraft path we tried (snap @ latest/7.x/8.x,
   # snapcore/action-publish, `pip install snapcraft`, direct curl REST API)
   # crashed with the same `018h` byte in the discharge macaroon. CI builds
   # the .snap as an artifact; download it and run on a local Multipass VM:
@@ -244,13 +244,13 @@ jobs:
           # Pre-install what the `gnome` extension would otherwise fetch
           # mid-build.  Previous destructive-mode attempts died with a
           # bare "Error installing snap" when snapcraft tried to install
-          # these itself; pre-staging sidesteps that.
+          # these itself; pre-staging sidesteps that
           sudo snap install core22
           sudo snap install gnome-42-2204
           sudo snap install gtk-common-themes
           # Build deps for the cargo compilation inside destructive-mode
           # (the snap will package its own lib runtimes via stage-packages,
-          # but the cargo build itself needs headers on the host).
+          # but the cargo build itself needs headers on the host)
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             pkg-config build-essential \
@@ -273,9 +273,9 @@ jobs:
   windows:
     needs: prepare
     runs-on: windows-2025
-    # `secrets` context is not allowed in step-level `if:` expressions, so
+    # `secrets` context isn't allowed in step-level `if:` expressions, so
     # expose HAS_WIN_CERT via job-level env (which can read secrets) and
-    # gate the Decode step on `env.HAS_WIN_CERT`.
+    # gate the Decode step on `env.HAS_WIN_CERT`
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       BUILD:   ${{ needs.prepare.outputs.build }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     # to keep the Swift test suite green.  The Swift PerformanceTests
     # are also CPU-noise-sensitive enough that gating the Rust PR on
     # them produces false negatives.  Re-enabled automatically once
-    # the branch is merged (no PR-source matches this name anymore).
+    # the branch is merged (no PR-source matches this name anymore)
     if: github.head_ref != 'rust-multiplatform' && github.ref != 'refs/heads/rust-multiplatform'
     runs-on: macos-15
     defaults:
@@ -38,9 +38,9 @@ jobs:
       - name: Run tests
         # `CI=true` is set on the runner shell by GitHub Actions, but
         # `xcodebuild test` does NOT propagate the shell environment
-        # to the xctest target's subprocess — the step's `env:` block
-        # reaches `xcodebuild` itself but not the test runner that it
-        # spawns.  Xcode's documented escape hatch: any env var prefixed
+        # to the xctest target's subprocess; the step's `env:` block
+        # reaches `xcodebuild` itself. The test runner it spawns never
+        # sees it.  Xcode's documented escape hatch: any env var prefixed
         # with `TEST_RUNNER_` is forwarded to the test runner with the
         # prefix stripped.  So `TEST_RUNNER_CI=true` lands in the
         # xctest process as `CI=true`, which `PerformanceTests`'s
@@ -48,8 +48,8 @@ jobs:
         # to pick the looser CPU thresholds calibrated for runner
         # noise instead of the tighter local thresholds.  Confirmed by
         # a prior failure measuring 8.18% avg under the 8.0% local
-        # threshold despite the runner setting `CI=true` in the shell
-        # — the test target wasn't seeing the env var
+        # threshold despite the runner setting `CI=true` in the shell;
+        # the test target wasn't seeing the env var
         env:
           CI: "true"
         run: >
@@ -87,9 +87,9 @@ jobs:
 
   # 8,400 lines of Rust currently have no compile gate anywhere in CI: the
   # release and dev-build workflows only ever run `cargo build --release`, and
-  # there is no `cargo test` / `check` / `clippy` job. `exhale-core` is the
+  # there's no `cargo test` / `check` / `clippy` job. `exhale-core` is the
   # cheap half to cover, since it has no wgpu, winit or GTK dependency and so
-  # needs no system packages. It is also where a generated presets table would
+  # needs no system packages. It's also where a generated presets table would
   # land if the research-panel work proceeds, and a checked-in generated .rs
   # that nothing compiles is a silent time bomb
   core-check:

--- a/.gitignore
+++ b/.gitignore
@@ -31,14 +31,14 @@ target/
 *.diff
 scratch/
 
-# Mac App Store signing — never commit provisioning profiles or keys
+# Mac App Store signing: never commit provisioning profiles or keys
 rust/signing/
 *.provisionprofile
 *.p12
 *.cer
 
 
-# Local secrets — release credentials (base64 of p12s, passwords, etc.)
+# Local secrets: release credentials (base64 of p12s, passwords, etc.)
 .env
 .env.*
 !.env.example

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,8 +6,8 @@ How to ship a new exhale release to the three stores plus the GitHub Releases pa
 
 | Target | Status | One-time | Per-release |
 |---|---|---|---|
-| Mac App Store | live (Swift listing id6447758995, being migrated to Rust) | Apple Developer membership (have), bundle ID + certs + profile | `bundle-mas.sh` → Transporter (must run locally, see "CI caveat" below) |
-| Windows Microsoft Store | listing live (Store ID `9P79Z1NJMZB3`) | Partner Center listing | `bundle-msix.ps1` → Partner Center |
+| Mac App Store | live (Swift listing id6447758995, being migrated to Rust) | Apple Developer membership (have), bundle ID + certs + profile | `bundle-mas.sh` -> Transporter (must run locally, see "CI caveat" below) |
+| Windows Microsoft Store | listing live (Store ID `9P79Z1NJMZB3`) | Partner Center listing | `bundle-msix.ps1` -> Partner Center |
 | Snap Store | published, manual upload | Snapcraft developer account, `snap-creds` Multipass VM | CI builds `.snap`, `multipass exec snap-creds -- snapcraft upload` |
 | Windows standalone `.exe` | direct ship | none | GitHub Release artifact from `release.yml` |
 | Linux `.deb` / AppImage | direct ship | none | GitHub Release artifact from `release.yml` |
@@ -31,19 +31,19 @@ For a store-only deploy (e.g. shipping MAS first and tagging later), use the no-
 
 ---
 
-## macOS — Mac App Store
+## macOS: Mac App Store
 
 You already have a paid Apple Developer Program membership and the App Store Connect record (id6447758995, originally created for the Swift build). The Rust port reuses the same listing, so most of the "one-time setup" was done years ago. The checklist below is the bits you'll touch when the certs roll over or when bringing up a fresh machine.
 
 ### One-time setup (per dev machine)
 
-1. **Bundle ID** at https://developer.apple.com → Certificates, Identifiers & Profiles → Identifiers. The ID `peterklingelhofer.exhale` already exists from the Swift app and is what [rust/scripts/bundle-mas.sh](rust/scripts/bundle-mas.sh#L51) embeds. Capabilities: only **App Sandbox**.
+1. **Bundle ID** at https://developer.apple.com -> Certificates, Identifiers & Profiles -> Identifiers. The ID `peterklingelhofer.exhale` already exists from the Swift app and is what [rust/scripts/bundle-mas.sh](rust/scripts/bundle-mas.sh#L51) embeds. Capabilities: only **App Sandbox**.
 2. **Certificates** in the same portal:
    - **Apple Distribution** (single cert covers iOS + macOS, replaces the legacy "3rd Party Mac Developer Application")
    - **Mac Installer Distribution** (a.k.a. "3rd Party Mac Developer Installer")
 
    Download each `.cer`, double-click to install into the login keychain.
-3. **Provisioning profile** → Profiles → "Mac App Store" → pick `peterklingelhofer.exhale` + the Apple Distribution cert. Save as [rust/signing/exhale.provisionprofile](rust/signing/exhale.provisionprofile) (already in place on this machine).
+3. **Provisioning profile** -> Profiles -> "Mac App Store" -> pick `peterklingelhofer.exhale` + the Apple Distribution cert. Save as [rust/signing/exhale.provisionprofile](rust/signing/exhale.provisionprofile) (already in place on this machine).
 4. **Verify**:
 
    ```sh
@@ -85,10 +85,10 @@ rust/target/mas/exhale.pkg
 ### Pre-flight checks (local)
 
 ```sh
-# Signature attached cleanly?
+# Confirm the signature attached cleanly
 codesign --verify --deep --strict --verbose=2 rust/target/mas/exhale.app
 
-# Entitlements embedded?
+# Confirm the entitlements are embedded
 codesign -d --entitlements - rust/target/mas/exhale.app
 ```
 
@@ -106,25 +106,25 @@ open -a Transporter rust/target/mas/exhale.pkg
 
 Sign in with the Apple ID on the developer account, click **Deliver**. Apple validates the signature, sandbox, icon set, and entitlements server-side; you get an email within ~15 minutes with either "Processed by App Store Connect" or a list of validation failures.
 
-**Scripted alternative:** `xcrun iTMSTransporter`. The older `xcrun altool --upload-app` was removed in Xcode 15, so it is no longer an option. `xcrun notarytool` is for non-Store notarization and is not used for MAS submissions. If you want CI to upload automatically, plumb iTMSTransporter (or the App Store Connect REST API with a JWT) in a new step on the `macos` job in [release.yml](.github/workflows/release.yml).
+**Scripted alternative:** `xcrun iTMSTransporter`. The older `xcrun altool --upload-app` was removed in Xcode 15, so it's no longer an option. `xcrun notarytool` is for non-Store notarization and isn't used for MAS submissions. If you want CI to upload automatically, plumb iTMSTransporter (or the App Store Connect REST API with a JWT) in a new step on the `macos` job in [release.yml](.github/workflows/release.yml).
 
 ### TestFlight (optional, recommended)
 
-Once the processed build appears in App Store Connect → Builds:
+Once the processed build appears in App Store Connect -> Builds:
 
-1. App Store Connect → exhale → TestFlight → enable for **Internal Testing** (your team)
+1. App Store Connect -> exhale -> TestFlight -> enable for **Internal Testing** (your team)
 2. Install via the TestFlight app on macOS for a sandboxed real-install QA pass
 
 External testing requires Beta App Review (~1 day) the first time. For a low-risk utility like exhale, internal-only is usually enough.
 
 ### Submit for review
 
-App Store Connect → exhale → macOS App → Prepare for Submission:
+App Store Connect -> exhale -> macOS App -> Prepare for Submission:
 
 1. Pick the uploaded build
 2. Fill in **What's New in This Version**
 3. Confirm pricing (free), age rating, availability
-4. Add for Review → Submit to App Review
+4. Add for Review -> Submit to App Review
 
 Typical SLA is 24–48 hours. First-time submissions can take 1–3 days.
 
@@ -140,7 +140,7 @@ For every subsequent release:
 1. Bump `version` in `rust/crates/exhale-app/Cargo.toml` (or run `rust/scripts/release.sh X.Y.Z`)
 2. `VERSION=… rust/scripts/bundle-mas.sh` **locally** (see CI caveat)
 3. Upload via Transporter
-4. App Store Connect → new version → pick the build → release notes → submit
+4. App Store Connect -> new version -> pick the build -> release notes -> submit
 
 No new certs / profile unless entitlements change.
 
@@ -171,7 +171,7 @@ Two compounding problems make CI unable to produce a usable macOS download:
 
 1. **`productbuild --sign` deterministically hangs on `macos-latest` runners** even with every Apple WWDR intermediate (G3, G4, G6) imported into the temp keychain. Suspected root cause is an unreachable OCSP / CRL endpoint during installer-cert chain validation, but `gtimeout` confirmed each attempt times out at 300s consistently. Root-causing further hasn't been worth the time given there's a clean workaround at the release level (manual Transporter upload).
 
-2. **A zipped Apple-Distribution-signed `.app` cannot launch outside the App Store.** The embedded provisioning profile + `app-sandbox` entitlements only validate when delivered via MAS. Downloading and unzipping such a build produces a `.app` that `launchd` refuses to spawn with `Launchd job spawn failed` (POSIX 153). So even if we sidestep productbuild by zipping the signed `.app`, the artifact is dead-on-arrival for sideload.
+2. **A zipped Apple-Distribution-signed `.app` can't launch outside the App Store.** The embedded provisioning profile + `app-sandbox` entitlements only validate when delivered via MAS. Downloading and unzipping such a build produces a `.app` that `launchd` refuses to spawn with `Launchd job spawn failed` (POSIX 153). So even if we sidestep productbuild by zipping the signed `.app`, the artifact is dead-on-arrival for sideload.
 
 Current setup: CI sets `SKIP_PKG=1` in [release.yml](.github/workflows/release.yml) so the macOS job runs codesign + verify as a build smoke-test, then stops. No `.pkg`, no `.zip`, no upload. Mac users install via the App Store badge in the README / GitHub Release notes.
 
@@ -181,7 +181,7 @@ If you want a sideload-friendly macOS download some day, the path is "Developer 
 
 ---
 
-## Windows — Microsoft Store
+## Windows: Microsoft Store
 
 The Partner Center listing already exists (Store ID `9P79Z1NJMZB3`, Package Family `PeterKlingelhofer.exhale_rrj7wxvvetjy2`). The identity values are baked into [rust/packaging/windows/AppxManifest.xml](rust/packaging/windows/AppxManifest.xml#L25-L28). You don't need to reserve a new identity for updates.
 
@@ -216,7 +216,7 @@ rust\scripts\bundle-msix.ps1 `
 
 ### Upload to Partner Center
 
-1. https://partner.microsoft.com/dashboard/windows/overview → exhale → Packages
+1. https://partner.microsoft.com/dashboard/windows/overview -> exhale -> Packages
 2. Drag `exhale.msix` into the package upload zone
 3. Validate (Partner Center checks signature, manifest, asset sizes server-side)
 4. Submit for certification
@@ -225,11 +225,11 @@ Microsoft cert review is usually faster than Apple: most updates clear in 6–12
 
 ### Standalone `.exe`
 
-`cargo build --release -p exhale-app` from the `rust/` dir produces a fully self-contained `target/release/exhale.exe`. This is what the GitHub Release attaches (no MSIX wrapping). Users get a "publisher unknown" SmartScreen warning since the standalone exe isn't code-signed; the warning is bypassable via "More info → Run anyway" but is the cost of not buying a Windows code-signing cert (~$200–400/year). The Store MSIX is the no-warning install path.
+`cargo build --release -p exhale-app` from the `rust/` dir produces a fully self-contained `target/release/exhale.exe`. This is what the GitHub Release attaches (no MSIX wrapping). Users get a "publisher unknown" SmartScreen warning since the standalone exe isn't code-signed; the warning is bypassable via "More info -> Run anyway" but is the cost of not buying a Windows code-signing cert (~$200–400/year). The Store MSIX is the no-warning install path.
 
 ---
 
-## Linux — Snap Store
+## Linux: Snap Store
 
 The snap is published as `exhale-app` on https://snapcraft.io.
 
@@ -268,7 +268,7 @@ multipass exec snap-creds -- snapcraft upload \
     --release=edge /tmp/exhale-app_2.0.20_amd64.snap
 ```
 
-Then promote `edge → stable` from https://snapcraft.io/exhale-app/releases once you've smoke-tested edge on a Linux box.
+Then promote `edge -> stable` from https://snapcraft.io/exhale-app/releases once you've smoke-tested edge on a Linux box.
 
 ### Local snap build (no CI)
 
@@ -284,7 +284,7 @@ sudo snapcraft pack --destructive-mode --verbose
 
 ---
 
-## Linux — `.deb` and AppImage
+## Linux: `.deb` and AppImage
 
 These ship directly on the GitHub Releases page (no store flow). CI builds them automatically via the `linux-direct` job. To produce them locally:
 
@@ -294,11 +294,11 @@ cd rust
 cargo install cargo-deb --locked
 cargo build --release --no-default-features -p exhale-app
 cargo deb --no-build -p exhale-app
-# → rust/target/debian/exhale-app_<VERSION>_amd64.deb
+# -> rust/target/debian/exhale-app_<VERSION>_amd64.deb
 
 # AppImage (Linux only, appimagetool is x86_64-Linux)
 rust/scripts/bundle-appimage.sh
-# → rust/target/appimage/exhale-<VERSION>-x86_64.AppImage
+# -> rust/target/appimage/exhale-<VERSION>-x86_64.AppImage
 ```
 
 On macOS, the AppImage step has to run via CI or a Linux VM. The `linux-direct` CI job handles both artifacts on every `v*` tag.
@@ -307,7 +307,7 @@ On macOS, the AppImage step has to run via CI or a Linux VM. The `linux-direct` 
 
 ## CI secrets
 
-[release.yml](.github/workflows/release.yml) gracefully degrades when secrets are missing (each platform job falls back to an unsigned dry-run build), but for a signed release configure these in repo Settings → Secrets:
+[release.yml](.github/workflows/release.yml) gracefully degrades when secrets are missing (each platform job falls back to an unsigned dry-run build), but for a signed release configure these in repo Settings -> Secrets:
 
 | Secret | Used by | What it is |
 |---|---|---|
@@ -324,7 +324,7 @@ Export a local `.p12` to base64 with `base64 -i cert.p12 -o cert.p12.b64` then p
 
 ---
 
-## What is not automated
+## What isn't automated
 
 Per release, after CI is green:
 

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -4,9 +4,9 @@ This is a beginner's guide to the Rust port of exhale. It assumes **zero Rust kn
 
 If you've never read Rust before, the syntax looks intimidating. Mostly it's not. Rust is just a language that's a little more honest than most about who owns which piece of memory and what's allowed to share it. Once you internalize that one rule, 80% of what looks weird stops looking weird.
 
-## What is Rust?
+## What Rust is
 
-A compiled language (like C++, Go, or Swift, not like Python or JavaScript). Source code goes through a compiler and produces a native binary that runs directly on the CPU. Rust's pitch is: "all the speed of C++, without the crashes from forgetting how memory works."
+A compiled language (like C++, Go, or Swift, rather than an interpreted one like Python or JavaScript). Source code goes through a compiler and produces a native binary that runs directly on the CPU. Rust's pitch is: "all the speed of C++, without the crashes from forgetting how memory works."
 
 The way Rust achieves that is a strict set of rules about who is allowed to read or modify a piece of data, enforced by the compiler. You'll bump into those rules constantly while learning. Don't fight them. The compiler errors are weirdly helpful (we'll get to those).
 
@@ -27,7 +27,7 @@ A **crate** is Rust's word for a package. Think of it like one `.jar` in Java or
 The three crates have a layered relationship:
 
 ```
-exhale-app  ─uses→  exhale-render  ─uses→  exhale-core
+exhale-app  ─uses-> exhale-render  ─uses-> exhale-core
 ```
 
 `exhale-core` knows nothing about windows or pixels. `exhale-render` knows how to draw, but nothing about windows. `exhale-app` glues them to a real OS window and tray icon. Each layer is independently testable.
@@ -45,7 +45,7 @@ cargo doc --no-deps --workspace --open
 - `--workspace` includes all three of our crates
 - `--open` pops the result in your browser
 
-You'll land on a page showing the three crates. Click `exhale_core` first — it has the least going on, and the breathing-animation math is genuinely interesting.
+You'll land on a page showing the three crates. Click `exhale_core` first; it has the least going on, and the breathing-animation math is interesting.
 
 The docs are most useful for the **type-level view**. For each struct (data shape) you'll see its fields and methods. Clicking a method jumps to its source code on the right side. Treat it like an interactive table of contents for the codebase.
 
@@ -59,7 +59,7 @@ let mut y = 5;          // can change y
 y = 10;                 // fine
 ```
 
-By default everything is **immutable**. If you want to be able to change a variable, you say `let mut` explicitly. This is the opposite of most languages and is annoying for the first day. It's a feature, not a bug — it means you can scan a file and instantly see which variables get mutated.
+By default everything is **immutable**. If you want to be able to change a variable, you say `let mut` explicitly. This is the opposite of most languages and is annoying for the first day. It's a feature: it means you can scan a file and instantly see which variables get mutated.
 
 You'll see types annotated sometimes, often not:
 
@@ -107,12 +107,12 @@ println!("{} is {} chars", s, length);   // s is still ours
 ```
 
 Two flavors of borrows:
-- `&T` — shared borrow. Many readers allowed, no writers.
-- `&mut T` — exclusive borrow. One writer allowed, no other readers or writers.
+- `&T`: shared borrow. Many readers allowed, no writers.
+- `&mut T`: exclusive borrow. One writer allowed, no other readers or writers.
 
 That rule (one OR the other, never both) is what prevents data races at compile time. You'll see it everywhere. When the compiler refuses to compile something, it's usually because you tried to break this rule.
 
-Look at `crates/exhale-core/src/controller.rs` and you'll see `&mut Settings` pop up — that's a function signature saying "give me exclusive write access to a Settings, just for this call."
+Look at `crates/exhale-core/src/controller.rs` and you'll see `&mut Settings` pop up: that's a function signature saying "give me exclusive write access to a Settings, just for this call."
 
 ### 4. `Option<T>` instead of `null`
 
@@ -185,9 +185,9 @@ let mut writable = settings.write().unwrap();     // exclusive write
 writable.is_paused = true;
 ```
 
-The `.unwrap()` is "this returns a Result, give me the inner value or panic" — used here because we trust the lock won't be poisoned (a thread holding the lock didn't crash mid-write).
+The `.unwrap()` is "this returns a Result, give me the inner value or panic": used here because we trust the lock won't be poisoned (a thread holding the lock didn't crash mid-write).
 
-This pattern is everywhere in `crates/exhale-app/src/main.rs` — the settings, controller state, and tray menu all use it because the GUI thread and the controller thread both need access.
+This pattern is everywhere in `crates/exhale-app/src/main.rs`: the settings, controller state, and tray menu all use it because the GUI thread and the controller thread both need access.
 
 ### 7. `match`: pattern matching that's worth knowing
 
@@ -200,7 +200,7 @@ match phase {
 }
 ```
 
-`match` is like a `switch` but the compiler checks that you handled every possible case. If `BreathingPhase` gains a fifth variant tomorrow, every `match` on it stops compiling until you add the new arm. That's a feature.
+`match` is like a `switch` but the compiler checks that you handled every possible case. If `BreathingPhase` gains a fifth variant tomorrow, every `match` on it stops compiling until you add the new arm, which is a feature.
 
 You can also destructure structs and tuples:
 
@@ -227,7 +227,7 @@ impl Drawable for Rectangle {
 }
 ```
 
-In exhale you'll see traits used heavily by external libraries. For example `winit::application::ApplicationHandler` is a trait — `crates/exhale-app/src/main.rs` implements it for the `App` struct, which tells winit "here's how to forward window events to me."
+In exhale you'll see traits used heavily by external libraries. For example `winit::application::ApplicationHandler` is a trait; `crates/exhale-app/src/main.rs` implements it for the `App` struct, which tells winit "here's how to forward window events to me."
 
 Some traits are special. `Send` means "safe to move between threads." `Sync` means "safe to share between threads." You'll see them as bounds: `T: Send + Sync` means "T must be both."
 
@@ -251,7 +251,7 @@ fn print_all<T: std::fmt::Display>(items: &[T]) {
 }
 ```
 
-That `T: std::fmt::Display` means "T must implement the Display trait" — only types that know how to print themselves are accepted. wgpu types use bounds heavily (`T: bytemuck::Pod` etc.).
+That `T: std::fmt::Display` means "T must implement the Display trait": only types that know how to print themselves are accepted. wgpu types use bounds heavily (`T: bytemuck::Pod` etc.).
 
 ### 10. `unsafe` blocks
 
@@ -263,7 +263,7 @@ unsafe {
 
 `unsafe` is a promise from you (the programmer) to the compiler: "I know this could break the borrow checker's rules, and I've thought about it." Inside `unsafe { }`, you can dereference raw pointers and call C functions.
 
-We use it only where we have to: talking to Apple's Objective-C APIs (`crates/exhale-app/src/platform/mac.rs`), calling Win32 APIs, or loading X11 functions on Linux. About 1% of the codebase. Everything else is "safe Rust" — the compiler proves it can't crash on memory safety issues.
+We use it only where we have to: talking to Apple's Objective-C APIs (`crates/exhale-app/src/platform/mac.rs`), calling Win32 APIs, or loading X11 functions on Linux. About 1% of the codebase. Everything else is "safe Rust": the compiler proves it can't crash on memory safety issues.
 
 ### Bonus: `#[cfg(...)]` for conditional compilation
 
@@ -275,7 +275,7 @@ fn dock_only_visibility() { /* macOS implementation */ }
 fn dock_only_visibility() { /* Windows implementation */ }
 ```
 
-`#[cfg(...)]` lines compile their item only when the condition matches. This is how we ship one source tree that produces three different platform binaries. You'll see `#[cfg(feature = "global-hotkeys")]` too — that gates code on a Cargo feature flag (the Mac App Store build disables it because Apple's sandbox blocks global hotkeys).
+`#[cfg(...)]` lines compile their item only when the condition matches. This is how we ship one source tree that produces three different platform binaries. You'll see `#[cfg(feature = "global-hotkeys")]` too: that gates code on a Cargo feature flag (the Mac App Store build disables it because Apple's sandbox blocks global hotkeys).
 
 ### Bonus: modules and `use`
 
@@ -294,12 +294,12 @@ use crate::overlay::OverlayManager;      // `crate::` means "starting from this 
 
 Pick one user action and trace what happens. Best one for this repo: clicking the "Start Animation" button.
 
-1. `crates/exhale-app/src/settings_window.rs` — the button is drawn here, and clicking it sends an `AppEvent::StartAnimation` via `proxy.send_event(...)`. Search for `StartAnimation` to find the click handler.
-2. `crates/exhale-app/src/main.rs` — `App::user_event(...)` matches `AppEvent::StartAnimation` and calls `self.do_start()`. Search for `fn do_start`.
+1. `crates/exhale-app/src/settings_window.rs`: the button is drawn here, and clicking it sends an `AppEvent::StartAnimation` via `proxy.send_event(...)`. Search for `StartAnimation` to find the click handler.
+2. `crates/exhale-app/src/main.rs`: `App::user_event(...)` matches `AppEvent::StartAnimation` and calls `self.do_start()`. Search for `fn do_start`.
 3. `do_start` flips `settings.is_animating = true` and calls `controller.restart()`.
-4. `crates/exhale-core/src/controller.rs` — `restart()` flips a flag and unparks the controller thread. That thread is running `tick()` in a loop. Search for `fn tick`.
+4. `crates/exhale-core/src/controller.rs`: `restart()` flips a flag and unparks the controller thread. That thread is running `tick()` in a loop. Search for `fn tick`.
 5. `tick()` computes the current frame's `BreathingState` and tells the renderer to draw it.
-6. `crates/exhale-render/src/renderer.rs` — the renderer's `render()` method uploads uniforms to the GPU and submits a draw call. That's what you see on screen.
+6. `crates/exhale-render/src/renderer.rs`: the renderer's `render()` method uploads uniforms to the GPU and submits a draw call, which is what you see on screen.
 
 Open all four files side by side and walk through it. That's enough to understand the architecture without reading 50 other things first.
 
@@ -329,7 +329,7 @@ Three parts:
 
 Read every error from top to bottom and look for the `help:` block. About 80% of the time, the suggested fix is correct. The remaining 20% the suggestion is a hint that you've designed something wrong at a higher level.
 
-`rustc --explain E0382` will give you the full essay version of any error code. Try it on a few — it's a free crash course in why Rust's rules exist.
+`rustc --explain E0382` will give you the full essay version of any error code. Try it on a few; it's a free crash course in why Rust's rules exist.
 
 ## What to skip on first read
 
@@ -362,4 +362,4 @@ If you see any of those in the wild, just trust they do what they look like they
 
 Open `crates/exhale-core/src/controller.rs` in your editor. Skim from the top. When you hit something that looks weird, check this guide. When you don't see it in this guide, run `cargo doc --no-deps --workspace --open` and look up the type.
 
-After 30 minutes you'll have read most of the controller. After an hour you'll have a real intuition for what the whole repo is doing. That's faster than reading any Rust book front-to-back.
+After 30 minutes you'll have read most of the controller. After an hour you'll have a real intuition for what the whole repo is doing, faster than reading any Rust book front-to-back.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,73 @@
 # exhale
 
-A minimal cross-platform breathing overlay - a friendly indicator and reminder to take full, deep breaths while looking at screens.
+A minimal cross-platform breathing overlay: a friendly indicator and reminder to take full, deep breaths while looking at screens.
 
-Demanding work at a keyboard measurably changes how you breathe. Data-entry operators monitored across full working days ran significantly *lower* end-tidal CO2 and *faster* respiration during data entry than during relaxation ([Schleifer & Ley 1994](docs/CITATIONS.md#schleifer1994-vdt-petco2), [Schleifer et al. 2008](docs/CITATIONS.md#schleifer2008-emg-gaps-computer-work)): two small samples from one research group, 34 people in all. The same pattern appears under cognitive load generally, where breathing gets faster and end-tidal CO2 falls while depth stays roughly stable ([Grassmann et al. 2016](docs/CITATIONS.md#grassmann2016-cognitive-load-respiration), 54 experiments), so the keyboard is where the effect was measured rather than its proven cause. A hyperventilation theory of job stress proposes that the pattern involves a shift from diaphragmatic to thoracic breathing ([Schleifer, Ley & Spalding 2002](docs/CITATIONS.md#schleifer2002-hyperventilation-job-stress)); that shift is theorised, not measured in screen users. Screen posture compounds it: heavy smartphone use tracks with worse head posture and lower peak expiratory flow ([Jung et al. 2016](docs/CITATIONS.md#jung2016-smartphone-posture-respiration)), and forward head posture is associated with FVC reductions of 0.25 to 0.81 L ([Deniz et al. 2024](docs/CITATIONS.md#deniz2024-forward-head-lung-volumes)).
+Demanding work at a keyboard measurably changes how you breathe. Data-entry operators monitored across full working days ran significantly *lower* end-tidal CO2 and *faster* respiration during data entry than during relaxation ([Schleifer & Ley 1994](docs/CITATIONS.md#schleifer1994-vdt-petco2), [Schleifer et al. 2008](docs/CITATIONS.md#schleifer2008-emg-gaps-computer-work)): two small samples from one research group, 34 people in all. The same pattern appears under cognitive load generally, where breathing gets faster and end-tidal CO2 falls while depth stays roughly stable ([Grassmann et al. 2016](docs/CITATIONS.md#grassmann2016-cognitive-load-respiration), 54 experiments), so the keyboard is where the effect was measured rather than its proven cause. A hyperventilation theory of job stress proposes that the pattern involves a shift from diaphragmatic to thoracic breathing ([Schleifer, Ley & Spalding 2002](docs/CITATIONS.md#schleifer2002-hyperventilation-job-stress)); that shift is a theory; no study has measured it in screen users. Screen posture compounds it: heavy smartphone use tracks with worse head posture and lower peak expiratory flow ([Jung et al. 2016](docs/CITATIONS.md#jung2016-smartphone-posture-respiration)), and forward head posture is associated with FVC reductions of 0.25 to 0.81 L ([Deniz et al. 2024](docs/CITATIONS.md#deniz2024-forward-head-lung-volumes)).
 
 Slow paced breathing is the breathing practice with the most published evidence behind it ([Laborde et al. 2022](docs/CITATIONS.md#laborde2022-vsb-meta), 223 studies; [Fincham et al. 2023](docs/CITATIONS.md#fincham2023-breathwork-meta), g = -0.35 for self-reported stress; [Zaccaro et al. 2018](docs/CITATIONS.md#zaccaro2018-slow-breathing-review)). Whether it counters the over-breathing above is untested, and one study found it can add to it (gap 5 in the ledger). exhale is a way to run one with no sensor, no account and no telemetry. In two single-session comparisons, a plain expanding shape at 6 breaths per minute raised heart rate variability as much as sensor-driven biofeedback ([Tabor et al. 2022](docs/CITATIONS.md#tabor2022-guided-breathing-design), [Laborde et al. 2021](docs/CITATIONS.md#laborde2021-spb-6cpm-biofeedback)); the biofeedback group in the second reported slightly more positive mood, and finding a personal resonance frequency still takes a sensor, so the claim is narrow: for one session's physiological effect, the hardware added nothing.
 
 Blink rate also falls sharply at a display ([Tsubota & Nakamori 1993](docs/CITATIONS.md#tsubota1993-vdt-blink), [Rosenfield 2011](docs/CITATIONS.md#rosenfield2011-computer-vision-syndrome), [Sheppard & Wolffsohn 2018](docs/CITATIONS.md#sheppard2018-digital-eye-strain)). exhale does nothing about that; it paces breathing only.
 
-Every claim above and below is sourced in **[docs/CITATIONS.md](docs/CITATIONS.md)**, 48 sources whose bibliographic records were checked against Crossref, Open Library or PubMed. Each link lands on that source's corpus entry, which carries its DOI, its access level, its evidence tier and its caveats, rather than on the paper directly, because several of these findings are weaker than a bare citation would suggest. The [gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices) collects fourteen places where exhale ships something the literature does not back.
+Every claim above and below is sourced in **[docs/CITATIONS.md](docs/CITATIONS.md)**, 48 sources whose bibliographic records were checked against Crossref, Open Library or PubMed. Each link lands on that source's corpus entry, which carries its DOI, its access level, its evidence tier and its caveats, rather than on the paper directly, because several of these findings are weaker than a bare citation would suggest. The [gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices) collects fourteen places where exhale ships something the literature doesn't back.
 
 The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable.
 
-**The default is `5` / `0` / `5` / `0`.** Five seconds in, five out, no holds. That is 6 breaths per minute, the rate at which most of the direct evidence was gathered. The band tested head-on runs 5 to 7 breaths per minute, and every rate in it beat spontaneous breathing ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)); average individual resonance frequency sits near 5.5 ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)), and one study found 5.5 beat 6 ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). In a four-way head-to-head (n = 84), 6 breaths per minute raised heart rate variability more than either box breathing or 4-7-8 ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)). Holding the breath is the hard part for a beginner, not the slow part, so this is also the gentlest place to start.
+**The default is `5` / `0` / `5` / `0`.** Five seconds in, five out, no holds. That's 6 breaths per minute, the rate at which most of the direct evidence was gathered. The band tested head-on runs 5 to 7 breaths per minute, and every rate in it beat spontaneous breathing ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)); average individual resonance frequency sits near 5.5 ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)), and one study found 5.5 beat 6 ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). In a four-way head-to-head (n = 84), 6 breaths per minute raised heart rate variability more than either box breathing or 4-7-8 ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)). Holding the breath is the hard part for a beginner; the slow part isn't, so this is also the gentlest place to start.
 
-Box breathing is `4` / `4` / `4` / `4` and exhale supports it, but note it is a 16-second cycle, or 3.75 breaths per minute: the holds hide the fact that it is *slower* than it looks. It lost that head-to-head ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six), whose authors note square and 4-7-8 breathing "have little empirical support"), and in a month-long randomised trial it did not separate from the control on mood while exhale-emphasising cyclic sighing did ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)); the box arm had 21 people and the two patterns were never tested against each other. The same applies to 4-7-8.
+Box breathing is `4` / `4` / `4` / `4` and exhale supports it, but note it's a 16-second cycle, or 3.75 breaths per minute: the holds hide the fact that it's *slower* than it looks. It lost that head-to-head ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six), whose authors note square and 4-7-8 breathing "have little empirical support"), and in a month-long randomised trial it didn't separate from the control on mood while exhale-emphasising cyclic sighing did ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)); the box arm had 21 people and the two patterns were never tested against each other. The same applies to 4-7-8.
 
-**On making the exhale longer than the inhale:** a preference, not a prescription. Whether a longer exhale raises heart rate variability more than an equal one is genuinely split: three studies found an effect ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation), [Laborde et al. 2021](docs/CITATIONS.md#laborde2021-ie-ratio-pauses)), one found the *equal* ratio better ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)), and one found no difference across an original experiment and its own replication ([Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)), whose review of the older literature adds three further nulls and one result the other way. No mechanism claim survives that split, so exhale does not make one.
+**On making the exhale longer than the inhale:** a preference. Whether a longer exhale raises heart rate variability more than an equal one is split: three studies found an effect ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation), [Laborde et al. 2021](docs/CITATIONS.md#laborde2021-ie-ratio-pauses)), one found the *equal* ratio better ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)), and one found no difference across an original experiment and its own replication ([Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)), whose review of the older literature adds three further nulls and one result the other way. No mechanism claim survives that split, so exhale doesn't make one.
 
-The subjective evidence is thinner than it is usually presented. One study of 30 people found the longer exhale produced more reported relaxation, stress reduction, mindfulness and positive energy, while slowing the rate alone moved only one of those four ([Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)). A larger one, 84 people, measured mood across both ratios at 6 breaths per minute and found no meaningful change in any condition ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)), and a third found *every* slow pattern beat baseline on relaxation with no ratio-specific edge ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). A month-long trial points toward exhale emphasis on mood ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)), though its cyclic-sighing arm also adds a double inhale. Prefer a longer exhale if it feels better to you; rate does most of the work, and ratio is a preference with a small and contested edge.
+The subjective evidence is thinner than it's usually presented. One study of 30 people found the longer exhale produced more reported relaxation, stress reduction, mindfulness and positive energy, while slowing the rate alone moved only one of those four ([Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)). A larger one, 84 people, measured mood across both ratios at 6 breaths per minute and found no meaningful change in any condition ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)), and a third found *every* slow pattern beat baseline on relaxation with no ratio-specific edge ([Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv)). A month-long trial points toward exhale emphasis on mood ([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)), though its cyclic-sighing arm also adds a double inhale. Prefer a longer exhale if it feels better to you; rate does most of the work, and ratio is a preference with a small and contested edge.
 
-Being inside the tested band is a claim about coverage, not about optimality: that band is five values wide, and resonance frequency varies from person to person ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)), which no single shipped number can accommodate. Treat 6 a minute as a good starting point rather than as your number. exhale's earlier default, `5` in / `10` out at 4 breaths per minute, is still one click away as a preset; nobody has measured 4 a minute. All of this, including the arithmetic, is laid out in [the gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices).
+Being inside the tested band is a claim about coverage; it says nothing about optimality. That band is five values wide, and resonance frequency varies from person to person ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)), which no single shipped number can accommodate. Treat 6 a minute as a good starting point rather than as your number. exhale's earlier default, `5` in / `10` out at 4 breaths per minute, is still one click away as a preset; nobody has measured 4 a minute. All of this, including the arithmetic, is laid out in [the gaps ledger](docs/CITATIONS.md#gaps-and-unsupported-choices).
 
-Take breaks if intense feelings arise; it's important not to overdo it. Few adverse effects are expected from *slow* breathing specifically ([Laborde et al. 2022](docs/CITATIONS.md#laborde2022-vsb-meta)), but exhale's sliders can also be set to fast, hold-heavy patterns that leave that evidence base for the high-ventilation literature, where transient tetany and light-headedness are documented ([Fincham et al. 2024](docs/CITATIONS.md#fincham2024-high-ventilation-rct)).
+Take breaks if intense feelings arise; don't overdo it. Few adverse effects are expected from *slow* breathing specifically ([Laborde et al. 2022](docs/CITATIONS.md#laborde2022-vsb-meta)), but exhale's sliders can also be set to fast, hold-heavy patterns that leave that evidence base for the high-ventilation literature, where transient tetany and light-headedness are documented ([Fincham et al. 2024](docs/CITATIONS.md#fincham2024-high-ventilation-rct)).
 
 ## Disclaimer
 
-The information and guidance provided by this app are intended for general informational purposes only and are not medical advice. The creator is not a medical professional. Always seek the advice of a qualified healthcare provider with any questions about your health, and do not disregard or delay professional medical advice because of this app. Use is at your own risk.
+The information and guidance provided by this app are intended for general informational purposes only and aren't medical advice. The creator isn't a medical professional. Always seek the advice of a qualified healthcare provider with any questions about your health, and don't disregard or delay professional medical advice because of this app. Use is at your own risk.
 
 ## What to expect
 
 **How long before it does anything.** In a lab comparison, HRV changes appeared roughly two minutes
 into a paced session ([Tabor et al. 2022](docs/CITATIONS.md#tabor2022-guided-breathing-design)). Expect the effect
 to last about as long as the pacer runs: the one study of an ambient on-screen pacer during real
-information work found breathing rate dropped while pacing was active and did not persist as a
+information work found breathing rate dropped while pacing was active and didn't persist as a
 lasting change ([Moraveji et al. 2011](docs/CITATIONS.md#moraveji2011-peripheral-paced-respiration)). The trial that
 showed a month-long mood benefit used five minutes a day
-([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). Running exhale all day is fine; just do not
+([Balban et al. 2023](docs/CITATIONS.md#balban2023-cyclic-sighing)). Running exhale all day is fine; just don't
 expect all-day carryover from it.
 
 **If you use the reminder timer instead of the always-on overlay.** Breaks of ten minutes or less
 reduce fatigue and increase vigor ([Albulescu et al. 2022](docs/CITATIONS.md#albulescu2022-micro-breaks), 22
 studies), and self-reported relief is higher after a single instructed deep breath than before it
-([Vlemincx et al. 2016](docs/CITATIONS.md#vlemincx2016-sigh-relief)). That is the closest published support for
+([Vlemincx et al. 2016](docs/CITATIONS.md#vlemincx2016-sigh-relief)). That's the closest published support for
 exhale's smallest gesture, which is being told to take one breath.
 
-**Breathe through your nose.** exhale cannot show you this and does not try, but it is free. Nasal
+**Breathe through your nose.** exhale can't show you this and doesn't try, but it's free. Nasal
 respiration entrains oscillations in human piriform cortex, amygdala and hippocampus, and the effect
 is specific to the nasal route rather than to breathing as such
 ([Zelano et al. 2016](docs/CITATIONS.md#zelano2016-nasal-respiration-limbic)).
 
 **Tune the numbers to yourself.** Resonance frequency is individual, and taller people and men tend
-to have lower ones ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)). That is the honest
-reason exhale's timings are sliders rather than a hardcoded rate: there is no single correct number
+to have lower ones ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)). That's the honest
+reason exhale's timings are sliders rather than a hardcoded rate: there's no single correct number
 to ship.
 
 **Why breathing reaches how you feel at all.** Heart rate rises on inhalation and falls on
 exhalation ([Yasuma & Hayano 2004](docs/CITATIONS.md#yasuma2004-rsa)), which is the coupling every HRV claim here
 rests on. Separately, a small population of neurons in the mouse breathing rhythm generator projects
 onto the locus coeruleus, and ablating them left breathing intact while increasing calm behaviour
-([Yackle et al. 2017](docs/CITATIONS.md#yackle2017-breathing-arousal-neurons)). That is a plausible route from
-breathing pattern to arousal state. It is mice, and it is a reason rather than a result.
+([Yackle et al. 2017](docs/CITATIONS.md#yackle2017-breathing-arousal-neurons)). That's a plausible route from
+breathing pattern to arousal state. It's mice, and it's a reason rather than a result.
 
 ## Research and evidence
 
 exhale's premise, its defaults and its interface choices are traced to the literature in
 **[docs/CITATIONS.md](docs/CITATIONS.md)**: 48 sources, 45 verified against the Crossref REST API,
 2 against Open Library and 1 against PubMed, each carrying an access level, an evidence tier and the
-specific claims it is allowed to back.
+specific claims it's allowed to back.
 
 The corpus is deliberately not a sales pitch. Alongside the meta-analyses that support slow paced
 breathing it carries the published dissent: a meta-analysis finds sustained slow breathing lowers
@@ -77,11 +77,11 @@ letter in a hypertension journal argues that case should be considered closed
 against exhale's own genre ([Johnson & Rosenfield 2023](docs/CITATIONS.md#johnson2023-20-20-20), where scheduled
 on-screen breaks did nothing), and a
 [ledger of fourteen places](docs/CITATIONS.md#gaps-and-unsupported-choices) where exhale ships
-something the literature does not settle. Four highlights:
+something the literature doesn't settle. Four highlights:
 
-- The **tested range is only 5 to 7 breaths per minute wide** ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)), and individual resonance frequency varies within and beyond it ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)). exhale's default of 6 sits inside it; box breathing, at 3.75, does not.
+- The **tested range is only 5 to 7 breaths per minute wide** ([You et al. 2023](docs/CITATIONS.md#you2023-respiratory-frequency)), and individual resonance frequency varies within and beyond it ([Lehrer & Gevirtz 2014](docs/CITATIONS.md#lehrer2014-hrv-biofeedback)). exhale's default of 6 sits inside it; box breathing, at 3.75, doesn't.
 - Whether a **longer exhale** beats an equal one on heart rate variability is split five ways ([Bae et al. 2021](docs/CITATIONS.md#bae2021-exhalation-inhalation-ratio), [Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation), [Laborde et al. 2021](docs/CITATIONS.md#laborde2021-ie-ratio-pauses), [Lin et al. 2014](docs/CITATIONS.md#lin2014-equal-ratio-hrv), [Meehan & Shaffer 2024](docs/CITATIONS.md#meehan2024-longer-exhalations)). On how people report *feeling*, one study favours it ([Van Diest et al. 2014](docs/CITATIONS.md#vandiest2014-ie-ratio-relaxation)) and a larger one found no mood difference ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)), which is why exhale offers the ratio as a preference rather than a recommendation.
-- The closest published analogue to exhale, an ambient on-screen pacer running during real information work, lowered breathing rate **only while it was running** ([Moraveji et al. 2011](docs/CITATIONS.md#moraveji2011-peripheral-paced-respiration)). Treat an always-on overlay as an effect that lasts as long as it is on. Visual pacing also changes breathing more than audio while feeling *less* calming ([Wongsuphasawat et al. 2012](docs/CITATIONS.md#wongsuphasawat2012-cant-force-calm)), which is a trade exhale makes deliberately.
+- The closest published analogue to exhale, an ambient on-screen pacer running during real information work, lowered breathing rate **only while it was running** ([Moraveji et al. 2011](docs/CITATIONS.md#moraveji2011-peripheral-paced-respiration)). Treat an always-on overlay as an effect that lasts as long as it's on. Visual pacing also changes breathing more than audio while feeling *less* calming ([Wongsuphasawat et al. 2012](docs/CITATIONS.md#wongsuphasawat2012-cant-force-calm)), which is a trade exhale makes deliberately.
 - Slow pacing itself mildly increases over-breathing ([Marchant et al. 2025](docs/CITATIONS.md#marchant2025-square-478-six)), and screen workers are already mildly hypocapnic ([Schleifer & Ley 1994](docs/CITATIONS.md#schleifer1994-vdt-petco2), [Schleifer et al. 2008](docs/CITATIONS.md#schleifer2008-emg-gaps-computer-work)). Nobody has tested a slow pacer on that population, which is exactly exhale's user.
 
 The tradition exhale actually descends from is named rather than airbrushed. The four-phase
@@ -89,11 +89,11 @@ inhale / hold / exhale / hold structure is pranayama ([Satyananda Saraswati 1999
 [Muktibodhananda 1998](docs/CITATIONS.md#muktibodhananda1998-hatha-yoga-pradipika)), and both references are carried
 at evidence tier **E**: citable for lineage, never for whether anything works. Both are catalogue
 records only, checked against Open Library and not read. Retrofitting a 2020s HRV
-citation onto an instruction that is centuries older would be revisionist about the app's own design
+citation onto an instruction that's centuries older would be revisionist about the app's own design
 history, and knowing the longer-exhale idea reached breathing apps through this tradition rather than
 through a laboratory is worth weighing when reading the studies that later tested it.
 
-The corpus is generated, not hand-maintained. [`docs/CITATIONS.csl.json`](docs/CITATIONS.csl.json) holds
+The corpus is generated. [`docs/CITATIONS.csl.json`](docs/CITATIONS.csl.json) holds
 the records, [`docs/citations-notes.md`](docs/citations-notes.md) holds the prose, and
 [`scripts/generate-citations.py`](scripts/generate-citations.py) renders the two into `CITATIONS.md`:
 
@@ -105,7 +105,7 @@ uv run --no-project scripts/generate-citations.py --check   # fail if stale
 `--check` also validates citekey format, enum values, every anchor link the gaps ledger makes into
 the corpus, the source counts quoted in this file, and the deep link the app itself compiles in, so a
 renamed entry or a stale number breaks the build rather than rotting silently. It also refuses a
-short list of claims the corpus does not support, anywhere they could be asserted rather than
+short list of claims the corpus doesn't support, anywhere they could be asserted rather than
 discussed: the Rust sources, the Snap description and the Microsoft Store listing copy. A store
 listing is edited somewhere a README review never reaches, which is exactly how the two drift.
 
@@ -114,10 +114,10 @@ the system-tray menu on every platform. Both open the gaps ledger rather than th
 reference list, which is the whole point of the item: the label is plain, so the anchor carries the
 intent. The Timing panel offers five patterns as one-click presets, computes the current rate from
 the four duration fields, and prints it against the tested range, unprompted, so a configuration
-outside that range says so where it is being chosen. Selecting box breathing makes the panel state
-that it is 3.8 breaths a minute and slower than anything tested directly, which is the honest thing
+outside that range says so where it's being chosen. Selecting box breathing makes the panel state
+that it's 3.8 breaths a minute and slower than anything tested directly, which is the honest thing
 to say about a pattern people arrive looking for by name. No preset carries a badge, a rank or an evidentiary caption: the arithmetic
-below them is computed live for whichever is selected, so it cannot go stale and does not have to
+below them is computed live for whichever is selected, so it can't go stale and doesn't have to
 be maintained against the corpus.
 
 The binary states arithmetic and one range and nothing else: no effect, no benefit, no condition.
@@ -156,8 +156,8 @@ Only one shortcut ships bound by default:
 
 Every other action (Start / Stop / Reset / Quit) is **unbound** on first launch so exhale never collides with another app's global shortcut without the user opting in. Customise via either path:
 
-- **Right-click** the Start / Stop / Reset / Quit buttons in the Preferences panel → "Change Shortcut…" → press your combo
-- **Tray menu** → "Keyboard Shortcuts ▶" → pick any of the five actions to start a capture
+- **Right-click** the Start / Stop / Reset / Quit buttons in the Preferences panel -> "Change Shortcut…" -> press your combo
+- **Tray menu** -> "Keyboard Shortcuts ▶" -> pick any of the five actions to start a capture
 
 Press **Esc** in the capture overlay to cancel. "Reset Shortcut to Default" in the right-click menu restores the per-action factory value (which, for everything except Preferences, is "unbound"). Reset to Defaults in the panel clears all custom bindings too.
 
@@ -299,7 +299,7 @@ Live A/B on macOS (M3 Max, default settings, single monitor, settings window clo
 | Swift (Release) |  4.95 % | 3.2 – 6.6 |
 | Rust  (Release) |  3.19 % | 1.5 – 4.3 |
 
-Rust runs about **36 % lower CPU in steady state**. The delta is statistically robust (means ~5σ apart) but small in absolute terms (~1.8 percentage points). Opening the settings window adds roughly 1–2 pp on both builds; each additional monitor adds another ~0.2–0.4 pp on Rust (one render thread per overlay).
+Rust runs about **36 % lower CPU in steady state**. The delta is statistically clear (means ~5σ apart) but small in absolute terms (~1.8 percentage points). Opening the settings window adds roughly 1–2 pp on both builds; each additional monitor adds another ~0.2–0.4 pp on Rust (one render thread per overlay).
 
 Reproduce via `cargo run --release --example cpu_bench -p exhale-render` for the headless per-frame number, or by running both binaries side-by-side under `ps -o %cpu` for the live-process number above.
 
@@ -331,7 +331,7 @@ python main.py
 
 Modify the constants at the top of [`python/main.py`](python/main.py) for inhale/exhale duration in seconds, shape mode, and full-screen toggle.
 
-**The Rust binary is the recommended path on every supported OS, including Wayland.** On a typical Wayland desktop the compositor doesn't expose alpha-capable swap chains, so the Rust binary opens as a regular movable window; you can either watch the animation directly in that window, or send it behind your other apps and narrow them so the animation peeks through the edges, exactly the same "make room for the overlay" trick this Python script uses in its bars mode (see the [Linux (Wayland) platform note](#platform-notes) above for details). The Python script is a hackable single-file alternative, not a performance recommendation.
+**The Rust binary is the recommended path on every supported OS, including Wayland.** On a typical Wayland desktop the compositor doesn't expose alpha-capable swap chains, so the Rust binary opens as a regular movable window; you can either watch the animation directly in that window, or send it behind your other apps and narrow them so the animation peeks through the edges, exactly the same "make room for the overlay" trick this Python script uses in its bars mode (see the [Linux (Wayland) platform note](#platform-notes) above for details). The Python script is a hackable single-file alternative; it isn't meant as a performance recommendation.
 
 ## Companion repository
 
@@ -341,7 +341,7 @@ A Perl version of this exists at <https://github.com/franco3445/Breathing>.
 
 ## Deprecated implementations
 
-The implementations below are superseded by the Rust port above and are kept in the repo for historical reference only. They will not receive new features or fixes. Use the Rust binary on every supported OS.
+The implementations below are superseded by the Rust port above and are kept in the repo for historical reference only. They won't receive new features or fixes. Use the Rust binary on every supported OS.
 
 ### Swift macOS app (`swift/`)
 

--- a/docs/CITATIONS.csl.json
+++ b/docs/CITATIONS.csl.json
@@ -52,7 +52,7 @@
         "short breaks of ten minutes or less from a work task reduce fatigue and increase vigor",
         "an interruption long enough to run one breath cycle is a plausible unit of recovery"
       ],
-      "caveat": "22 studies, 19 manuscripts. The performance effect was smaller and less consistent than the well-being effect, and the authors report it depended on task type. None of the included studies used a breathing exercise as the break activity, so this supports the general shape of exhale's reminder timer, not its specific content."
+      "caveat": "22 studies, 19 manuscripts. The performance effect was smaller and less consistent than the well-being effect, and the authors report it depended on task type. None of the included studies used a breathing exercise as the break activity, so this supports the general shape of exhale's reminder timer; the breathing content itself is untested here."
     }
   },
   {
@@ -171,9 +171,9 @@
       "inAppCitable": false,
       "backsClaims": [
         "five minutes a day of exhale-emphasising cyclic sighing improved mood and lowered respiratory rate more than an equal period of mindfulness meditation over one month",
-        "box breathing, equal inhale / hold / exhale, was tested head-to-head and was not the best-performing arm"
+        "box breathing, equal inhale / hold / exhale, was tested head-to-head and wasn't the best-performing arm"
       ],
-      "caveat": "Remote randomised controlled study, pre-registered as NCT05304000, with 108 participants: 24 in the mindfulness-meditation control, 30 cyclic sighing, 21 box breathing and 33 cyclic hyperventilation. The comparator is mindfulness meditation rather than a sham, so the arms differ in more than breath ratio. In the mixed-effects model, cyclic sighing separated from the control on positive affect; box breathing and cyclic hyperventilation did not, and the breathwork arms were not tested against one another. Daily positive-affect gains were 1.89 points for cyclic sighing and 1.84 for box breathing. This is the best evidence in the corpus that emphasising the exhale is the right emphasis, and it is weaker than the abstract suggests: the box arm is small and the difference between the two patterns is not established. The cyclic-sighing protocol also adds a double inhale, so its effect cannot be attributed to exhale length alone."
+      "caveat": "Remote randomised controlled study, pre-registered as NCT05304000, with 108 participants: 24 in the mindfulness-meditation control, 30 cyclic sighing, 21 box breathing and 33 cyclic hyperventilation. The comparator is mindfulness meditation rather than a sham, so the arms differ in more than breath ratio. In the mixed-effects model, cyclic sighing separated from the control on positive affect; box breathing and cyclic hyperventilation didn't, and the breathwork arms weren't tested against one another. Daily positive-affect gains were 1.89 points for cyclic sighing and 1.84 for box breathing. This is the best evidence in the corpus that emphasising the exhale is the right emphasis, and it's weaker than the abstract suggests: the box arm is small and the difference between the two patterns isn't established. The cyclic-sighing protocol also adds a double inhale, so its effect can't be attributed to exhale length alone."
     }
   },
   {
@@ -309,7 +309,7 @@
         "fifteen minutes of paced breathing at 6 per minute raised arterial oxygen saturation and lowered systemic and pulmonary arterial pressure at high altitude",
         "the proposed mechanism is a larger tidal volume reducing the proportion of each breath spent on anatomical dead space"
       ],
-      "caveat": "Conducted at high altitude in a hypoxic state, so it does not transfer to a desk at sea level and must not be cited as if it did. It is carried for two narrow purposes: it is a second study placing the controlled literature at 6 breaths per minute, and its dead-space mechanism is the reason slow breathing is not simply less breathing."
+      "caveat": "Conducted at high altitude in a hypoxic state, so it doesn't transfer to a desk at sea level and must not be cited as if it did. It's carried for two narrow purposes: it's a second study placing the controlled literature at 6 breaths per minute, and its dead-space mechanism is the reason slow breathing isn't simply less breathing."
     }
   },
   {
@@ -356,7 +356,7 @@
       "backsClaims": [
         "sustained slow breathing programmes lower systolic blood pressure by about 5.6 mmHg and diastolic by about 3.0 mmHg in hypertensive and prehypertensive adults"
       ],
-      "caveat": "17 RCTs. Heterogeneity was high for every analysis, and the authors say so. Inclusion required at least 5 minutes of breathing at 10 breaths/min or slower, on at least 3 days a week, for at least 4 weeks. exhale asks for none of that and measures none of it, so this describes a dose exhale does not deliver. Read alongside vandijk2018-close-the-book."
+      "caveat": "17 RCTs. Heterogeneity was high for every analysis, and the authors say so. Inclusion required at least 5 minutes of breathing at 10 breaths/min or slower, on at least 3 days a week, for at least 4 weeks. exhale asks for none of that and measures none of it, so this describes a dose exhale doesn't deliver. Read alongside vandijk2018-close-the-book."
     }
   },
   {
@@ -400,7 +400,7 @@
         "across four comparison studies totalling 115 participants, forward head posture was associated with FVC reductions of 0.25 to 0.81 L and FEV1 reductions of 0.16 to 0.93 L",
         "craniovertebral angle correlates positively with dynamic pulmonary volumes"
       ],
-      "caveat": "Systematic review without meta-analysis of four small comparison studies and two correlation studies; the authors phrase the conclusion as forward head posture 'can potentially cause' pulmonary abnormalities. The search included ResearchGate alongside PubMed and Google Scholar, which is an unusual choice. This is the posture half of the screen-breathing argument: it is about head position, not about screens, and the link to screens comes from jung2016-smartphone-posture-respiration. The Crossref deposit carries the second and third authors' names with a dotless i, a transliteration artefact; they are printed here in standard Turkish orthography."
+      "caveat": "Systematic review without meta-analysis of four small comparison studies and two correlation studies; the authors phrase the conclusion as forward head posture 'can potentially cause' pulmonary abnormalities. The search included ResearchGate alongside PubMed and Google Scholar, which is an unusual choice. This is the posture half of the screen-breathing argument: it measures head position, and the link to screens comes from jung2016-smartphone-posture-respiration. The Crossref deposit carries the second and third authors' names with a dotless i, a transliteration artefact; they're printed here in standard Turkish orthography."
     }
   },
   {
@@ -450,7 +450,7 @@
         "comparable small-to-medium effects for anxiety (g = -0.32, k = 20) and depressive symptoms (g = -0.40, k = 18)",
         "adverse-event reporting in breathwork trials is sparse: four of the twelve primary-outcome trials reported on it, and none attributed lasting harm to breathwork"
       ],
-      "caveat": "Most included studies were rated at moderate risk of bias. Effects are small-to-medium and self-reported. Only four of the twelve primary-outcome trials reported on adverse events, and none attributed lasting harm to breathwork; the authors call for better reporting, particularly for fast-paced techniques. This is the strongest single warrant for the claim that a breathing practice does something, and it is still an effect of about a third of a standard deviation."
+      "caveat": "Most included studies were rated at moderate risk of bias. Effects are small-to-medium and self-reported. Only four of the twelve primary-outcome trials reported on adverse events, and none attributed lasting harm to breathwork; the authors call for better reporting, particularly for fast-paced techniques. This is the strongest single warrant for the claim that a breathing practice does something, and it's still an effect of about a third of a standard deviation."
     }
   },
   {
@@ -502,7 +502,7 @@
         "high-ventilation breathwork with retention is a distinct practice from slow-paced breathing and warrants a placebo-controlled evaluation of its own",
         "short-term effects reported by participants in the high-ventilation arm included light-headedness, dizziness and tetany, with no lasting adverse effects reported"
       ],
-      "caveat": "Pre-registered as NCT06064474, 200 healthy young adults, blinded against an active comparator; the largest trial of this technique to date. The primary finding is a null: high-ventilation breathwork did not outperform the comparator on stress. It is carried for the distinction it draws and for its tolerability data. It matters to exhale because the sliders can be set to fast, hold-heavy patterns that leave the slow-breathing evidence base entirely, and this is where the documented short-term effects of those patterns are recorded."
+      "caveat": "Pre-registered as NCT06064474, 200 healthy young adults, blinded against an active comparator; the largest trial of this technique to date. The primary finding is a null: high-ventilation breathwork didn't outperform the comparator on stress. It's carried for the distinction it draws and for its tolerability data. It matters to exhale because the sliders can be set to fast, hold-heavy patterns that leave the slow-breathing evidence base entirely, and this is where the documented short-term effects of those patterns are recorded."
     }
   },
   {
@@ -551,10 +551,10 @@
       "evidenceTier": "B",
       "backsClaims": [
         "mentally demanding work is reliably marked by faster breathing, with medium to large effects",
-        "respiratory amplitude stays roughly stable under cognitive load rather than shrinking",
+        "respiratory amplitude stays roughly stable under cognitive load",
         "cognitive load lowers end-tidal CO2, meaning ventilation runs ahead of metabolic need"
       ],
-      "caveat": "54 experiments across 53 articles. Note the direction of the amplitude finding: cognitive load raises rate while leaving amplitude roughly stable, so this does not support 'shallow' if shallow means less air moved. Minute ventilation goes up. For the diaphragmatic-to-thoracic shift that 'shallow' usually names, see schleifer2002-hyperventilation-job-stress; for the same over-breathing measured at a keyboard, see schleifer1994-vdt-petco2 and schleifer2008-emg-gaps-computer-work. This entry is the general cognitive-load backdrop, and it is also the reason the keyboard cannot be singled out as the cause: any demanding task produces the pattern."
+      "caveat": "54 experiments across 53 articles. Note the direction of the amplitude finding: cognitive load raises rate while leaving amplitude roughly stable, so this doesn't support 'shallow' if shallow means less air moved. Minute ventilation goes up. For the diaphragmatic-to-thoracic shift that 'shallow' usually names, see schleifer2002-hyperventilation-job-stress; for the same over-breathing measured at a keyboard, see schleifer1994-vdt-petco2 and schleifer2008-emg-gaps-computer-work. This entry is the general cognitive-load backdrop, and it's also the reason the keyboard can't be singled out as the cause: any demanding task produces the pattern."
     }
   },
   {
@@ -594,7 +594,7 @@
         "the widely repeated 20-20-20 rule has little peer-reviewed support",
         "scheduled 20-second breaks every 5, 10 or 20 minutes produced no significant effect on ocular symptoms, reading speed or task accuracy"
       ],
-      "caveat": "n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge is not self-evidently effective just because it is popular and plausible."
+      "caveat": "n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge isn't self-evidently effective just because it's popular and plausible."
     }
   },
   {
@@ -638,7 +638,7 @@
         "six weeks of pranayama practice in 75 young adults lowered resting respiratory rate and prolonged breath-holding time",
         "the same training raised forced vital capacity, FEV1, maximum voluntary ventilation and peak expiratory flow rate"
       ],
-      "caveat": "Findings taken from the abstract. No DOI exists, and the record was verified against the NCBI E-utilities API by PMID rather than Crossref. Uncontrolled before-and-after design in a 1992 regional journal, so treat the effect sizes as unusable. It is carried because it is the only entry in this corpus that speaks to graded extension as a training progression: capacity grew over six weeks of practice. That is a claim about adaptation across sessions, not evidence for extending the breath without limit inside a single sitting, which is a different proposition that shaffer2020-resonance-frequency-assessment bears on."
+      "caveat": "Findings taken from the abstract. No DOI exists, and the record was verified against the NCBI E-utilities API by PMID rather than Crossref. Uncontrolled before-and-after design in a 1992 regional journal, so treat the effect sizes as unusable. It's carried because it's the only entry in this corpus that speaks to graded extension as a training progression: capacity grew over six weeks of practice. That's a claim about adaptation across sessions. Extending the breath without limit inside a single sitting is a different proposition, and shaffer2020-resonance-frequency-assessment bears on it."
     }
   },
   {
@@ -689,7 +689,7 @@
       "backsClaims": [
         "people using smartphones more than four hours a day had significantly worse craniovertebral angle, worse scapular index and lower peak expiratory flow than people using them less than four hours a day"
       ],
-      "caveat": "n = 50, cross-sectional, two groups split on self-reported usage. Correlational: heavy users may differ in many ways besides screen time, and peak expiratory flow was the only respiratory measure that separated (FVC and FEV1 did not). Crossref carries no license; access level taken from J Phys Ther Sci being fully open access."
+      "caveat": "n = 50, cross-sectional, two groups split on self-reported usage. Correlational: heavy users may differ in many ways besides screen time, and peak expiratory flow was the only respiratory measure that separated (FVC and FEV1 didn't). Crossref carries no license; access level taken from J Phys Ther Sci being fully open access."
     }
   },
   {
@@ -747,9 +747,9 @@
       "evidenceTier": "C",
       "backsClaims": [
         "at six cycles per minute, RMSSD was higher when the exhalation was longer than the inhalation, across inhalation/exhalation ratios of 0.8, 1.0 and 1.2",
-        "brief 0.4 s pauses after inhalation and after exhalation did not further change RMSSD"
+        "brief 0.4 s pauses after inhalation and after exhalation didn't further change RMSSD"
       ],
-      "caveat": "n = 64 athletes, within-subjects, six 5-minute conditions in one session. Findings taken from the abstract; effect sizes not read. This is the fifth study bearing on the ratio disagreement tabulated in gap 4, on the side of the longer exhale, and the only one that also manipulates respiratory pauses, which is why it also settles gap 11 as far as brief pauses go. Published in Sustainability, an MDPI journal outside the field, which is worth knowing when weighing it against the other four."
+      "caveat": "n = 64 athletes, within-subjects, six 5-minute conditions in one session. Findings taken from the abstract; effect sizes not read. This is the fifth study bearing on the ratio disagreement tabulated in gap 4, on the side of the longer exhale, and the only one that also manipulates respiratory pauses, which is why it also settles gap 11 as far as brief pauses go. Published in Sustainability, an MDPI journal outside the field, which matters when weighing it against the other four."
     }
   },
   {
@@ -815,9 +815,9 @@
       "evidenceTier": "C",
       "backsClaims": [
         "slow-paced breathing at six cycles per minute raised RMSSD relative to control in every condition tested",
-        "adding heart-rate-variability biofeedback on top of the six-per-minute pace did not add a further RMSSD benefit, though that condition reported more positive emotional valence"
+        "adding heart-rate-variability biofeedback on top of the six-per-minute pace didn't add a further RMSSD benefit, though that condition reported more positive emotional valence"
       ],
-      "caveat": "n = 112, single session. Crossref records this as issued 2021, appearing in the January 2022 issue (59:1). Both conditions raised RMSSD and lowered arousal; the biofeedback condition additionally reported more positive emotional valence, so 'no added benefit' is specific to the cardiac measure. Together with tabor2022-guided-breathing-design this is why exhale ships without a sensor: for the physiological effect of a single session, the pace does the work rather than the feedback loop."
+      "caveat": "n = 112, single session. Crossref records this as issued 2021, appearing in the January 2022 issue (59:1). Both conditions raised RMSSD and lowered arousal; the biofeedback condition also reported more positive emotional valence, so 'no added benefit' is specific to the cardiac measure. Together with tabor2022-guided-breathing-design this is why exhale ships without a sensor: for the physiological effect of a single session, the pace does the work."
     }
   },
   {
@@ -893,7 +893,7 @@
         "voluntary slow breathing raises vagally-mediated HRV during the session, immediately after a single session, and after a multi-session intervention",
         "few adverse effects are expected from slow breathing practice"
       ],
-      "caveat": "223 studies from 1842 screened abstracts (172 during, 16 immediately-after, 49 after-intervention). This is the central warrant for exhale's whole premise. Note what it establishes: an effect on a cardiac index of parasympathetic activity, not an effect on how anyone feels or works."
+      "caveat": "223 studies from 1842 screened abstracts (172 during, 16 immediately-after, 49 after-intervention). This is the central warrant for exhale's whole premise. Note what it establishes: an effect on a cardiac index of parasympathetic activity; it says nothing about how anyone feels or works."
     }
   },
   {
@@ -934,7 +934,7 @@
         "resonance frequency is individual: taller people and men tend to have lower resonance frequencies",
         "baroreflex gain increases substantially during HRV biofeedback"
       ],
-      "caveat": "Narrative mechanistic review by the technique's principal developers. Read as the mechanism argument, not as independent evidence. The individual-variation point is the honest reason exhale's timing sliders are user-editable at all: there is no single correct number to hardcode."
+      "caveat": "Narrative mechanistic review by the technique's principal developers. Read as the mechanism argument rather than as independent evidence. The individual-variation point is the honest reason exhale's timing sliders are user-editable at all: there's no single correct number to hardcode."
     }
   },
   {
@@ -992,7 +992,7 @@
       "openCopy": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4852886/",
       "evidenceTier": "D",
       "backsClaims": [
-        "sighing is generated by a dedicated peptidergic circuit projecting onto the preBotzinger complex, not as a byproduct of ordinary breathing rhythm"
+        "sighing is generated by a dedicated peptidergic circuit projecting onto the preBotzinger complex rather than as a byproduct of ordinary breathing rhythm"
       ],
       "caveat": "Mouse work. It establishes that the sigh is a distinct, hardwired respiratory behaviour, which is the mechanistic backdrop for the cyclic-sighing result in balban2023-cyclic-sighing. It says nothing about humans deliberately performing sighs, and must not be cited as if it did."
     }
@@ -1038,7 +1038,7 @@
         "5.5 breaths per minute with an equal 5:5 inhale-to-exhale ratio produced higher SDNN and LF power than 6 bpm or than a 4:6 ratio",
         "all four slow-breathing patterns increased self-reported relaxation relative to spontaneous breathing"
       ],
-      "caveat": "n = 47, Latin-square counterbalanced. The clearest published result against a longer exhale on HRV grounds, and one reason exhale makes no mechanism claim for the 1:2 ratio. It also measured relaxation and anxiety across the four patterns and reports that all four increased relaxation over baseline, with no ratio-specific advantage; that is one of three subjective measurements bearing on gap 4. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works."
+      "caveat": "n = 47, Latin-square counterbalanced. The clearest published result against a longer exhale on HRV grounds, and one reason exhale makes no mechanism claim for the 1:2 ratio. It also measured relaxation and anxiety across the four patterns and reports that all four increased relaxation over baseline, with no ratio-specific advantage; that's one of three subjective measurements bearing on gap 4. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best rather than about whether slow breathing works."
     }
   },
   {
@@ -1166,7 +1166,7 @@
         "none of the four conditions produced meaningful changes in blood pressure or mood",
         "breathing at 6 breaths per minute unexpectedly produced mild over-breathing"
       ],
-      "caveat": "n = 84 college students, within-subjects, four conditions: square, 4-7-8, 6 bpm at 4:6, and 6 bpm at 5:5. Single session, so it speaks to acute effect only, and it is the largest ratio comparison in this corpus. This is the head-to-head that ranks exhale's presets, and it ranks against box breathing and 4-7-8. Two of its findings cut against arguments made elsewhere in this corpus: mood did not change meaningfully in any condition, which is the largest subjective null in gap 4, and 6 bpm produced mild over-breathing, which is gap 5."
+      "caveat": "n = 84 college students, within-subjects, four conditions: square, 4-7-8, 6 bpm at 4:6, and 6 bpm at 5:5. Single session, so it speaks to acute effect only, and it's the largest ratio comparison in this corpus. This is the head-to-head that ranks exhale's presets, and it ranks against box breathing and 4-7-8. Two of its findings cut against arguments made elsewhere in this corpus: mood didn't change meaningfully in any condition, which is the largest subjective null in gap 4, and 6 bpm produced mild over-breathing, which is gap 5."
     }
   },
   {
@@ -1206,7 +1206,7 @@
         "at 6 breaths per minute, a 1:2 inhale-to-exhale ratio produced no HRV advantage over 1:1 in either an original experiment or its replication",
         "the finding held across time-domain, frequency-domain and nonlinear HRV metrics"
       ],
-      "caveat": "Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication, and its introduction tallies the older literature: three further nulls and one result favouring the longer inhale. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of five disagreeing studies; see also vandiest2014-ie-ratio-relaxation, laborde2021-ie-ratio-pauses and lin2014-equal-ratio-hrv. All five measured HRV; vandiest2014-ie-ratio-relaxation, lin2014-equal-ratio-hrv and marchant2025-square-478-six also measured how participants felt, and those three do not agree either."
+      "caveat": "Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it's the only entry in this corpus that ran its own replication, and its introduction tallies the older literature: three further nulls and one result favouring the longer inhale. Its scope condition matters: it holds rate fixed inside the resonance range, so it doesn't rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of five disagreeing studies; see also vandiest2014-ie-ratio-relaxation, laborde2021-ie-ratio-pauses and lin2014-equal-ratio-hrv. All five measured HRV; vandiest2014-ie-ratio-relaxation, lin2014-equal-ratio-hrv and marchant2025-square-478-six also measured how participants felt, and those three don't agree either."
     }
   },
   {
@@ -1262,9 +1262,9 @@
       "evidenceTier": "C",
       "backsClaims": [
         "a translucent animated bar spanning the screen, running in the periphery of attention during normal information work, significantly lowered participants' breathing rate",
-        "peripheral pacing does not require the user's full attention to change breathing"
+        "peripheral pacing doesn't require the user's full attention to change breathing"
       ],
-      "caveat": "This is the closest published analogue to exhale that exists, and its limitation is the important part: the reduction occurred while the pacing feedback was active and did not persist as a lasting change in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as it is on. An author copy has been distributed from vis.stanford.edu; the ACM Digital Library version is paywalled."
+      "caveat": "This is the closest published analogue to exhale that exists, and its limitation is the important part: the reduction occurred while the pacing feedback was active and didn't persist as a lasting change in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as it's on. An author copy has been distributed from vis.stanford.edu; the ACM Digital Library version is paywalled."
     }
   },
   {
@@ -1297,7 +1297,7 @@
       "backsClaims": [
         "the classical hatha text and commentary in which timed inhale, retention and exhale ratios are set out is the historical origin of the ratio instructions modern breathing apps repeat"
       ],
-      "caveat": "Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third edition, Bihar School of Yoga, 1998, 642 pages. Not peer reviewed, and a commentary on a fifteenth-century text rather than a primary source in any modern sense. Carried because the longer-exhale instruction exhale ships did not come from a laboratory: it came from this tradition, centuries before anyone measured HRV. Naming that is more accurate than retrofitting a citation to psychophysiology. It must never back a physiological claim."
+      "caveat": "Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third edition, Bihar School of Yoga, 1998, 642 pages. Not peer reviewed, and a commentary on a fifteenth-century text rather than a primary source in any modern sense. Carried because the longer-exhale instruction exhale ships didn't come from a laboratory: it came from this tradition, centuries before anyone measured HRV. Naming that is more accurate than retrofitting a citation to psychophysiology. It must never back a physiological claim."
     },
     "edition": "3rd ed.",
     "number-of-pages": "642"
@@ -1378,7 +1378,7 @@
       "backsClaims": [
         "slow breathing improves ventilation efficiency and alters cardiorespiratory coupling, respiratory sinus arrhythmia and sympathovagal balance"
       ],
-      "caveat": "Narrative review. The authors close by calling explicitly for further research, and describe the health claims as potential rather than demonstrated. Use it to explain a mechanism, not to assert an outcome."
+      "caveat": "Narrative review. The authors close by calling explicitly for further research, and describe the health claims as potential rather than demonstrated. Use it to explain a mechanism rather than to assert an outcome."
     }
   },
   {
@@ -1412,7 +1412,7 @@
       "backsClaims": [
         "the systematic pranayama tradition from which exhale's controllable inhale / retention / exhale / retention structure descends is documented in a standard modern reference manual"
       ],
-      "caveat": "Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third revised edition, Yoga Publications Trust, 1999, 553 pages. A 2008 fourth revised edition exists under the same imprint; this entry cites the edition the ISBN resolves to. Not peer reviewed. Cited only for lineage: it is where exhale's four-phase structure comes from, and presenting the design as derived from 2020s psychophysiology would be revisionist. It must never back a physiological claim."
+      "caveat": "Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third revised edition, Yoga Publications Trust, 1999, 553 pages. A 2008 fourth revised edition exists under the same imprint; this entry cites the edition the ISBN resolves to. Not peer reviewed. Cited only for lineage: it's where exhale's four-phase structure comes from, and presenting the design as derived from 2020s psychophysiology would be revisionist. It must never back a physiological claim."
     },
     "edition": "3rd rev. ed."
   },
@@ -1453,7 +1453,7 @@
         "during computer data-entry work, end-tidal CO2 was significantly lower and respiration frequency significantly higher than during either baseline relaxation or progressive muscle relaxation",
         "breathing changes measurably at a screen, and end-tidal CO2 discriminates the state"
       ],
-      "caveat": "n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real work over real working days, not a lab proxy. Note the comparison: data entry against two relaxation conditions, so it shows what demanding work at a keyboard does, not that the screen itself is the cause; grassmann2016-cognitive-load-respiration finds the same pattern under cognitive load generally. Along with schleifer2008-emg-gaps-computer-work it is the direct evidence that keyboard work changes respiration, and it dates from 1994, well before the topic reached breathwork writing."
+      "caveat": "n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real work over real working days rather than a lab proxy. Note the comparison: data entry against two relaxation conditions, so it shows what demanding work at a keyboard does; it doesn't show that the screen itself is the cause, and grassmann2016-cognitive-load-respiration finds the same pattern under cognitive load generally. Along with schleifer2008-emg-gaps-computer-work it's the direct evidence that keyboard work changes respiration, and it dates from 1994, well before the topic reached breathwork writing."
     }
   },
   {
@@ -1498,7 +1498,7 @@
         "thoracic breathing recruits sternocleidomastoid, scalene and trapezius muscles, imposing biomechanical stress on the neck and shoulder region",
         "breathing training and rest breaks are a rationale-backed response to this pattern at work"
       ],
-      "caveat": "Theory paper, not an experiment, hence tier D. It is nonetheless the closest thing in the peer-reviewed literature to the folk claim about 'shallow' breathing at a screen: the diaphragmatic-to-thoracic shift is what people mean by shallow. Cite it for the pattern, never for a measured tidal volume, and note it theorises the shift rather than demonstrating it in screen users."
+      "caveat": "Theory paper rather than an experiment, hence tier D. It's nonetheless the closest thing in the peer-reviewed literature to the folk claim about 'shallow' breathing at a screen: the diaphragmatic-to-thoracic shift is what people mean by shallow. Cite it for the pattern, never for a measured tidal volume, and note that it theorises the shift; no study demonstrates it in screen users."
     }
   },
   {
@@ -1629,11 +1629,11 @@
       "readDepth": "full-text",
       "evidenceTier": "D",
       "backsClaims": [
-        "the relationship between breathing rate and heart-rate-variability amplitude is an inverted U with a peak, not a slope",
+        "the relationship between breathing rate and heart-rate-variability amplitude is an inverted U with a peak",
         "resonance frequency ranges from 4.5 to 6.5 breaths per minute in adults, and 6.5 to 9.5 in children",
         "breathing in a narrow band around the resonance frequency stimulates the baroreflex better than breathing across a wider range"
       ],
-      "caveat": "Methods guide rather than an experiment, hence tier D. It bears on exhale's drift setting: if HRV amplitude peaks at the resonance frequency, breathing progressively slower moves away from that peak once past it, so 'slower is always better' is false for HRV amplitude. Gap 6 notes that the peak is in HRV amplitude rather than in relaxation or comfort, so this bounds the HRV argument for drift without settling the question. Shaffer is also an author of meehan2024-longer-exhalations, so this corpus leans on one group twice; the resonance-frequency model itself is not a contested finding."
+      "caveat": "Methods guide rather than an experiment, hence tier D. It bears on exhale's drift setting: if HRV amplitude peaks at the resonance frequency, breathing progressively slower moves away from that peak once past it, so 'slower is always better' is false for HRV amplitude. Gap 6 notes that the peak is in HRV amplitude rather than in relaxation or comfort, so this bounds the HRV argument for drift without settling the question. Shaffer is also an author of meehan2024-longer-exhalations, so this corpus leans on one group twice; the resonance-frequency model itself isn't a contested finding."
     }
   },
   {
@@ -1707,10 +1707,10 @@
       "evidenceTier": "C",
       "backsClaims": [
         "one sentence of instruction cut the end-tidal CO2 drop during 6-per-minute paced breathing from 5.21 to 2.7 mmHg",
-        "hyperventilation symptoms rose 0.63 points on a 7-point scale without the instruction and did not rise significantly with it",
+        "hyperventilation symptoms rose 0.63 points on a 7-point scale without the instruction and didn't rise significantly with it",
         "the instruction used was to avoid excessively deep breathing and to breathe shallowly and naturally"
       ],
-      "caveat": "Randomised, two groups, n = 46 aged 19-26, single session. This is the mitigation for gap 5 and it is unusually cheap: the problem with slow pacing is depth, not rate, and a single sentence removes most of it. exhale paces rate and says nothing about depth, so this is the one instruction in the corpus with a safety rationale for appearing in the app rather than a persuasive one."
+      "caveat": "Randomised, two groups, n = 46 aged 19-26, single session. This is the mitigation for gap 5 and it's unusually cheap: the problem with slow pacing is depth rather than rate, and a single sentence removes most of it. exhale paces rate and says nothing about depth, so this is the one instruction in the corpus with a safety rationale for appearing in the app."
     }
   },
   {
@@ -1746,7 +1746,7 @@
         "across seven consecutive days of ten-minute paced breathing, self-reported task pleasantness rose significantly and unpleasant arousal fell, with the affective gains emerging by mid-training rather than on day one",
         "the end-tidal CO2 drop caused by paced breathing shrank with practice: 37.5% of participants dropped below 30 mmHg on day one against 6.3% on day seven"
       ],
-      "caveat": "n = 16, single group, no control, one week. Small and uncontrolled, so treat the magnitudes as indicative. It is carried because it is the closest thing in this corpus to evidence for the pranayama proposition that the practice improves with practice: relaxation was not immediate, it accrued. Note what it does not show. Training was at a fixed 0.1 Hz throughout; it is evidence that repeated practice at one rate gets better, not that progressively slowing within a session helps. That second proposition remains untested. See also joshi1992-pranayam-training."
+      "caveat": "n = 16, single group, no control, one week. Small and uncontrolled, so treat the magnitudes as indicative. It's carried because it's the closest thing in this corpus to evidence for the pranayama proposition that the practice improves with practice: relaxation wasn't immediate, it accrued. Note what it doesn't show. Training was at a fixed 0.1 Hz throughout; it's evidence that repeated practice at one rate gets better. Whether progressively slowing within a session helps is a second proposition, and it remains untested. See also joshi1992-pranayam-training."
     }
   },
   {
@@ -1834,7 +1834,7 @@
       "backsClaims": [
         "blink rate during display work is far below blink rate at rest"
       ],
-      "caveat": "Not read. This is a one-page correspondence item rather than a full paper. It is the origin of the widely quoted '22 blinks a minute at rest, 7 during screen work' figures, which circulate almost entirely by secondary citation. Cite it for the direction of the effect. For a magnitude, use rosenfield2011-computer-vision-syndrome or sheppard2018-digital-eye-strain instead."
+      "caveat": "Not read. This is a one-page correspondence item rather than a full paper. It's the origin of the widely quoted '22 blinks a minute at rest, 7 during screen work' figures, which circulate almost entirely by secondary citation. Cite it for the direction of the effect. For a magnitude, use rosenfield2011-computer-vision-syndrome or sheppard2018-digital-eye-strain instead."
     }
   },
   {
@@ -1892,7 +1892,7 @@
         "a low inhale/exhale ratio also produced more HF-HRV power, but only in the slow breathing condition",
         "slowing the rate on its own improved only self-reported positive energy"
       ],
-      "caveat": "n = 30, four patterns crossing rate (6 or 12 breaths/min) with i/e ratio (0.42 or 2.33). This is the single most important entry for exhale's longer-exhale preference: it is the one study in this corpus in which the longer exhale won on how people felt. It is not the only study that measured that. lin2014-equal-ratio-hrv found every slow pattern raised relaxation with no ratio-specific edge, and marchant2025-square-478-six, at nearly three times the sample, found no meaningful mood change in any condition. Gap 4 weighs the three."
+      "caveat": "n = 30, four patterns crossing rate (6 or 12 breaths/min) with i/e ratio (0.42 or 2.33). This is the single most important entry for exhale's longer-exhale preference: it's the one study in this corpus in which the longer exhale won on how people felt. It isn't the only study that measured that. lin2014-equal-ratio-hrv found every slow pattern raised relaxation with no ratio-specific edge, and marchant2025-square-478-six, at nearly three times the sample, found no meaningful mood change in any condition. Gap 4 weighs the three."
     }
   },
   {
@@ -1940,7 +1940,7 @@
       "backsClaims": [
         "a body of specialist opinion holds that the blood-pressure case for device-guided slow breathing is weak and should be considered closed"
       ],
-      "caveat": "Letter, two pages, not a study, hence no evidence tier. Carried deliberately: it is the strongest published dissent against the cardiovascular claims exhale sits next to, and a corpus that omitted it would be advocacy rather than provenance."
+      "caveat": "Letter, two pages, so no evidence tier applies. Carried deliberately: it's the strongest published dissent against the cardiovascular claims exhale sits next to, and a corpus that omitted it would be advocacy rather than provenance."
     }
   },
   {
@@ -1995,7 +1995,7 @@
       "backsClaims": [
         "sighs act as resetters of respiratory variability: random variability is elevated before a sigh and correlated variability increases after one"
       ],
-      "caveat": "Theoretical model paper with supporting data. Carried because it is the honest place to point when someone asks why a deliberately irregular breath might be useful, which is the only literature adjacent to exhale's randomised-timing sliders. It is not evidence that those sliders help; see the gaps ledger."
+      "caveat": "Theoretical model paper with supporting data. Carried because it's the honest place to point when someone asks why a deliberately irregular breath might be useful, which is the only literature adjacent to exhale's randomised-timing sliders. It's not evidence that those sliders help; see the gaps ledger."
     }
   },
   {
@@ -2079,7 +2079,7 @@
       "backsClaims": [
         "visual pacing produced more measured respiratory change than auditory pacing, but auditory pacing was rated as subjectively more calming"
       ],
-      "caveat": "Two-page adjunct paper, effectively a poster; treat the finding as a design signal, not a result. It is carried anyway because it is the one published comparison that puts exhale's visual-only design at a disadvantage on the outcome most users actually care about, which is whether they feel calmer."
+      "caveat": "Two-page adjunct paper, effectively a poster; treat the finding as a design signal rather than a result. It's carried anyway because it's the one published comparison that puts exhale's visual-only design at a disadvantage on the outcome most users actually care about, which is whether they feel calmer."
     }
   },
   {
@@ -2144,7 +2144,7 @@
         "a small preBotzinger subpopulation projects to and positively regulates noradrenergic locus coeruleus neurons, giving breathing a direct anatomical route to arousal state",
         "ablating those roughly 175 neurons left breathing intact but increased calm behaviours"
       ],
-      "caveat": "Mouse work, and the direction is breathing pattern to arousal rather than voluntarily slow breathing to calm. It is the single best answer to 'why would breathing slowly change how I feel at all', and it is still an inference from mice. Do not cite it for a human effect."
+      "caveat": "Mouse work, and the direction is breathing pattern to arousal rather than voluntarily slow breathing to calm. It's the single best answer to 'why would breathing slowly change how I feel at all', and it's still an inference from mice. Don't cite it for a human effect."
     }
   },
   {
@@ -2183,7 +2183,7 @@
       "backsClaims": [
         "heart rate rises on inhalation and falls on exhalation, and this respiratory sinus arrhythmia is the coupling that HRV-based breathing claims rest on"
       ],
-      "caveat": "Review. This is the physiological fact underneath every 'longer exhale calms you' claim in this corpus, which is why the claim is so intuitive and why meehan2024-longer-exhalations failing to find a ratio effect is worth taking seriously: a real beat-to-beat mechanism does not guarantee a measurable session-level outcome."
+      "caveat": "Review. This is the physiological fact underneath every 'longer exhale calms you' claim in this corpus, which is why the claim is so intuitive and why meehan2024-longer-exhalations failing to find a ratio effect is worth taking seriously: a real beat-to-beat mechanism doesn't guarantee a measurable session-level outcome."
     }
   },
   {
@@ -2240,7 +2240,7 @@
         "LF-HRV discriminated between the tested frequencies more sensitively than RMSSD",
         "the band actually tested and supported is 5 to 7 cycles per minute"
       ],
-      "caveat": "Crossref records this as issued 2023 (online 8 December); it appears in the March 2024 issue, 49(1), which is how it is usually cited. The citekey follows the Crossref issued year, as everywhere else in this corpus. n = 75, all athletes aged 19-31, single lab session. Generalisation to a desk worker is an assumption, not a finding. This is the source that fixes the tested band the settings panel reports: 5 s in and 5 s out is 6 cycles per minute, inside it; the earlier 5 s in and 10 s out is 4.0, below it."
+      "caveat": "Crossref records this as issued 2023 (online 8 December); it appears in the March 2024 issue, 49(1), which is how it's usually cited. The citekey follows the Crossref issued year, as everywhere else in this corpus. n = 75, all athletes aged 19-31, single lab session. Generalisation to a desk worker is an assumption rather than a finding. This is the source that fixes the tested band the settings panel reports: 5 s in and 5 s out is 6 cycles per minute, inside it; the earlier 5 s in and 10 s out is 4.0, below it."
     }
   },
   {
@@ -2358,7 +2358,7 @@
       "backsClaims": [
         "nasal breathing entrains oscillations in human piriform cortex, amygdala and hippocampus, and the effect is specific to the nasal route rather than to breathing as such"
       ],
-      "caveat": "Human intracranial recordings in a small epilepsy-surgery cohort plus behavioural experiments. Carried because it is the reason nose-versus-mouth is a real variable and not folklore. exhale gives no nasal-breathing guidance at all, which is a defensible omission for a wordless overlay but should be a conscious one."
+      "caveat": "Human intracranial recordings in a small epilepsy-surgery cohort plus behavioural experiments. Carried because it's the reason nose-versus-mouth is a real variable and not folklore. exhale gives no nasal-breathing guidance at all, which is a defensible omission for a wordless overlay but should be a conscious one."
     }
   }
 ]

--- a/docs/CITATIONS.md
+++ b/docs/CITATIONS.md
@@ -11,9 +11,9 @@ Every claim was re-checked against the abstracts and open full texts on 2026-09-
 > `uv run --no-project scripts/generate-citations.py`. Editing `CITATIONS.md` directly will be
 > overwritten. `--check` fails if the two drift apart.
 
-exhale is a breathing overlay, not a medical device, and nothing here is medical advice. See the
+exhale is a breathing overlay with no medical purpose, and nothing here is medical advice. See the
 [disclaimer](../README.md#disclaimer). This corpus exists so that anyone, including the author, can
-check which of exhale's claims and defaults rest on published evidence and which do not. The
+check which of exhale's claims and defaults rest on published evidence and which don't. The
 [gaps ledger](#gaps-and-unsupported-choices) at the end is the more useful half.
 
 ## How to read this
@@ -25,7 +25,7 @@ true, and nothing about whether the full text was read.
 
 | Status | Meaning |
 |---|---|
-| `crossref-verified` | The DOI resolves in Crossref, and the title, authors, year, journal, volume and pages printed here are the ones Crossref returned, not the ones a search result claimed. |
+| `crossref-verified` | The DOI resolves in Crossref, and the title, authors, year, journal, volume and pages printed here are the ones Crossref returned rather than the ones a search result claimed. |
 | `openlibrary-verified` | No DOI exists because the source is a book. The title, author, publisher, edition and page count printed here were checked against the Open Library record for the stated ISBN. |
 | `pubmed-verified` | No DOI exists, but the article is indexed in PubMed. The title, authors, journal, year, volume and pages were checked against the NCBI E-utilities record for the stated PMID. |
 | `unverified` | No resolvable DOI and no catalogue record. Bibliographic details are inherited from secondary citation and may be wrong. |
@@ -33,8 +33,8 @@ true, and nothing about whether the full text was read.
 Author names are printed as the registry holds them, which is why a few records carry initials
 where others carry full given names.
 
-A verified record can still carry a loud caveat. Verification confirms the *citation*, not the
-*claim*, so each entry also states how deeply the source was read before its claims were written
+A verified record can still carry a loud caveat. Verification confirms the *citation* rather than the
+*claim*, so each entry also states to what depth the source was read before its claims were written
 down: in full, from the abstract only, or as a catalogue record only.
 
 ### Access level
@@ -48,7 +48,7 @@ entry links it as an open copy.
 ### Evidence tier
 
 Applied to sources making a claim about what happens to a human being. Physiological and animal
-mechanism papers are tier D by definition: they explain why something might work, they do not
+mechanism papers are tier D by definition: they explain why something might work, they don't
 establish that it does.
 
 | Tier | Definition | How exhale is allowed to use it |
@@ -56,7 +56,7 @@ establish that it does.
 | A | Systematic review or meta-analysis of controlled trials, or a pre-registered RCT with 200 or more participants | May be cited for an outcome claim |
 | B | Pre-registered or internally replicated controlled experiment, or a systematic review of experiments without meta-analysis | May be cited for an outcome claim, with its scope conditions stated |
 | C | Single controlled experiment, small n, lab-only, or observational work, including systematic reviews of observational studies | Cite as suggestive; never as "research shows" |
-| D | Narrative review, theory, mechanism, or animal work | Cite for *why*, never for *whether* |
+| D | Narrative review, theory, mechanism, or animal work | Cite for mechanism only; it can't establish that a practice works |
 | E | Not peer reviewed, or contradicted by better evidence | May be cited for provenance, meaning where a practice came from. Never for whether it works |
 
 ### Counts
@@ -106,7 +106,7 @@ Albulescu, Patricia; Macsinga, Irina; Rusu, Andrei; Sulea, Coralia; Bodnaru, Ale
 - Backs:
   - short breaks of ten minutes or less from a work task reduce fatigue and increase vigor
   - an interruption long enough to run one breath cycle is a plausible unit of recovery
-- Caveat: 22 studies, 19 manuscripts. The performance effect was smaller and less consistent than the well-being effect, and the authors report it depended on task type. None of the included studies used a breathing exercise as the break activity, so this supports the general shape of exhale's reminder timer, not its specific content.
+- Caveat: 22 studies, 19 manuscripts. The performance effect was smaller and less consistent than the well-being effect, and the authors report it depended on task type. None of the included studies used a breathing exercise as the break activity, so this supports the general shape of exhale's reminder timer; the breathing content itself is untested here.
 
 #### `deniz2024-forward-head-lung-volumes`
 
@@ -117,7 +117,7 @@ Deniz, Yasemin; Ertekin, Damla; Çokar, Dilek. (2024). *The effect of forward he
 - Backs:
   - across four comparison studies totalling 115 participants, forward head posture was associated with FVC reductions of 0.25 to 0.81 L and FEV1 reductions of 0.16 to 0.93 L
   - craniovertebral angle correlates positively with dynamic pulmonary volumes
-- Caveat: Systematic review without meta-analysis of four small comparison studies and two correlation studies; the authors phrase the conclusion as forward head posture 'can potentially cause' pulmonary abnormalities. The search included ResearchGate alongside PubMed and Google Scholar, which is an unusual choice. This is the posture half of the screen-breathing argument: it is about head position, not about screens, and the link to screens comes from jung2016-smartphone-posture-respiration. The Crossref deposit carries the second and third authors' names with a dotless i, a transliteration artefact; they are printed here in standard Turkish orthography.
+- Caveat: Systematic review without meta-analysis of four small comparison studies and two correlation studies; the authors phrase the conclusion as forward head posture 'can potentially cause' pulmonary abnormalities. The search included ResearchGate alongside PubMed and Google Scholar, which is an unusual choice. This is the posture half of the screen-breathing argument: it measures head position, and the link to screens comes from jung2016-smartphone-posture-respiration. The Crossref deposit carries the second and third authors' names with a dotless i, a transliteration artefact; they're printed here in standard Turkish orthography.
 
 #### `grassmann2016-cognitive-load-respiration`
 
@@ -127,9 +127,9 @@ Grassmann, Mariel; Vlemincx, Elke; von Leupoldt, Andreas; Mittelstädt, Justin M
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **B**
 - Backs:
   - mentally demanding work is reliably marked by faster breathing, with medium to large effects
-  - respiratory amplitude stays roughly stable under cognitive load rather than shrinking
+  - respiratory amplitude stays roughly stable under cognitive load
   - cognitive load lowers end-tidal CO2, meaning ventilation runs ahead of metabolic need
-- Caveat: 54 experiments across 53 articles. Note the direction of the amplitude finding: cognitive load raises rate while leaving amplitude roughly stable, so this does not support 'shallow' if shallow means less air moved. Minute ventilation goes up. For the diaphragmatic-to-thoracic shift that 'shallow' usually names, see schleifer2002-hyperventilation-job-stress; for the same over-breathing measured at a keyboard, see schleifer1994-vdt-petco2 and schleifer2008-emg-gaps-computer-work. This entry is the general cognitive-load backdrop, and it is also the reason the keyboard cannot be singled out as the cause: any demanding task produces the pattern.
+- Caveat: 54 experiments across 53 articles. Note the direction of the amplitude finding: cognitive load raises rate while leaving amplitude roughly stable, so this doesn't support 'shallow' if shallow means less air moved. Minute ventilation goes up. For the diaphragmatic-to-thoracic shift that 'shallow' usually names, see schleifer2002-hyperventilation-job-stress; for the same over-breathing measured at a keyboard, see schleifer1994-vdt-petco2 and schleifer2008-emg-gaps-computer-work. This entry is the general cognitive-load backdrop, and it's also the reason the keyboard can't be singled out as the cause: any demanding task produces the pattern.
 
 #### `johnson2023-20-20-20`
 
@@ -140,7 +140,7 @@ Johnson, Sophia; Rosenfield, Mark. (2023). *20-20-20 Rule: Are These Numbers Jus
 - Backs:
   - the widely repeated 20-20-20 rule has little peer-reviewed support
   - scheduled 20-second breaks every 5, 10 or 20 minutes produced no significant effect on ocular symptoms, reading speed or task accuracy
-- Caveat: n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge is not self-evidently effective just because it is popular and plausible.
+- Caveat: n = 30, 40-minute tablet reading task, four break schedules. Symptoms rose significantly in all four conditions including the most frequent break schedule. Included here as a caution against exhale's own genre: a periodic on-screen nudge isn't self-evidently effective just because it's popular and plausible.
 
 #### `jung2016-smartphone-posture-respiration`
 
@@ -150,7 +150,7 @@ Jung, Sang In; Lee, Na Kyung; Kang, Kyung Woo; Kim, Kyoung; Lee, Do Youn. (2016)
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **C**
 - Backs:
   - people using smartphones more than four hours a day had significantly worse craniovertebral angle, worse scapular index and lower peak expiratory flow than people using them less than four hours a day
-- Caveat: n = 50, cross-sectional, two groups split on self-reported usage. Correlational: heavy users may differ in many ways besides screen time, and peak expiratory flow was the only respiratory measure that separated (FVC and FEV1 did not). Crossref carries no license; access level taken from J Phys Ther Sci being fully open access.
+- Caveat: n = 50, cross-sectional, two groups split on self-reported usage. Correlational: heavy users may differ in many ways besides screen time, and peak expiratory flow was the only respiratory measure that separated (FVC and FEV1 didn't). Crossref carries no license; access level taken from J Phys Ther Sci being fully open access.
 
 #### `rosenfield2011-computer-vision-syndrome`
 
@@ -172,7 +172,7 @@ Schleifer, Lawrence M.; Ley, Ronald. (1994). *End-tidal PCO2 as an index of psyc
 - Backs:
   - during computer data-entry work, end-tidal CO2 was significantly lower and respiration frequency significantly higher than during either baseline relaxation or progressive muscle relaxation
   - breathing changes measurably at a screen, and end-tidal CO2 discriminates the state
-- Caveat: n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real work over real working days, not a lab proxy. Note the comparison: data entry against two relaxation conditions, so it shows what demanding work at a keyboard does, not that the screen itself is the cause; grassmann2016-cognitive-load-respiration finds the same pattern under cognitive load generally. Along with schleifer2008-emg-gaps-computer-work it is the direct evidence that keyboard work changes respiration, and it dates from 1994, well before the topic reached breathwork writing.
+- Caveat: n = 11 data-entry operators monitored continuously across three consecutive six-hour work days. Small sample, but this is real work over real working days rather than a lab proxy. Note the comparison: data entry against two relaxation conditions, so it shows what demanding work at a keyboard does; it doesn't show that the screen itself is the cause, and grassmann2016-cognitive-load-respiration finds the same pattern under cognitive load generally. Along with schleifer2008-emg-gaps-computer-work it's the direct evidence that keyboard work changes respiration, and it dates from 1994, well before the topic reached breathwork writing.
 
 #### `schleifer2002-hyperventilation-job-stress`
 
@@ -184,7 +184,7 @@ Schleifer, Lawrence M.; Ley, Ronald; Spalding, Thomas W. (2002). *A hyperventila
   - hyperventilation is often characterised by a shift from a diaphragmatic to a thoracic breathing pattern
   - thoracic breathing recruits sternocleidomastoid, scalene and trapezius muscles, imposing biomechanical stress on the neck and shoulder region
   - breathing training and rest breaks are a rationale-backed response to this pattern at work
-- Caveat: Theory paper, not an experiment, hence tier D. It is nonetheless the closest thing in the peer-reviewed literature to the folk claim about 'shallow' breathing at a screen: the diaphragmatic-to-thoracic shift is what people mean by shallow. Cite it for the pattern, never for a measured tidal volume, and note it theorises the shift rather than demonstrating it in screen users.
+- Caveat: Theory paper rather than an experiment, hence tier D. It's nonetheless the closest thing in the peer-reviewed literature to the folk claim about 'shallow' breathing at a screen: the diaphragmatic-to-thoracic shift is what people mean by shallow. Cite it for the pattern, never for a measured tidal volume, and note that it theorises the shift; no study demonstrates it in screen users.
 
 #### `schleifer2008-emg-gaps-computer-work`
 
@@ -217,7 +217,7 @@ Tsubota, Kazuo; Nakamori, Katsu. (1993). *Dry Eyes and Video Display Terminals*.
 - Verification: crossref-verified | Access: paywalled | Read: catalogue record only | evidence tier **C**
 - Backs:
   - blink rate during display work is far below blink rate at rest
-- Caveat: Not read. This is a one-page correspondence item rather than a full paper. It is the origin of the widely quoted '22 blinks a minute at rest, 7 during screen work' figures, which circulate almost entirely by secondary citation. Cite it for the direction of the effect. For a magnitude, use rosenfield2011-computer-vision-syndrome or sheppard2018-digital-eye-strain instead.
+- Caveat: Not read. This is a one-page correspondence item rather than a full paper. It's the origin of the widely quoted '22 blinks a minute at rest, 7 during screen work' figures, which circulate almost entirely by secondary citation. Cite it for the direction of the effect. For a magnitude, use rosenfield2011-computer-vision-syndrome or sheppard2018-digital-eye-strain instead.
 
 ---
 
@@ -233,7 +233,7 @@ Chaddha, Ashish; Modaff, Daniel; Hooper-Lane, Christopher; Feldstein, David A. (
 - Verification: crossref-verified | Access: paywalled | Read: full text | evidence tier **A**
 - Backs:
   - sustained slow breathing programmes lower systolic blood pressure by about 5.6 mmHg and diastolic by about 3.0 mmHg in hypertensive and prehypertensive adults
-- Caveat: 17 RCTs. Heterogeneity was high for every analysis, and the authors say so. Inclusion required at least 5 minutes of breathing at 10 breaths/min or slower, on at least 3 days a week, for at least 4 weeks. exhale asks for none of that and measures none of it, so this describes a dose exhale does not deliver. Read alongside vandijk2018-close-the-book.
+- Caveat: 17 RCTs. Heterogeneity was high for every analysis, and the authors say so. Inclusion required at least 5 minutes of breathing at 10 breaths/min or slower, on at least 3 days a week, for at least 4 weeks. exhale asks for none of that and measures none of it, so this describes a dose exhale doesn't deliver. Read alongside vandijk2018-close-the-book.
 
 #### `fincham2023-breathwork-meta`
 
@@ -245,7 +245,7 @@ Fincham, Guy William; Strauss, Clara; Montero-Marin, Jesus; Cavanagh, Kate. (202
   - breathwork lowers self-reported stress against control conditions, g = -0.35 (95% CI -0.55 to -0.14), 12 RCTs, 785 adults
   - comparable small-to-medium effects for anxiety (g = -0.32, k = 20) and depressive symptoms (g = -0.40, k = 18)
   - adverse-event reporting in breathwork trials is sparse: four of the twelve primary-outcome trials reported on it, and none attributed lasting harm to breathwork
-- Caveat: Most included studies were rated at moderate risk of bias. Effects are small-to-medium and self-reported. Only four of the twelve primary-outcome trials reported on adverse events, and none attributed lasting harm to breathwork; the authors call for better reporting, particularly for fast-paced techniques. This is the strongest single warrant for the claim that a breathing practice does something, and it is still an effect of about a third of a standard deviation.
+- Caveat: Most included studies were rated at moderate risk of bias. Effects are small-to-medium and self-reported. Only four of the twelve primary-outcome trials reported on adverse events, and none attributed lasting harm to breathwork; the authors call for better reporting, particularly for fast-paced techniques. This is the strongest single warrant for the claim that a breathing practice does something, and it's still an effect of about a third of a standard deviation.
 
 #### `laborde2022-vsb-meta`
 
@@ -257,7 +257,7 @@ Laborde, S.; Allen, M. S.; Borges, U.; Dosseville, F.; Hosang, T. J.; Iskra, M.;
 - Backs:
   - voluntary slow breathing raises vagally-mediated HRV during the session, immediately after a single session, and after a multi-session intervention
   - few adverse effects are expected from slow breathing practice
-- Caveat: 223 studies from 1842 screened abstracts (172 during, 16 immediately-after, 49 after-intervention). This is the central warrant for exhale's whole premise. Note what it establishes: an effect on a cardiac index of parasympathetic activity, not an effect on how anyone feels or works.
+- Caveat: 223 studies from 1842 screened abstracts (172 during, 16 immediately-after, 49 after-intervention). This is the central warrant for exhale's whole premise. Note what it establishes: an effect on a cardiac index of parasympathetic activity; it says nothing about how anyone feels or works.
 
 #### `little2025-a52-breath-method`
 
@@ -279,7 +279,7 @@ Russo, Marc A.; Santarelli, Danielle M.; O'Rourke, Dean. (2017). *The physiologi
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **D**
 - Backs:
   - slow breathing improves ventilation efficiency and alters cardiorespiratory coupling, respiratory sinus arrhythmia and sympathovagal balance
-- Caveat: Narrative review. The authors close by calling explicitly for further research, and describe the health claims as potential rather than demonstrated. Use it to explain a mechanism, not to assert an outcome.
+- Caveat: Narrative review. The authors close by calling explicitly for further research, and describe the health claims as potential rather than demonstrated. Use it to explain a mechanism rather than to assert an outcome.
 
 #### `vandijk2018-close-the-book`
 
@@ -290,7 +290,7 @@ van Dijk, Peter R.; van Hateren, Kornelis J. J.; Kleefstra, Nanne; Landman, Gijs
 - Verification: crossref-verified | Access: paywalled | Read: full text | no evidence tier (not a study)
 - Backs:
   - a body of specialist opinion holds that the blood-pressure case for device-guided slow breathing is weak and should be considered closed
-- Caveat: Letter, two pages, not a study, hence no evidence tier. Carried deliberately: it is the strongest published dissent against the cardiovascular claims exhale sits next to, and a corpus that omitted it would be advocacy rather than provenance.
+- Caveat: Letter, two pages, so no evidence tier applies. Carried deliberately: it's the strongest published dissent against the cardiovascular claims exhale sits next to, and a corpus that omitted it would be advocacy rather than provenance.
 
 #### `zaccaro2018-slow-breathing-review`
 
@@ -328,8 +328,8 @@ Balban, Melis Yilmaz; Neri, Eric; Kogon, Manuela M.; Weed, Lara; Nouriani, Bita;
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **B**
 - Backs:
   - five minutes a day of exhale-emphasising cyclic sighing improved mood and lowered respiratory rate more than an equal period of mindfulness meditation over one month
-  - box breathing, equal inhale / hold / exhale, was tested head-to-head and was not the best-performing arm
-- Caveat: Remote randomised controlled study, pre-registered as NCT05304000, with 108 participants: 24 in the mindfulness-meditation control, 30 cyclic sighing, 21 box breathing and 33 cyclic hyperventilation. The comparator is mindfulness meditation rather than a sham, so the arms differ in more than breath ratio. In the mixed-effects model, cyclic sighing separated from the control on positive affect; box breathing and cyclic hyperventilation did not, and the breathwork arms were not tested against one another. Daily positive-affect gains were 1.89 points for cyclic sighing and 1.84 for box breathing. This is the best evidence in the corpus that emphasising the exhale is the right emphasis, and it is weaker than the abstract suggests: the box arm is small and the difference between the two patterns is not established. The cyclic-sighing protocol also adds a double inhale, so its effect cannot be attributed to exhale length alone.
+  - box breathing, equal inhale / hold / exhale, was tested head-to-head and wasn't the best-performing arm
+- Caveat: Remote randomised controlled study, pre-registered as NCT05304000, with 108 participants: 24 in the mindfulness-meditation control, 30 cyclic sighing, 21 box breathing and 33 cyclic hyperventilation. The comparator is mindfulness meditation rather than a sham, so the arms differ in more than breath ratio. In the mixed-effects model, cyclic sighing separated from the control on positive affect; box breathing and cyclic hyperventilation didn't, and the breathwork arms weren't tested against one another. Daily positive-affect gains were 1.89 points for cyclic sighing and 1.84 for box breathing. This is the best evidence in the corpus that emphasising the exhale is the right emphasis, and it's weaker than the abstract suggests: the box arm is small and the difference between the two patterns isn't established. The cyclic-sighing protocol also adds a double inhale, so its effect can't be attributed to exhale length alone.
 
 #### `bernardi2001-slow-breathing-chemoreflex`
 
@@ -351,7 +351,7 @@ Bilo, Grzegorz; Revera, Miriam; Bussotti, Maurizio; Bonacina, Daniele; Styczkiew
 - Backs:
   - fifteen minutes of paced breathing at 6 per minute raised arterial oxygen saturation and lowered systemic and pulmonary arterial pressure at high altitude
   - the proposed mechanism is a larger tidal volume reducing the proportion of each breath spent on anatomical dead space
-- Caveat: Conducted at high altitude in a hypoxic state, so it does not transfer to a desk at sea level and must not be cited as if it did. It is carried for two narrow purposes: it is a second study placing the controlled literature at 6 breaths per minute, and its dead-space mechanism is the reason slow breathing is not simply less breathing.
+- Caveat: Conducted at high altitude in a hypoxic state, so it doesn't transfer to a desk at sea level and must not be cited as if it did. It's carried for two narrow purposes: it's a second study placing the controlled literature at 6 breaths per minute, and its dead-space mechanism is the reason slow breathing isn't simply less breathing.
 
 #### `laborde2021-ie-ratio-pauses`
 
@@ -361,8 +361,8 @@ Laborde, Sylvain; Iskra, Maša; Zammit, Nina; Borges, Uirassu; You, Min; Sevoz-C
 - Verification: crossref-verified | Access: open-access | Read: abstract only | evidence tier **C**
 - Backs:
   - at six cycles per minute, RMSSD was higher when the exhalation was longer than the inhalation, across inhalation/exhalation ratios of 0.8, 1.0 and 1.2
-  - brief 0.4 s pauses after inhalation and after exhalation did not further change RMSSD
-- Caveat: n = 64 athletes, within-subjects, six 5-minute conditions in one session. Findings taken from the abstract; effect sizes not read. This is the fifth study bearing on the ratio disagreement tabulated in gap 4, on the side of the longer exhale, and the only one that also manipulates respiratory pauses, which is why it also settles gap 11 as far as brief pauses go. Published in Sustainability, an MDPI journal outside the field, which is worth knowing when weighing it against the other four.
+  - brief 0.4 s pauses after inhalation and after exhalation didn't further change RMSSD
+- Caveat: n = 64 athletes, within-subjects, six 5-minute conditions in one session. Findings taken from the abstract; effect sizes not read. This is the fifth study bearing on the ratio disagreement tabulated in gap 4, on the side of the longer exhale, and the only one that also manipulates respiratory pauses, which is why it also settles gap 11 as far as brief pauses go. Published in Sustainability, an MDPI journal outside the field, which matters when weighing it against the other four.
 
 #### `laborde2021-spb-6cpm-biofeedback`
 
@@ -372,8 +372,8 @@ Laborde, Sylvain; Allen, Mark S.; Borges, Uirassu; Iskra, Maša; Zammit, Nina; Y
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **C**
 - Backs:
   - slow-paced breathing at six cycles per minute raised RMSSD relative to control in every condition tested
-  - adding heart-rate-variability biofeedback on top of the six-per-minute pace did not add a further RMSSD benefit, though that condition reported more positive emotional valence
-- Caveat: n = 112, single session. Crossref records this as issued 2021, appearing in the January 2022 issue (59:1). Both conditions raised RMSSD and lowered arousal; the biofeedback condition additionally reported more positive emotional valence, so 'no added benefit' is specific to the cardiac measure. Together with tabor2022-guided-breathing-design this is why exhale ships without a sensor: for the physiological effect of a single session, the pace does the work rather than the feedback loop.
+  - adding heart-rate-variability biofeedback on top of the six-per-minute pace didn't add a further RMSSD benefit, though that condition reported more positive emotional valence
+- Caveat: n = 112, single session. Crossref records this as issued 2021, appearing in the January 2022 issue (59:1). Both conditions raised RMSSD and lowered arousal; the biofeedback condition also reported more positive emotional valence, so 'no added benefit' is specific to the cardiac measure. Together with tabor2022-guided-breathing-design this is why exhale ships without a sensor: for the physiological effect of a single session, the pace does the work.
 
 #### `lin2014-equal-ratio-hrv`
 
@@ -384,7 +384,7 @@ Lin, I. M.; Tai, L. Y.; Fan, S. Y. (2014). *Breathing at a rate of 5.5 breaths p
 - Backs:
   - 5.5 breaths per minute with an equal 5:5 inhale-to-exhale ratio produced higher SDNN and LF power than 6 bpm or than a 4:6 ratio
   - all four slow-breathing patterns increased self-reported relaxation relative to spontaneous breathing
-- Caveat: n = 47, Latin-square counterbalanced. The clearest published result against a longer exhale on HRV grounds, and one reason exhale makes no mechanism claim for the 1:2 ratio. It also measured relaxation and anxiety across the four patterns and reports that all four increased relaxation over baseline, with no ratio-specific advantage; that is one of three subjective measurements bearing on gap 4. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best, not about whether slow breathing works.
+- Caveat: n = 47, Latin-square counterbalanced. The clearest published result against a longer exhale on HRV grounds, and one reason exhale makes no mechanism claim for the 1:2 ratio. It also measured relaxation and anxiety across the four patterns and reports that all four increased relaxation over baseline, with no ratio-specific advantage; that's one of three subjective measurements bearing on gap 4. Note the second claim carefully: every pattern tested increased relaxation, so the ratio argument is about which slow pattern is best rather than about whether slow breathing works.
 
 #### `marchant2025-square-478-six`
 
@@ -397,7 +397,7 @@ Marchant, Joshua; Khazan, Inna; Cressman, Mikel; Steffen, Patrick. (2025). *Comp
   - square and 4-7-8 breathing are popularly promoted but have little empirical support
   - none of the four conditions produced meaningful changes in blood pressure or mood
   - breathing at 6 breaths per minute unexpectedly produced mild over-breathing
-- Caveat: n = 84 college students, within-subjects, four conditions: square, 4-7-8, 6 bpm at 4:6, and 6 bpm at 5:5. Single session, so it speaks to acute effect only, and it is the largest ratio comparison in this corpus. This is the head-to-head that ranks exhale's presets, and it ranks against box breathing and 4-7-8. Two of its findings cut against arguments made elsewhere in this corpus: mood did not change meaningfully in any condition, which is the largest subjective null in gap 4, and 6 bpm produced mild over-breathing, which is gap 5.
+- Caveat: n = 84 college students, within-subjects, four conditions: square, 4-7-8, 6 bpm at 4:6, and 6 bpm at 5:5. Single session, so it speaks to acute effect only, and it's the largest ratio comparison in this corpus. This is the head-to-head that ranks exhale's presets, and it ranks against box breathing and 4-7-8. Two of its findings cut against arguments made elsewhere in this corpus: mood didn't change meaningfully in any condition, which is the largest subjective null in gap 4, and 6 bpm produced mild over-breathing, which is gap 5.
 
 #### `meehan2024-longer-exhalations`
 
@@ -408,7 +408,7 @@ Meehan, Zachary M.; Shaffer, Fred. (2024). *Do Longer Exhalations Increase HRV D
 - Backs:
   - at 6 breaths per minute, a 1:2 inhale-to-exhale ratio produced no HRV advantage over 1:1 in either an original experiment or its replication
   - the finding held across time-domain, frequency-domain and nonlinear HRV metrics
-- Caveat: Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it is the only entry in this corpus that ran its own replication, and its introduction tallies the older literature: three further nulls and one result favouring the longer inhale. Its scope condition matters: it holds rate fixed inside the resonance range, so it does not rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of five disagreeing studies; see also vandiest2014-ie-ratio-relaxation, laborde2021-ie-ratio-pauses and lin2014-equal-ratio-hrv. All five measured HRV; vandiest2014-ie-ratio-relaxation, lin2014-equal-ratio-hrv and marchant2025-square-478-six also measured how participants felt, and those three do not agree either.
+- Caveat: Original n = 26, replication n = 16; both undergraduate samples, both within-subjects with manipulation checks. Small, but it's the only entry in this corpus that ran its own replication, and its introduction tallies the older literature: three further nulls and one result favouring the longer inhale. Its scope condition matters: it holds rate fixed inside the resonance range, so it doesn't rule out a ratio effect at a person's spontaneous rate, which is what bae2021-exhalation-inhalation-ratio measured. One of five disagreeing studies; see also vandiest2014-ie-ratio-relaxation, laborde2021-ie-ratio-pauses and lin2014-equal-ratio-hrv. All five measured HRV; vandiest2014-ie-ratio-relaxation, lin2014-equal-ratio-hrv and marchant2025-square-478-six also measured how participants felt, and those three don't agree either.
 
 #### `sevozcouche2022-coherence-resonance`
 
@@ -428,10 +428,10 @@ Shaffer, Fred; Meehan, Zachary M. (2020). *A Practical Guide to Resonance Freque
 - DOI: [10.3389/fnins.2020.570400](https://doi.org/10.3389/fnins.2020.570400)
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **D**
 - Backs:
-  - the relationship between breathing rate and heart-rate-variability amplitude is an inverted U with a peak, not a slope
+  - the relationship between breathing rate and heart-rate-variability amplitude is an inverted U with a peak
   - resonance frequency ranges from 4.5 to 6.5 breaths per minute in adults, and 6.5 to 9.5 in children
   - breathing in a narrow band around the resonance frequency stimulates the baroreflex better than breathing across a wider range
-- Caveat: Methods guide rather than an experiment, hence tier D. It bears on exhale's drift setting: if HRV amplitude peaks at the resonance frequency, breathing progressively slower moves away from that peak once past it, so 'slower is always better' is false for HRV amplitude. Gap 6 notes that the peak is in HRV amplitude rather than in relaxation or comfort, so this bounds the HRV argument for drift without settling the question. Shaffer is also an author of meehan2024-longer-exhalations, so this corpus leans on one group twice; the resonance-frequency model itself is not a contested finding.
+- Caveat: Methods guide rather than an experiment, hence tier D. It bears on exhale's drift setting: if HRV amplitude peaks at the resonance frequency, breathing progressively slower moves away from that peak once past it, so 'slower is always better' is false for HRV amplitude. Gap 6 notes that the peak is in HRV amplitude rather than in relaxation or comfort, so this bounds the HRV argument for drift without settling the question. Shaffer is also an author of meehan2024-longer-exhalations, so this corpus leans on one group twice; the resonance-frequency model itself isn't a contested finding.
 
 #### `szulczewski2019-training-relaxation`
 
@@ -442,7 +442,7 @@ Szulczewski, Mikołaj Tytus. (2019). *Training of paced breathing at 0.1 Hz impr
 - Backs:
   - across seven consecutive days of ten-minute paced breathing, self-reported task pleasantness rose significantly and unpleasant arousal fell, with the affective gains emerging by mid-training rather than on day one
   - the end-tidal CO2 drop caused by paced breathing shrank with practice: 37.5% of participants dropped below 30 mmHg on day one against 6.3% on day seven
-- Caveat: n = 16, single group, no control, one week. Small and uncontrolled, so treat the magnitudes as indicative. It is carried because it is the closest thing in this corpus to evidence for the pranayama proposition that the practice improves with practice: relaxation was not immediate, it accrued. Note what it does not show. Training was at a fixed 0.1 Hz throughout; it is evidence that repeated practice at one rate gets better, not that progressively slowing within a session helps. That second proposition remains untested. See also joshi1992-pranayam-training.
+- Caveat: n = 16, single group, no control, one week. Small and uncontrolled, so treat the magnitudes as indicative. It's carried because it's the closest thing in this corpus to evidence for the pranayama proposition that the practice improves with practice: relaxation wasn't immediate, it accrued. Note what it doesn't show. Training was at a fixed 0.1 Hz throughout; it's evidence that repeated practice at one rate gets better. Whether progressively slowing within a session helps is a second proposition, and it remains untested. See also joshi1992-pranayam-training.
 
 #### `vandiest2014-ie-ratio-relaxation`
 
@@ -455,7 +455,7 @@ Van Diest, Ilse; Verstappen, Karen; Aubert, André E.; Widjaja, Devy; Vansteenwe
   - participants reported more relaxation, more stress reduction, more mindfulness and more positive energy breathing with a low inhale/exhale ratio (longer exhale) than a high one
   - a low inhale/exhale ratio also produced more HF-HRV power, but only in the slow breathing condition
   - slowing the rate on its own improved only self-reported positive energy
-- Caveat: n = 30, four patterns crossing rate (6 or 12 breaths/min) with i/e ratio (0.42 or 2.33). This is the single most important entry for exhale's longer-exhale preference: it is the one study in this corpus in which the longer exhale won on how people felt. It is not the only study that measured that. lin2014-equal-ratio-hrv found every slow pattern raised relaxation with no ratio-specific edge, and marchant2025-square-478-six, at nearly three times the sample, found no meaningful mood change in any condition. Gap 4 weighs the three.
+- Caveat: n = 30, four patterns crossing rate (6 or 12 breaths/min) with i/e ratio (0.42 or 2.33). This is the single most important entry for exhale's longer-exhale preference: it's the one study in this corpus in which the longer exhale won on how people felt. It isn't the only study that measured that. lin2014-equal-ratio-hrv found every slow pattern raised relaxation with no ratio-specific edge, and marchant2025-square-478-six, at nearly three times the sample, found no meaningful mood change in any condition. Gap 4 weighs the three.
 
 #### `you2023-respiratory-frequency`
 
@@ -467,7 +467,7 @@ You, Min; Laborde, Sylvain; Ackermann, Stefan; Borges, Uirassu; Dosseville, Fabr
   - five minutes of slow-paced breathing at 5, 5.5, 6, 6.5 and 7 cycles per minute all raised cardiac vagal activity above spontaneous breathing
   - LF-HRV discriminated between the tested frequencies more sensitively than RMSSD
   - the band actually tested and supported is 5 to 7 cycles per minute
-- Caveat: Crossref records this as issued 2023 (online 8 December); it appears in the March 2024 issue, 49(1), which is how it is usually cited. The citekey follows the Crossref issued year, as everywhere else in this corpus. n = 75, all athletes aged 19-31, single lab session. Generalisation to a desk worker is an assumption, not a finding. This is the source that fixes the tested band the settings panel reports: 5 s in and 5 s out is 6 cycles per minute, inside it; the earlier 5 s in and 10 s out is 4.0, below it.
+- Caveat: Crossref records this as issued 2023 (online 8 December); it appears in the March 2024 issue, 49(1), which is how it's usually cited. The citekey follows the Crossref issued year, as everywhere else in this corpus. n = 75, all athletes aged 19-31, single lab session. Generalisation to a desk worker is an assumption rather than a finding. This is the source that fixes the tested band the settings panel reports: 5 s in and 5 s out is 6 cycles per minute, inside it; the earlier 5 s in and 10 s out is 4.0, below it.
 
 ---
 
@@ -484,7 +484,7 @@ Joshi, L. N.; Joshi, V. D.; Gokhale, L. V. (1992). *Effect of short term 'Pranay
 - Backs:
   - six weeks of pranayama practice in 75 young adults lowered resting respiratory rate and prolonged breath-holding time
   - the same training raised forced vital capacity, FEV1, maximum voluntary ventilation and peak expiratory flow rate
-- Caveat: Findings taken from the abstract. No DOI exists, and the record was verified against the NCBI E-utilities API by PMID rather than Crossref. Uncontrolled before-and-after design in a 1992 regional journal, so treat the effect sizes as unusable. It is carried because it is the only entry in this corpus that speaks to graded extension as a training progression: capacity grew over six weeks of practice. That is a claim about adaptation across sessions, not evidence for extending the breath without limit inside a single sitting, which is a different proposition that shaffer2020-resonance-frequency-assessment bears on.
+- Caveat: Findings taken from the abstract. No DOI exists, and the record was verified against the NCBI E-utilities API by PMID rather than Crossref. Uncontrolled before-and-after design in a 1992 regional journal, so treat the effect sizes as unusable. It's carried because it's the only entry in this corpus that speaks to graded extension as a training progression: capacity grew over six weeks of practice. That's a claim about adaptation across sessions. Extending the breath without limit inside a single sitting is a different proposition, and shaffer2020-resonance-frequency-assessment bears on it.
 
 #### `muktibodhananda1998-hatha-yoga-pradipika`
 
@@ -494,7 +494,7 @@ Muktibodhananda, Swami. (1998). *Hatha Yoga Pradipika*, 3rd ed. Munger, Bihar, I
 - Verification: openlibrary-verified | Access: paywalled | Read: catalogue record only | evidence tier **E**
 - Backs:
   - the classical hatha text and commentary in which timed inhale, retention and exhale ratios are set out is the historical origin of the ratio instructions modern breathing apps repeat
-- Caveat: Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third edition, Bihar School of Yoga, 1998, 642 pages. Not peer reviewed, and a commentary on a fifteenth-century text rather than a primary source in any modern sense. Carried because the longer-exhale instruction exhale ships did not come from a laboratory: it came from this tradition, centuries before anyone measured HRV. Naming that is more accurate than retrofitting a citation to psychophysiology. It must never back a physiological claim.
+- Caveat: Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third edition, Bihar School of Yoga, 1998, 642 pages. Not peer reviewed, and a commentary on a fifteenth-century text rather than a primary source in any modern sense. Carried because the longer-exhale instruction exhale ships didn't come from a laboratory: it came from this tradition, centuries before anyone measured HRV. Naming that is more accurate than retrofitting a citation to psychophysiology. It must never back a physiological claim.
 
 #### `satyananda1999-apmb`
 
@@ -504,7 +504,7 @@ Satyananda Saraswati, Swami. (1999). *Asana Pranayama Mudra Bandha*, 3rd rev. ed
 - Verification: openlibrary-verified | Access: paywalled | Read: catalogue record only | evidence tier **E**
 - Backs:
   - the systematic pranayama tradition from which exhale's controllable inhale / retention / exhale / retention structure descends is documented in a standard modern reference manual
-- Caveat: Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third revised edition, Yoga Publications Trust, 1999, 553 pages. A 2008 fourth revised edition exists under the same imprint; this entry cites the edition the ISBN resolves to. Not peer reviewed. Cited only for lineage: it is where exhale's four-phase structure comes from, and presenting the design as derived from 2020s psychophysiology would be revisionist. It must never back a physiological claim.
+- Caveat: Contents not consulted; the bibliographic record was checked against Open Library, which lists this ISBN as the third revised edition, Yoga Publications Trust, 1999, 553 pages. A 2008 fourth revised edition exists under the same imprint; this entry cites the edition the ISBN resolves to. Not peer reviewed. Cited only for lineage: it's where exhale's four-phase structure comes from, and presenting the design as derived from 2020s psychophysiology would be revisionist. It must never back a physiological claim.
 
 ---
 
@@ -520,8 +520,8 @@ Moraveji, Neema; Olson, Ben; Nguyen, Truc; Saadat, Mahmoud; Khalighi, Yaser; Pea
 - Verification: crossref-verified | Access: paywalled | Read: full text | evidence tier **C**
 - Backs:
   - a translucent animated bar spanning the screen, running in the periphery of attention during normal information work, significantly lowered participants' breathing rate
-  - peripheral pacing does not require the user's full attention to change breathing
-- Caveat: This is the closest published analogue to exhale that exists, and its limitation is the important part: the reduction occurred while the pacing feedback was active and did not persist as a lasting change in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as it is on. An author copy has been distributed from vis.stanford.edu; the ACM Digital Library version is paywalled.
+  - peripheral pacing doesn't require the user's full attention to change breathing
+- Caveat: This is the closest published analogue to exhale that exists, and its limitation is the important part: the reduction occurred while the pacing feedback was active and didn't persist as a lasting change in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as it's on. An author copy has been distributed from vis.stanford.edu; the ACM Digital Library version is paywalled.
 
 #### `tabor2022-guided-breathing-design`
 
@@ -543,7 +543,7 @@ Wongsuphasawat, Kanit; Gamburg, Alex; Moraveji, Neema. (2012). *You can't force 
 - Verification: crossref-verified | Access: paywalled | Read: full text | evidence tier **C**
 - Backs:
   - visual pacing produced more measured respiratory change than auditory pacing, but auditory pacing was rated as subjectively more calming
-- Caveat: Two-page adjunct paper, effectively a poster; treat the finding as a design signal, not a result. It is carried anyway because it is the one published comparison that puts exhale's visual-only design at a disadvantage on the outcome most users actually care about, which is whether they feel calmer.
+- Caveat: Two-page adjunct paper, effectively a poster; treat the finding as a design signal rather than a result. It's carried anyway because it's the one published comparison that puts exhale's visual-only design at a disadvantage on the outcome most users actually care about, which is whether they feel calmer.
 
 ---
 
@@ -562,7 +562,7 @@ Lehrer, Paul M.; Gevirtz, Richard. (2014). *Heart rate variability biofeedback: 
   - refined measurement puts the average resonance frequency nearer 0.09 Hz, about 5.5 breaths per minute, a breath lasting roughly 11 seconds
   - resonance frequency is individual: taller people and men tend to have lower resonance frequencies
   - baroreflex gain increases substantially during HRV biofeedback
-- Caveat: Narrative mechanistic review by the technique's principal developers. Read as the mechanism argument, not as independent evidence. The individual-variation point is the honest reason exhale's timing sliders are user-editable at all: there is no single correct number to hardcode.
+- Caveat: Narrative mechanistic review by the technique's principal developers. Read as the mechanism argument rather than as independent evidence. The individual-variation point is the honest reason exhale's timing sliders are user-editable at all: there's no single correct number to hardcode.
 
 #### `li2016-sigh-circuit`
 
@@ -572,7 +572,7 @@ Li, Peng; Janczewski, Wiktor A.; Yackle, Kevin; Kam, Kaiwen; Pagliardini, Silvia
 - Open copy: <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4852886/>
 - Verification: crossref-verified | Access: paywalled | Read: full text | evidence tier **D**
 - Backs:
-  - sighing is generated by a dedicated peptidergic circuit projecting onto the preBotzinger complex, not as a byproduct of ordinary breathing rhythm
+  - sighing is generated by a dedicated peptidergic circuit projecting onto the preBotzinger complex rather than as a byproduct of ordinary breathing rhythm
 - Caveat: Mouse work. It establishes that the sigh is a distinct, hardwired respiratory behaviour, which is the mechanistic backdrop for the cyclic-sighing result in balban2023-cyclic-sighing. It says nothing about humans deliberately performing sighs, and must not be cited as if it did.
 
 #### `vlemincx2013-sigh-reset-model`
@@ -583,7 +583,7 @@ Vlemincx, Elke; Abelson, James L.; Lehrer, Paul M.; Davenport, Paul W.; Van Dies
 - Verification: crossref-verified | Access: paywalled | Read: full text | evidence tier **D**
 - Backs:
   - sighs act as resetters of respiratory variability: random variability is elevated before a sigh and correlated variability increases after one
-- Caveat: Theoretical model paper with supporting data. Carried because it is the honest place to point when someone asks why a deliberately irregular breath might be useful, which is the only literature adjacent to exhale's randomised-timing sliders. It is not evidence that those sliders help; see the gaps ledger.
+- Caveat: Theoretical model paper with supporting data. Carried because it's the honest place to point when someone asks why a deliberately irregular breath might be useful, which is the only literature adjacent to exhale's randomised-timing sliders. It's not evidence that those sliders help; see the gaps ledger.
 
 #### `vlemincx2016-sigh-relief`
 
@@ -606,7 +606,7 @@ Yackle, Kevin; Schwarz, Lindsay A.; Kam, Kaiwen; Sorokin, Jordan M.; Huguenard, 
 - Backs:
   - a small preBotzinger subpopulation projects to and positively regulates noradrenergic locus coeruleus neurons, giving breathing a direct anatomical route to arousal state
   - ablating those roughly 175 neurons left breathing intact but increased calm behaviours
-- Caveat: Mouse work, and the direction is breathing pattern to arousal rather than voluntarily slow breathing to calm. It is the single best answer to 'why would breathing slowly change how I feel at all', and it is still an inference from mice. Do not cite it for a human effect.
+- Caveat: Mouse work, and the direction is breathing pattern to arousal rather than voluntarily slow breathing to calm. It's the single best answer to 'why would breathing slowly change how I feel at all', and it's still an inference from mice. Don't cite it for a human effect.
 
 #### `yasuma2004-rsa`
 
@@ -616,7 +616,7 @@ Yasuma, Fumihiko; Hayano, Jun-ichiro. (2004). *Respiratory Sinus Arrhythmia: Why
 - Verification: crossref-verified | Access: paywalled | Read: full text | evidence tier **D**
 - Backs:
   - heart rate rises on inhalation and falls on exhalation, and this respiratory sinus arrhythmia is the coupling that HRV-based breathing claims rest on
-- Caveat: Review. This is the physiological fact underneath every 'longer exhale calms you' claim in this corpus, which is why the claim is so intuitive and why meehan2024-longer-exhalations failing to find a ratio effect is worth taking seriously: a real beat-to-beat mechanism does not guarantee a measurable session-level outcome.
+- Caveat: Review. This is the physiological fact underneath every 'longer exhale calms you' claim in this corpus, which is why the claim is so intuitive and why meehan2024-longer-exhalations failing to find a ratio effect is worth taking seriously: a real beat-to-beat mechanism doesn't guarantee a measurable session-level outcome.
 
 #### `zelano2016-nasal-respiration-limbic`
 
@@ -626,7 +626,7 @@ Zelano, Christina; Jiang, Heidi; Zhou, Guangyu; Arora, Nikita; Schuele, Stephan;
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **C**
 - Backs:
   - nasal breathing entrains oscillations in human piriform cortex, amygdala and hippocampus, and the effect is specific to the nasal route rather than to breathing as such
-- Caveat: Human intracranial recordings in a small epilepsy-surgery cohort plus behavioural experiments. Carried because it is the reason nose-versus-mouth is a real variable and not folklore. exhale gives no nasal-breathing guidance at all, which is a defensible omission for a wordless overlay but should be a conscious one.
+- Caveat: Human intracranial recordings in a small epilepsy-surgery cohort plus behavioural experiments. Carried because it's the reason nose-versus-mouth is a real variable and not folklore. exhale gives no nasal-breathing guidance at all, which is a defensible omission for a wordless overlay but should be a conscious one.
 
 ---
 
@@ -643,7 +643,7 @@ Fincham, Guy W.; Epel, Elissa; Colasanti, Alessandro; Strauss, Clara; Cavanagh, 
 - Backs:
   - high-ventilation breathwork with retention is a distinct practice from slow-paced breathing and warrants a placebo-controlled evaluation of its own
   - short-term effects reported by participants in the high-ventilation arm included light-headedness, dizziness and tetany, with no lasting adverse effects reported
-- Caveat: Pre-registered as NCT06064474, 200 healthy young adults, blinded against an active comparator; the largest trial of this technique to date. The primary finding is a null: high-ventilation breathwork did not outperform the comparator on stress. It is carried for the distinction it draws and for its tolerability data. It matters to exhale because the sliders can be set to fast, hold-heavy patterns that leave the slow-breathing evidence base entirely, and this is where the documented short-term effects of those patterns are recorded.
+- Caveat: Pre-registered as NCT06064474, 200 healthy young adults, blinded against an active comparator; the largest trial of this technique to date. The primary finding is a null: high-ventilation breathwork didn't outperform the comparator on stress. It's carried for the distinction it draws and for its tolerability data. It matters to exhale because the sliders can be set to fast, hold-heavy patterns that leave the slow-breathing evidence base entirely, and this is where the documented short-term effects of those patterns are recorded.
 
 #### `linardon2020-app-attrition`
 
@@ -664,17 +664,17 @@ Szulczewski, Mikołaj Tytus. (2019). *An Anti-hyperventilation Instruction Decre
 - Verification: crossref-verified | Access: open-access | Read: full text | evidence tier **C**
 - Backs:
   - one sentence of instruction cut the end-tidal CO2 drop during 6-per-minute paced breathing from 5.21 to 2.7 mmHg
-  - hyperventilation symptoms rose 0.63 points on a 7-point scale without the instruction and did not rise significantly with it
+  - hyperventilation symptoms rose 0.63 points on a 7-point scale without the instruction and didn't rise significantly with it
   - the instruction used was to avoid excessively deep breathing and to breathe shallowly and naturally
-- Caveat: Randomised, two groups, n = 46 aged 19-26, single session. This is the mitigation for gap 5 and it is unusually cheap: the problem with slow pacing is depth, not rate, and a single sentence removes most of it. exhale paces rate and says nothing about depth, so this is the one instruction in the corpus with a safety rationale for appearing in the app rather than a persuasive one.
+- Caveat: Randomised, two groups, n = 46 aged 19-26, single session. This is the mitigation for gap 5 and it's unusually cheap: the problem with slow pacing is depth rather than rate, and a single sentence removes most of it. exhale paces rate and says nothing about depth, so this is the one instruction in the corpus with a safety rationale for appearing in the app.
 
 ---
 
 ## Gaps and unsupported choices
 
 Written by hand. This section is the point of the exercise: everything below is a place where exhale
-ships something the literature does not settle, or where the evidence is thinner or more divided
-than a bare citation would suggest. Nothing here is a reason not to use the app. It is a list of
+ships something the literature doesn't settle, or where the evidence is thinner or more divided
+than a bare citation would suggest. Nothing here is a reason not to use the app. It's a list of
 things that are currently believed rather than known.
 
 ### 1. What is actually measured about breathing at a screen
@@ -694,7 +694,7 @@ The relevant literature is old, small, and filed under ergonomics rather than br
   scalene and trapezius.
 
 That diaphragmatic-to-thoracic shift is what people mean by "shallow": chest breathing instead of
-belly breathing. It is a theory of mechanism. No study in this corpus measures chest against
+belly breathing. It's a theory of mechanism. No study in this corpus measures chest against
 diaphragm breathing in screen users.
 
 Two things limit how much the keyboard can be blamed. Both Schleifer studies compare work with
@@ -710,7 +710,7 @@ and lower peak expiratory flow than lighter users, and
 [`deniz2024-forward-head-lung-volumes`](#deniz2024-forward-head-lung-volumes) found forward head
 posture associated with FVC reductions of 0.25 to 0.81 L across 115 participants.
 
-**What the evidence does not support** is "shallow" meaning a reduced *volume of air moved*.
+**What the evidence doesn't support** is "shallow" meaning a reduced *volume of air moved*.
 [`grassmann2016-cognitive-load-respiration`](#grassmann2016-cognitive-load-respiration), 54
 experiments, finds respiratory amplitude roughly stable and minute ventilation **up** under
 cognitive load. Both things can hold at once: more air per minute, on the theory above moved by
@@ -718,14 +718,14 @@ the wrong muscles, from a slumped posture associated with less capacity.
 
 The defensible statement is therefore that during demanding work at a keyboard people breathe
 **faster and slightly over-ventilated**, from a posture associated with reduced lung volumes; the
-shift to chest breathing is the theory of why, not a measurement. That is the claim the README
+shift to chest breathing is the theory of why; no study measures it. That's the claim the README
 makes.
 
-It is not the same claim as "screen apnea" or "email apnea," meaning outright breath-*holding* at a
+It isn't the same claim as "screen apnea" or "email apnea," meaning outright breath-*holding* at a
 screen. That framing traces to unpublished observations by Linda Stone from 2007, tested informally
 on acquaintances with no protocol, no published data and no replication. Nothing found in this pass
 measures breath-holding during screen use, and the over-breathing finding above points the other
-way. The two claims should not be run together.
+way. The two claims shouldn't be run together.
 
 ### 2. The default is inside the tested band, but the band is narrow and resonance frequency is individual
 
@@ -739,31 +739,31 @@ per minute and found all of them raised cardiac vagal activity above spontaneous
 4-7-8 breathing head-to-head, n = 84, and 6 won. So the default is the pace with the most direct
 support of anything exhale could have shipped.
 
-That is a weaker statement than it sounds, for two reasons.
+That's a weaker statement than it sounds, for two reasons.
 
 **The tested band is five values wide.** Nobody has compared 6 against 3, or against 8, in this
-corpus. "Inside the range that has been tested" is a statement about coverage, not about optimality.
+corpus. "Inside the range that has been tested" is a statement about coverage; it says nothing about which rate is best.
 
 **Resonance frequency is individual.** [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback)
 puts the average at about 5.5 breaths per minute and is explicit that it varies from person to
 person; [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6. A single
-shipped number cannot be right for everyone, and finding a person's own resonance frequency takes an
+shipped number can't be right for everyone, and finding a person's own resonance frequency takes an
 assessment protocol and a sensor, neither of which exhale has. The default is a reasonable starting
-point, not a personalised one.
+point rather than a personalised one.
 
 Anyone who already has exhale installed keeps whatever they had: the timing fields carry no
 `#[serde(default)]`, so an existing `settings.toml` is untouched and the change reaches only fresh
 installs and Reset to Defaults. The previous default, `5` / `0` / `10` / `0` at 4 a minute, is still
-offered as a one-click preset. Nobody has measured 4 a minute in this corpus, which is why it is no
+offered as a one-click preset. Nobody has measured 4 a minute in this corpus, which is why it's no
 longer what a new user gets without asking.
 
 ### 3. Box breathing is slower than it looks
 
 `4` / `4` / `4` / `4` is a 16-second cycle, or **3.75 breaths per minute**: *slower* than exhale's
-default and further below the tested band, not closer to it. The holds hide the rate, which is why
+default and further below the tested band. The holds hide the rate, which is why
 the settings panel computes it.
 
-Box breathing has also been tested head-to-head twice and did not win either time:
+Box breathing has also been tested head-to-head twice and didn't win either time:
 
 - [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84, compared square breathing,
   4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 raised HRV **more than
@@ -772,22 +772,22 @@ Box breathing has also been tested head-to-head twice and did not win either tim
 - [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing), a pre-registered RCT, tested box
   breathing, cyclic sighing and cyclic hyperventilation over a month against a
   mindfulness-meditation control. Cyclic sighing, the exhale-emphasising arm, separated from the
-  control on positive affect; box breathing did not. The box arm had 21 people, the arms were not
+  control on positive affect; box breathing didn't. The box arm had 21 people, the arms weren't
   tested against each other, and their daily gains were 1.84 and 1.89 points, so this is a
   difference in reaching significance rather than a demonstrated gap.
 
 The same evidence applies to 4-7-8, sometimes attributed to Andrew Weil: it lost in Marchant, and at
-4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
+4+7+8 = 19 s it's 3.16 breaths per minute, slower still.
 
 The pattern with the best direct support is `5` / `0` / `5` / `0`: 6 breaths per minute, no holds, a
-10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and
-holding the breath is the harder part for a beginner rather than the slow part. It is what exhale
-defaults to. Box breathing remains a reasonable thing to want, and exhale offers it as a preset. It
-is simply not the pattern the evidence points at.
+10-second cycle. It sits inside the tested band, it's the condition that won in Marchant, and
+holding the breath is the harder part for a beginner rather than the slow part. It's what exhale
+defaults to. Box breathing remains a reasonable thing to want, and exhale offers it as a preset. It's
+simply not the pattern the evidence points at.
 
 ### 4. Longer exhale: contested on the heart, thin on how people feel
 
-On HRV, five results, and they do not line up:
+On HRV, five results, and they don't line up:
 
 | Source | n | Design | Result on ratio |
 |---|---|---|---|
@@ -800,9 +800,9 @@ On HRV, five results, and they do not line up:
 Three for, one against, one null inside this corpus.
 [`meehan2024-longer-exhalations`](#meehan2024-longer-exhalations)'s introduction tallies the older
 literature as three further nulls and one result favouring the longer inhale. No mechanism claim
-survives that split, which is why exhale does not make one.
+survives that split, which is why exhale doesn't make one.
 
-On how people reported feeling, the picture is not cleaner. Three studies here measured subjective
+On how people reported feeling, the picture isn't cleaner. Three studies here measured subjective
 state across ratios. [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation), n = 30,
 found more relaxation, stress reduction, mindfulness and positive energy with the longer exhale, and
 slowing the rate alone moved only one of those four.
@@ -811,7 +811,7 @@ relaxation over baseline, with no ratio-specific advantage.
 [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84 and the largest of the three,
 found no meaningful mood change in any condition, including its two 6-per-minute ratios.
 [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) points toward exhale emphasis over a
-month, but its cyclic-sighing arm also adds a double inhale, so the ratio cannot be isolated.
+month, but its cyclic-sighing arm also adds a double inhale, so the ratio can't be isolated.
 
 So a longer exhale is offered as a preference. One study of thirty people found it felt better, a
 larger one found no difference, and rate does most of the work either way: every slow pattern in
@@ -828,12 +828,12 @@ went down. Meanwhile [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2) and
 a keyboard is *already* mildly hypocapnic.
 
 exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while taking
-large breaths moves more air per minute, not less. No study in this corpus tests a slow pacer on an
+large breaths moves more air per minute. No study in this corpus tests a slow pacer on an
 already-hypocapnic screen worker, which is exactly exhale's user.
 
-This is not a safety warning: the effect Marchant reports is mild and was measured in a single
-session. It is recorded because it is the most interesting unanswered question this corpus turned up,
-and because an app that paces breathing should know that pacing rate is not the same as pacing
+This isn't a safety warning: the effect Marchant reports is mild and was measured in a single
+session. It's recorded because it's the most interesting unanswered question this corpus turned up,
+and because an app that paces breathing should know that pacing rate isn't the same as pacing
 volume. The one mitigation with evidence behind it is an instruction rather than a setting:
 [`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
 shows one sentence of anti-hyperventilation guidance cuts the end-tidal CO2 drop from 5.21 mmHg to
@@ -849,7 +849,7 @@ trained at a fixed rate and found relaxation accrued over a week of practice, wh
 practising" rather than "keep slowing down within a session."
 
 Nothing in this review contradicts the tradition either. The literature simply stops below about 5
-breaths a minute; it does not turn around and report worse outcomes there. What subjective evidence
+breaths a minute; it doesn't turn around and report worse outcomes there. What subjective evidence
 exists points the tradition's way:
 [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
 produced more relaxation, stress reduction and positive energy;
@@ -857,15 +857,15 @@ produced more relaxation, stress reduction and positive energy;
 relaxation; and [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of
 practice lowered resting respiratory rate and lengthened breath-holding time. The inverted-U in
 [`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment) is worth
-reading alongside these, but it describes a peak in **HRV amplitude**, not in relaxation or comfort,
-and does not transfer to one.
+reading alongside these, but it describes a peak in **HRV amplitude** rather than in relaxation or comfort,
+and doesn't transfer to one.
 
-The one documented caution is about **depth, not rate**. See gap 5.
+The one documented caution is about **depth rather than rate**. See gap 5.
 
 `drift` is therefore unbounded and **defaults to 0, off**. Off by default is a coverage argument
 rather than a claim of harm: on by default it would move every new user out of the region anyone has
 measured, within minutes, without asking. Unbounded because a 10-second inhale with a 20-second
-exhale is unremarkable in pranayama, and absence of research is not evidence of harm.
+exhale is unremarkable in pranayama, and absence of research isn't evidence of harm.
 
 The stepper moves in 0.1 percentage points, and values below that can be typed; display is capped at
 three decimals, so 0.001 % is the finest value the field round-trips. Compounding is steep enough
@@ -879,7 +879,7 @@ would disagree with the minute figures quoted above, which are anchored to the 1
 ### 7. Randomised timing has no literature behind it either
 
 The four randomisation sliders inject per-phase jitter. Every pacing study in this corpus uses a
-fixed rate; that is what "paced" means. The nearest adjacent literature is
+fixed rate; that's what "paced" means. The nearest adjacent literature is
 [`vlemincx2013-sigh-reset-model`](#vlemincx2013-sigh-reset-model), on natural respiratory
 variability and sighs, which is about spontaneous breathing rather than about deliberately
 destabilising a pacer. Defaults are 0, which is the right default. Treat the sliders as an
@@ -891,41 +891,41 @@ No study in this corpus is about exhale. The closest published analogue is
 [`moraveji2011-peripheral-paced-respiration`](#moraveji2011-peripheral-paced-respiration): a
 translucent animated bar across the screen, running in the periphery during real information work,
 which significantly lowered participants' breathing rate. Its limitation is the one that matters
-here. The reduction happened **while the pacing was active** and did not persist as a lasting change
+here. The reduction happened **while the pacing was active** and didn't persist as a lasting change
 in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as
-it is on.
+it's on.
 
 The strongest design warrant is [`tabor2022-guided-breathing-design`](#tabor2022-guided-breathing-design):
 an expanding and contracting circle at 6 breaths/min matched sensor-driven HRV biofeedback on HRV
-amplitude, with effects appearing in about two minutes and no hardware needed. That is exhale's
-Circle mode, and it is why exhale needs no sensor, no account and no telemetry. It is still n = 28
+amplitude, with effects appearing in about two minutes and no hardware needed. That's exhale's
+Circle mode, and it's why exhale needs no sensor, no account and no telemetry. It's still n = 28
 in one session.
 
 ### 9. Visual-only guidance is the weaker modality for the outcome users care about
 
 [`wongsuphasawat2012-cant-force-calm`](#wongsuphasawat2012-cant-force-calm) found visual pacing
 produced more measured respiratory change than auditory pacing, but auditory was rated more calming.
-exhale is visual-only by design, because it is meant to sit silently in the corner of a working
-screen. That is a real trade-off against felt calm, made deliberately. The source is a two-page
-adjunct paper, so it is a signal rather than a result.
+exhale is visual-only by design, because it's meant to sit silently in the corner of a working
+screen. That's a real trade-off against felt calm, made deliberately. The source is a two-page
+adjunct paper, so it's a signal rather than a result.
 
 ### 10. exhale cites blink research and does nothing about blinking
 
-The blink-rate literature is well supported, and exhale does not act on it. The overlay paces
-breathing; it does not prompt a blink, does not detect blinks, and does not implement anything from
-the digital eye strain literature. The blink finding is context for why screens deserve a nudge, not
+The blink-rate literature is well supported, and exhale doesn't act on it. The overlay paces
+breathing; it doesn't prompt a blink, doesn't detect blinks, and doesn't implement anything from
+the digital eye strain literature. The blink finding is context for why screens deserve a nudge rather than
 a description of what this app does.
 
 Also relevant to exhale's whole genre: [`johnson2023-20-20-20`](#johnson2023-20-20-20) found that
 scheduled 20-second breaks at any of three intervals produced no significant effect on symptoms,
-reading speed or accuracy. A periodic on-screen nudge is not effective merely because it is popular.
+reading speed or accuracy. A periodic on-screen nudge isn't effective merely because it's popular.
 
 ### 11. Both hold sliders default to 0; brief pauses are neutral and longer holds are untested
 
 `post_inhale_hold_duration` and `post_exhale_hold_duration` both default to 0.
 [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the study that manipulates
 respiratory pauses directly: at 6 cycles per minute, adding 0.4 s pauses after inhalation and after
-exhalation did not change RMSSD. [`little2025-a52-breath-method`](#little2025-a52-breath-method)
+exhalation didn't change RMSSD. [`little2025-a52-breath-method`](#little2025-a52-breath-method)
 argues for a 2 s post-exhale hold, and [`marchant2025-square-478-six`](#marchant2025-square-478-six)
 found the two hold-heavy patterns it tested underperformed a no-hold 6 bpm pace. Brief pauses are
 neutral and longer holds are untested at exhale's rates, so 0 is a defensible default.
@@ -938,7 +938,7 @@ keep it running, is unmeasured and unmeasurable here.
 [`linardon2020-app-attrition`](#linardon2020-app-attrition) is the reality check: dropout and
 non-adherence dominate outcomes for app-delivered interventions even where efficacy trials are
 positive. Every effect size in this corpus was measured in a supervised session with a compliant
-participant. That is not the same population as someone who installed a menu-bar app in March.
+participant. That's not the same population as someone who installed a menu-bar app in March.
 
 ### 13. Adverse-event reporting in this field is thin
 
@@ -951,18 +951,18 @@ high-ventilation literature ([`fincham2024-high-ventilation-rct`](#fincham2024-h
 where transient tetany, light-headedness and distress are documented. This is the basis for the
 README's advice to take breaks if intense feelings arise.
 
-### 14. The tradition sources are lineage, not evidence, and are tiered accordingly
+### 14. The tradition sources are lineage rather than evidence, and are tiered accordingly
 
-exhale's four-phase structure, inhale / retention / exhale / retention, is pranayama. It did not come
+exhale's four-phase structure, inhale / retention / exhale / retention, is pranayama. It didn't come
 from psychophysiology, and the corpus says so: [`satyananda1999-apmb`](#satyananda1999-apmb) and
 [`muktibodhananda1998-hatha-yoga-pradipika`](#muktibodhananda1998-hatha-yoga-pradipika) are carried
 at tier **E**, meaning they may be cited for where a practice came from and never for whether it
 works.
 
 This is a deliberate inclusion rather than an endorsement, for two reasons. Retrofitting a 2020s HRV
-citation onto an instruction that is centuries older would be revisionist about the app's actual
+citation onto an instruction that's centuries older would be revisionist about the app's actual
 design history. And the "longer exhale" idea specifically entered modern breathing apps through this
-tradition, not through a laboratory, which is worth knowing when weighing how much of the supporting
+tradition rather than through a laboratory, which matters when weighing how much of the supporting
 literature was designed to test a pre-existing belief rather than to discover something.
 
 Both entries are catalogue records only: checked against Open Library, contents not consulted, and
@@ -976,7 +976,7 @@ In rough order of value per unit effort:
 1. Read the four entries cited from their abstract only, and the full text of
    [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses), whose effect sizes would sharpen
    gaps 4 and 11.
-2. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+2. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That's a
    real, publishable question that exhale is unusually well placed to ask.
 3. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
    this corpus varies the pace *within* a session, so the question is open in both directions.

--- a/docs/citations-notes.md
+++ b/docs/citations-notes.md
@@ -11,9 +11,9 @@ Every claim was re-checked against the abstracts and open full texts on 2026-09-
 > `uv run --no-project scripts/generate-citations.py`. Editing `CITATIONS.md` directly will be
 > overwritten. `--check` fails if the two drift apart.
 
-exhale is a breathing overlay, not a medical device, and nothing here is medical advice. See the
+exhale is a breathing overlay with no medical purpose, and nothing here is medical advice. See the
 [disclaimer](../README.md#disclaimer). This corpus exists so that anyone, including the author, can
-check which of exhale's claims and defaults rest on published evidence and which do not. The
+check which of exhale's claims and defaults rest on published evidence and which don't. The
 [gaps ledger](#gaps-and-unsupported-choices) at the end is the more useful half.
 
 ## How to read this
@@ -25,7 +25,7 @@ true, and nothing about whether the full text was read.
 
 | Status | Meaning |
 |---|---|
-| `crossref-verified` | The DOI resolves in Crossref, and the title, authors, year, journal, volume and pages printed here are the ones Crossref returned, not the ones a search result claimed. |
+| `crossref-verified` | The DOI resolves in Crossref, and the title, authors, year, journal, volume and pages printed here are the ones Crossref returned rather than the ones a search result claimed. |
 | `openlibrary-verified` | No DOI exists because the source is a book. The title, author, publisher, edition and page count printed here were checked against the Open Library record for the stated ISBN. |
 | `pubmed-verified` | No DOI exists, but the article is indexed in PubMed. The title, authors, journal, year, volume and pages were checked against the NCBI E-utilities record for the stated PMID. |
 | `unverified` | No resolvable DOI and no catalogue record. Bibliographic details are inherited from secondary citation and may be wrong. |
@@ -33,8 +33,8 @@ true, and nothing about whether the full text was read.
 Author names are printed as the registry holds them, which is why a few records carry initials
 where others carry full given names.
 
-A verified record can still carry a loud caveat. Verification confirms the *citation*, not the
-*claim*, so each entry also states how deeply the source was read before its claims were written
+A verified record can still carry a loud caveat. Verification confirms the *citation* rather than the
+*claim*, so each entry also states to what depth the source was read before its claims were written
 down: in full, from the abstract only, or as a catalogue record only.
 
 ### Access level
@@ -48,7 +48,7 @@ entry links it as an open copy.
 ### Evidence tier
 
 Applied to sources making a claim about what happens to a human being. Physiological and animal
-mechanism papers are tier D by definition: they explain why something might work, they do not
+mechanism papers are tier D by definition: they explain why something might work, they don't
 establish that it does.
 
 | Tier | Definition | How exhale is allowed to use it |
@@ -56,7 +56,7 @@ establish that it does.
 | A | Systematic review or meta-analysis of controlled trials, or a pre-registered RCT with 200 or more participants | May be cited for an outcome claim |
 | B | Pre-registered or internally replicated controlled experiment, or a systematic review of experiments without meta-analysis | May be cited for an outcome claim, with its scope conditions stated |
 | C | Single controlled experiment, small n, lab-only, or observational work, including systematic reviews of observational studies | Cite as suggestive; never as "research shows" |
-| D | Narrative review, theory, mechanism, or animal work | Cite for *why*, never for *whether* |
+| D | Narrative review, theory, mechanism, or animal work | Cite for mechanism only; it can't establish that a practice works |
 | E | Not peer reviewed, or contradicted by better evidence | May be cited for provenance, meaning where a practice came from. Never for whether it works |
 
 <!-- COUNTS -->
@@ -68,8 +68,8 @@ establish that it does.
 ## Gaps and unsupported choices
 
 Written by hand. This section is the point of the exercise: everything below is a place where exhale
-ships something the literature does not settle, or where the evidence is thinner or more divided
-than a bare citation would suggest. Nothing here is a reason not to use the app. It is a list of
+ships something the literature doesn't settle, or where the evidence is thinner or more divided
+than a bare citation would suggest. Nothing here is a reason not to use the app. It's a list of
 things that are currently believed rather than known.
 
 ### 1. What is actually measured about breathing at a screen
@@ -89,7 +89,7 @@ The relevant literature is old, small, and filed under ergonomics rather than br
   scalene and trapezius.
 
 That diaphragmatic-to-thoracic shift is what people mean by "shallow": chest breathing instead of
-belly breathing. It is a theory of mechanism. No study in this corpus measures chest against
+belly breathing. It's a theory of mechanism. No study in this corpus measures chest against
 diaphragm breathing in screen users.
 
 Two things limit how much the keyboard can be blamed. Both Schleifer studies compare work with
@@ -105,7 +105,7 @@ and lower peak expiratory flow than lighter users, and
 [`deniz2024-forward-head-lung-volumes`](#deniz2024-forward-head-lung-volumes) found forward head
 posture associated with FVC reductions of 0.25 to 0.81 L across 115 participants.
 
-**What the evidence does not support** is "shallow" meaning a reduced *volume of air moved*.
+**What the evidence doesn't support** is "shallow" meaning a reduced *volume of air moved*.
 [`grassmann2016-cognitive-load-respiration`](#grassmann2016-cognitive-load-respiration), 54
 experiments, finds respiratory amplitude roughly stable and minute ventilation **up** under
 cognitive load. Both things can hold at once: more air per minute, on the theory above moved by
@@ -113,14 +113,14 @@ the wrong muscles, from a slumped posture associated with less capacity.
 
 The defensible statement is therefore that during demanding work at a keyboard people breathe
 **faster and slightly over-ventilated**, from a posture associated with reduced lung volumes; the
-shift to chest breathing is the theory of why, not a measurement. That is the claim the README
+shift to chest breathing is the theory of why; no study measures it. That's the claim the README
 makes.
 
-It is not the same claim as "screen apnea" or "email apnea," meaning outright breath-*holding* at a
+It isn't the same claim as "screen apnea" or "email apnea," meaning outright breath-*holding* at a
 screen. That framing traces to unpublished observations by Linda Stone from 2007, tested informally
 on acquaintances with no protocol, no published data and no replication. Nothing found in this pass
 measures breath-holding during screen use, and the over-breathing finding above points the other
-way. The two claims should not be run together.
+way. The two claims shouldn't be run together.
 
 ### 2. The default is inside the tested band, but the band is narrow and resonance frequency is individual
 
@@ -134,31 +134,31 @@ per minute and found all of them raised cardiac vagal activity above spontaneous
 4-7-8 breathing head-to-head, n = 84, and 6 won. So the default is the pace with the most direct
 support of anything exhale could have shipped.
 
-That is a weaker statement than it sounds, for two reasons.
+That's a weaker statement than it sounds, for two reasons.
 
 **The tested band is five values wide.** Nobody has compared 6 against 3, or against 8, in this
-corpus. "Inside the range that has been tested" is a statement about coverage, not about optimality.
+corpus. "Inside the range that has been tested" is a statement about coverage; it says nothing about which rate is best.
 
 **Resonance frequency is individual.** [`lehrer2014-hrv-biofeedback`](#lehrer2014-hrv-biofeedback)
 puts the average at about 5.5 breaths per minute and is explicit that it varies from person to
 person; [`lin2014-equal-ratio-hrv`](#lin2014-equal-ratio-hrv) found 5.5 outperformed 6. A single
-shipped number cannot be right for everyone, and finding a person's own resonance frequency takes an
+shipped number can't be right for everyone, and finding a person's own resonance frequency takes an
 assessment protocol and a sensor, neither of which exhale has. The default is a reasonable starting
-point, not a personalised one.
+point rather than a personalised one.
 
 Anyone who already has exhale installed keeps whatever they had: the timing fields carry no
 `#[serde(default)]`, so an existing `settings.toml` is untouched and the change reaches only fresh
 installs and Reset to Defaults. The previous default, `5` / `0` / `10` / `0` at 4 a minute, is still
-offered as a one-click preset. Nobody has measured 4 a minute in this corpus, which is why it is no
+offered as a one-click preset. Nobody has measured 4 a minute in this corpus, which is why it's no
 longer what a new user gets without asking.
 
 ### 3. Box breathing is slower than it looks
 
 `4` / `4` / `4` / `4` is a 16-second cycle, or **3.75 breaths per minute**: *slower* than exhale's
-default and further below the tested band, not closer to it. The holds hide the rate, which is why
+default and further below the tested band. The holds hide the rate, which is why
 the settings panel computes it.
 
-Box breathing has also been tested head-to-head twice and did not win either time:
+Box breathing has also been tested head-to-head twice and didn't win either time:
 
 - [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84, compared square breathing,
   4-7-8 breathing, and 6 breaths per minute at two ratios. Breathing at 6 raised HRV **more than
@@ -167,22 +167,22 @@ Box breathing has also been tested head-to-head twice and did not win either tim
 - [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing), a pre-registered RCT, tested box
   breathing, cyclic sighing and cyclic hyperventilation over a month against a
   mindfulness-meditation control. Cyclic sighing, the exhale-emphasising arm, separated from the
-  control on positive affect; box breathing did not. The box arm had 21 people, the arms were not
+  control on positive affect; box breathing didn't. The box arm had 21 people, the arms weren't
   tested against each other, and their daily gains were 1.84 and 1.89 points, so this is a
   difference in reaching significance rather than a demonstrated gap.
 
 The same evidence applies to 4-7-8, sometimes attributed to Andrew Weil: it lost in Marchant, and at
-4+7+8 = 19 s it is 3.16 breaths per minute, slower still.
+4+7+8 = 19 s it's 3.16 breaths per minute, slower still.
 
 The pattern with the best direct support is `5` / `0` / `5` / `0`: 6 breaths per minute, no holds, a
-10-second cycle. It sits inside the tested band, it is the condition that won in Marchant, and
-holding the breath is the harder part for a beginner rather than the slow part. It is what exhale
-defaults to. Box breathing remains a reasonable thing to want, and exhale offers it as a preset. It
-is simply not the pattern the evidence points at.
+10-second cycle. It sits inside the tested band, it's the condition that won in Marchant, and
+holding the breath is the harder part for a beginner rather than the slow part. It's what exhale
+defaults to. Box breathing remains a reasonable thing to want, and exhale offers it as a preset. It's
+simply not the pattern the evidence points at.
 
 ### 4. Longer exhale: contested on the heart, thin on how people feel
 
-On HRV, five results, and they do not line up:
+On HRV, five results, and they don't line up:
 
 | Source | n | Design | Result on ratio |
 |---|---|---|---|
@@ -195,9 +195,9 @@ On HRV, five results, and they do not line up:
 Three for, one against, one null inside this corpus.
 [`meehan2024-longer-exhalations`](#meehan2024-longer-exhalations)'s introduction tallies the older
 literature as three further nulls and one result favouring the longer inhale. No mechanism claim
-survives that split, which is why exhale does not make one.
+survives that split, which is why exhale doesn't make one.
 
-On how people reported feeling, the picture is not cleaner. Three studies here measured subjective
+On how people reported feeling, the picture isn't cleaner. Three studies here measured subjective
 state across ratios. [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation), n = 30,
 found more relaxation, stress reduction, mindfulness and positive energy with the longer exhale, and
 slowing the rate alone moved only one of those four.
@@ -206,7 +206,7 @@ relaxation over baseline, with no ratio-specific advantage.
 [`marchant2025-square-478-six`](#marchant2025-square-478-six), n = 84 and the largest of the three,
 found no meaningful mood change in any condition, including its two 6-per-minute ratios.
 [`balban2023-cyclic-sighing`](#balban2023-cyclic-sighing) points toward exhale emphasis over a
-month, but its cyclic-sighing arm also adds a double inhale, so the ratio cannot be isolated.
+month, but its cyclic-sighing arm also adds a double inhale, so the ratio can't be isolated.
 
 So a longer exhale is offered as a preference. One study of thirty people found it felt better, a
 larger one found no difference, and rate does most of the work either way: every slow pattern in
@@ -223,12 +223,12 @@ went down. Meanwhile [`schleifer1994-vdt-petco2`](#schleifer1994-vdt-petco2) and
 a keyboard is *already* mildly hypocapnic.
 
 exhale paces rate and says nothing about depth. A user who slows to 6 breaths per minute while taking
-large breaths moves more air per minute, not less. No study in this corpus tests a slow pacer on an
+large breaths moves more air per minute. No study in this corpus tests a slow pacer on an
 already-hypocapnic screen worker, which is exactly exhale's user.
 
-This is not a safety warning: the effect Marchant reports is mild and was measured in a single
-session. It is recorded because it is the most interesting unanswered question this corpus turned up,
-and because an app that paces breathing should know that pacing rate is not the same as pacing
+This isn't a safety warning: the effect Marchant reports is mild and was measured in a single
+session. It's recorded because it's the most interesting unanswered question this corpus turned up,
+and because an app that paces breathing should know that pacing rate isn't the same as pacing
 volume. The one mitigation with evidence behind it is an instruction rather than a setting:
 [`szulczewski2019-antihyperventilation-instruction`](#szulczewski2019-antihyperventilation-instruction)
 shows one sentence of anti-hyperventilation guidance cuts the end-tidal CO2 drop from 5.21 mmHg to
@@ -244,7 +244,7 @@ trained at a fixed rate and found relaxation accrued over a week of practice, wh
 practising" rather than "keep slowing down within a session."
 
 Nothing in this review contradicts the tradition either. The literature simply stops below about 5
-breaths a minute; it does not turn around and report worse outcomes there. What subjective evidence
+breaths a minute; it doesn't turn around and report worse outcomes there. What subjective evidence
 exists points the tradition's way:
 [`vandiest2014-ie-ratio-relaxation`](#vandiest2014-ie-ratio-relaxation) found the longer exhale
 produced more relaxation, stress reduction and positive energy;
@@ -252,15 +252,15 @@ produced more relaxation, stress reduction and positive energy;
 relaxation; and [`joshi1992-pranayam-training`](#joshi1992-pranayam-training) found six weeks of
 practice lowered resting respiratory rate and lengthened breath-holding time. The inverted-U in
 [`shaffer2020-resonance-frequency-assessment`](#shaffer2020-resonance-frequency-assessment) is worth
-reading alongside these, but it describes a peak in **HRV amplitude**, not in relaxation or comfort,
-and does not transfer to one.
+reading alongside these, but it describes a peak in **HRV amplitude** rather than in relaxation or comfort,
+and doesn't transfer to one.
 
-The one documented caution is about **depth, not rate**. See gap 5.
+The one documented caution is about **depth rather than rate**. See gap 5.
 
 `drift` is therefore unbounded and **defaults to 0, off**. Off by default is a coverage argument
 rather than a claim of harm: on by default it would move every new user out of the region anyone has
 measured, within minutes, without asking. Unbounded because a 10-second inhale with a 20-second
-exhale is unremarkable in pranayama, and absence of research is not evidence of harm.
+exhale is unremarkable in pranayama, and absence of research isn't evidence of harm.
 
 The stepper moves in 0.1 percentage points, and values below that can be typed; display is capped at
 three decimals, so 0.001 % is the finest value the field round-trips. Compounding is steep enough
@@ -274,7 +274,7 @@ would disagree with the minute figures quoted above, which are anchored to the 1
 ### 7. Randomised timing has no literature behind it either
 
 The four randomisation sliders inject per-phase jitter. Every pacing study in this corpus uses a
-fixed rate; that is what "paced" means. The nearest adjacent literature is
+fixed rate; that's what "paced" means. The nearest adjacent literature is
 [`vlemincx2013-sigh-reset-model`](#vlemincx2013-sigh-reset-model), on natural respiratory
 variability and sighs, which is about spontaneous breathing rather than about deliberately
 destabilising a pacer. Defaults are 0, which is the right default. Treat the sliders as an
@@ -286,41 +286,41 @@ No study in this corpus is about exhale. The closest published analogue is
 [`moraveji2011-peripheral-paced-respiration`](#moraveji2011-peripheral-paced-respiration): a
 translucent animated bar across the screen, running in the periphery during real information work,
 which significantly lowered participants' breathing rate. Its limitation is the one that matters
-here. The reduction happened **while the pacing was active** and did not persist as a lasting change
+here. The reduction happened **while the pacing was active** and didn't persist as a lasting change
 in respiratory pattern. An always-on overlay should be understood as an effect that lasts as long as
-it is on.
+it's on.
 
 The strongest design warrant is [`tabor2022-guided-breathing-design`](#tabor2022-guided-breathing-design):
 an expanding and contracting circle at 6 breaths/min matched sensor-driven HRV biofeedback on HRV
-amplitude, with effects appearing in about two minutes and no hardware needed. That is exhale's
-Circle mode, and it is why exhale needs no sensor, no account and no telemetry. It is still n = 28
+amplitude, with effects appearing in about two minutes and no hardware needed. That's exhale's
+Circle mode, and it's why exhale needs no sensor, no account and no telemetry. It's still n = 28
 in one session.
 
 ### 9. Visual-only guidance is the weaker modality for the outcome users care about
 
 [`wongsuphasawat2012-cant-force-calm`](#wongsuphasawat2012-cant-force-calm) found visual pacing
 produced more measured respiratory change than auditory pacing, but auditory was rated more calming.
-exhale is visual-only by design, because it is meant to sit silently in the corner of a working
-screen. That is a real trade-off against felt calm, made deliberately. The source is a two-page
-adjunct paper, so it is a signal rather than a result.
+exhale is visual-only by design, because it's meant to sit silently in the corner of a working
+screen. That's a real trade-off against felt calm, made deliberately. The source is a two-page
+adjunct paper, so it's a signal rather than a result.
 
 ### 10. exhale cites blink research and does nothing about blinking
 
-The blink-rate literature is well supported, and exhale does not act on it. The overlay paces
-breathing; it does not prompt a blink, does not detect blinks, and does not implement anything from
-the digital eye strain literature. The blink finding is context for why screens deserve a nudge, not
+The blink-rate literature is well supported, and exhale doesn't act on it. The overlay paces
+breathing; it doesn't prompt a blink, doesn't detect blinks, and doesn't implement anything from
+the digital eye strain literature. The blink finding is context for why screens deserve a nudge rather than
 a description of what this app does.
 
 Also relevant to exhale's whole genre: [`johnson2023-20-20-20`](#johnson2023-20-20-20) found that
 scheduled 20-second breaks at any of three intervals produced no significant effect on symptoms,
-reading speed or accuracy. A periodic on-screen nudge is not effective merely because it is popular.
+reading speed or accuracy. A periodic on-screen nudge isn't effective merely because it's popular.
 
 ### 11. Both hold sliders default to 0; brief pauses are neutral and longer holds are untested
 
 `post_inhale_hold_duration` and `post_exhale_hold_duration` both default to 0.
 [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses) is the study that manipulates
 respiratory pauses directly: at 6 cycles per minute, adding 0.4 s pauses after inhalation and after
-exhalation did not change RMSSD. [`little2025-a52-breath-method`](#little2025-a52-breath-method)
+exhalation didn't change RMSSD. [`little2025-a52-breath-method`](#little2025-a52-breath-method)
 argues for a 2 s post-exhale hold, and [`marchant2025-square-478-six`](#marchant2025-square-478-six)
 found the two hold-heavy patterns it tested underperformed a no-hold 6 bpm pace. Brief pauses are
 neutral and longer holds are untested at exhale's rates, so 0 is a defensible default.
@@ -333,7 +333,7 @@ keep it running, is unmeasured and unmeasurable here.
 [`linardon2020-app-attrition`](#linardon2020-app-attrition) is the reality check: dropout and
 non-adherence dominate outcomes for app-delivered interventions even where efficacy trials are
 positive. Every effect size in this corpus was measured in a supervised session with a compliant
-participant. That is not the same population as someone who installed a menu-bar app in March.
+participant. That's not the same population as someone who installed a menu-bar app in March.
 
 ### 13. Adverse-event reporting in this field is thin
 
@@ -346,18 +346,18 @@ high-ventilation literature ([`fincham2024-high-ventilation-rct`](#fincham2024-h
 where transient tetany, light-headedness and distress are documented. This is the basis for the
 README's advice to take breaks if intense feelings arise.
 
-### 14. The tradition sources are lineage, not evidence, and are tiered accordingly
+### 14. The tradition sources are lineage rather than evidence, and are tiered accordingly
 
-exhale's four-phase structure, inhale / retention / exhale / retention, is pranayama. It did not come
+exhale's four-phase structure, inhale / retention / exhale / retention, is pranayama. It didn't come
 from psychophysiology, and the corpus says so: [`satyananda1999-apmb`](#satyananda1999-apmb) and
 [`muktibodhananda1998-hatha-yoga-pradipika`](#muktibodhananda1998-hatha-yoga-pradipika) are carried
 at tier **E**, meaning they may be cited for where a practice came from and never for whether it
 works.
 
 This is a deliberate inclusion rather than an endorsement, for two reasons. Retrofitting a 2020s HRV
-citation onto an instruction that is centuries older would be revisionist about the app's actual
+citation onto an instruction that's centuries older would be revisionist about the app's actual
 design history. And the "longer exhale" idea specifically entered modern breathing apps through this
-tradition, not through a laboratory, which is worth knowing when weighing how much of the supporting
+tradition rather than through a laboratory, which matters when weighing how much of the supporting
 literature was designed to test a pre-existing belief rather than to discover something.
 
 Both entries are catalogue records only: checked against Open Library, contents not consulted, and
@@ -371,7 +371,7 @@ In rough order of value per unit effort:
 1. Read the four entries cited from their abstract only, and the full text of
    [`laborde2021-ie-ratio-pauses`](#laborde2021-ie-ratio-pauses), whose effect sizes would sharpen
    gaps 4 and 11.
-2. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That is a
+2. Nobody has tested a slow visual pacer on an already-hypocapnic screen worker (gap 5). That's a
    real, publishable question that exhale is unusually well placed to ask.
 3. Settle whether graded extension does anything, which would put a floor under gap 6. No study in
    this corpus varies the pace *within* a session, so the question is open in both directions.

--- a/docs/citations.html
+++ b/docs/citations.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>exhale citation corpus</title>
-<meta name="description" content="Every claim and default in exhale, with the published evidence behind it and a ledger of what the evidence does not support.">
+<meta name="description" content="Every claim and default in exhale, with the published evidence behind it and a ledger of what the evidence doesn't support.">
 <meta name="color-scheme" content="light dark">
 <link rel="canonical" href="https://peterklingelhofer.github.io/exhale/citations.html">
 <!-- Inline so the page stays one file and the browser stops asking for /favicon.ico -->
@@ -67,9 +67,9 @@
   .skip:focus { left: 0; }
 
   /* The deep-linked heading is focused to move the reading position,
-     not because it is a control.  A full-width ring across a section
-     title reads as an error state to a reader who did not put it
-     there, and the heading is not reachable by Tab, so the scroll
+     not because it's a control.  A full-width ring across a section
+     title reads as an error state to a reader who didn't put it
+     there, and the heading isn't reachable by Tab, so the scroll
      itself is the indication */
   #doc [tabindex="-1"]:focus { outline: none; }
 
@@ -279,7 +279,7 @@
     <noscript>
       <div class="status">
         <h2>This page needs JavaScript</h2>
-        <p>It reads the corpus straight from the repository so it is never out of date with the
+        <p>It reads the corpus straight from the repository so it's never out of date with the
         published evidence. Without scripting, read it on
         <a href="https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md">GitHub</a>
         instead.</p>
@@ -290,7 +290,7 @@
       Rendered live from
       <a href="https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md"><code>docs/CITATIONS.md</code></a>
       on the <code>main</code> branch, so a correction or a retraction reaches this page without a
-      release. exhale is a breathing overlay, not a medical device, and nothing here is medical advice.
+      release. exhale is a breathing overlay; it isn't a medical device, and nothing here is medical advice.
     </p>
   </div>
 </div>
@@ -329,7 +329,7 @@
     status.hidden = false;
     status.innerHTML = "";
     var h = document.createElement("h2");
-    h.textContent = "The corpus could not be loaded";
+    h.textContent = "The corpus couldn't be loaded";
     var p1 = document.createElement("p");
     p1.textContent = message;
     var p2 = document.createElement("p");
@@ -439,7 +439,7 @@
   }
 
   if (!window.marked || !window.DOMPurify) {
-    fail("The rendering libraries did not load. A network filter or an offline connection will do this.");
+    fail("The rendering libraries didn't load. A network filter or an offline connection will do this.");
     return;
   }
 
@@ -461,9 +461,9 @@
       if (h1) document.title = h1.textContent + " · exhale";
 
       // The contents rail is an enhancement, and the deep link into
-      // the gaps ledger is not.  Building the rail last, in its own
-      // guard, keeps a failure here from reporting a corpus that is
-      // sitting right there rendered as one that could not be loaded
+      // the gaps ledger isn't.  Building the rail last, in its own
+      // guard, keeps a failure here from reporting a corpus that's
+      // sitting right there rendered as one that couldn't be loaded
       try { buildToc(); } catch (err) { console.error("contents rail: " + err.message); }
     })
     .catch(function (err) {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,8 +20,8 @@ winit = { path = "../vendor/winit" }
 # declaration of the private `_CGSSetWindowBackgroundBlurRadius`,
 # which Apple's App Store review flags as a non-public API and
 # rejects the submission. LTO=true (fat) strips unreachable fns
-# across the whole crate graph and removes the symbol.
-# Build time ~2-3x longer for release, binary slightly smaller
+# across the whole crate graph and removes the symbol. Build time
+# ~2-3x longer for release, binary slightly smaller
 lto         = true
 codegen-units = 1
 strip       = "symbols"
@@ -40,7 +40,7 @@ wgpu       = "22"
 winit      = "0.30"
 pollster   = "0.3"
 
-# UI — egui 0.29 uses winit ^0.30 and wgpu ^0.20, matching our stack exactly.
+# UI: egui 0.29 uses winit ^0.30 and wgpu ^0.20, matching our stack exactly
 egui        = "0.29"
 egui-winit  = "0.29"
 egui-wgpu   = { version = "0.29", features = ["winit"] }

--- a/rust/crates/exhale-app/Cargo.toml
+++ b/rust/crates/exhale-app/Cargo.toml
@@ -11,7 +11,7 @@ homepage    = "https://github.com/peterklingelhofer/exhale"
 # ── Debian package metadata (used by `cargo deb`) ─────────────────────────────
 # Runtime dependency list is the conservative superset covering Ubuntu 20.04+
 # (`focal`, `jammy`, `noble`).  `libayatana-appindicator3-1` is the modern
-# tray-icon backend; distros that still ship libappindicator3-1 symlink it.
+# tray-icon backend; distros that still ship libappindicator3-1 symlink it
 [package.metadata.deb]
 maintainer          = "Peter Klingelhofer <peterklingelhofer@gmail.com>"
 copyright           = "2023-2026, Peter Klingelhofer"
@@ -39,7 +39,7 @@ path = "src/main.rs"
 # `global-hotkeys` wires up the Carbon `RegisterEventHotKey`-backed
 # `global-hotkey` crate.  Disabled for the Mac App Store build
 # (`--no-default-features`) as a hedge in case App Review flags the
-# behaviour — it's trivial to re-enable per-target later.
+# behaviour: it's trivial to re-enable per-target later
 default        = ["global-hotkeys"]
 global-hotkeys = ["dep:global-hotkey"]
 
@@ -60,12 +60,12 @@ global-hotkey = { workspace = true, optional = true }
 directories   = "5"
 
 [target.'cfg(unix)'.dependencies]
-# `flock(2)` for the single-instance file lock — sandbox-safe on
-# macOS App Sandbox, Flatpak, Snap, and AppImage.
+# `flock(2)` for the single-instance file lock: sandbox-safe on
+# macOS App Sandbox, Flatpak, Snap, and AppImage
 libc          = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# macOS uses native `UNUserNotifications` via objc2 — `notify-rust` is only
+# macOS uses native `UNUserNotifications` via objc2; `notify-rust` is only
 # pulled in on other platforms.  objc2 + the per-framework binding crates
 # give us typed message dispatch (selector typos and arg-type mismatches
 # become compile errors) and `Retained<T>` retain/release safety, replacing
@@ -105,7 +105,7 @@ block2                   = "0.6"
 # binary has a proper icon in File Explorer / Start menu / Alt-Tab.
 # Plain (host-conditional) build-dependencies so the workflow can
 # build for Windows from any host that has the resource compiler
-# (the GitHub Actions `windows-latest` runner has it).
+# (the GitHub Actions `windows-latest` runner has it)
 [build-dependencies]
 image       = { version = "0.25", default-features = false, features = ["png"] }
 ico         = "0.4"
@@ -119,7 +119,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_UI_Shell",
     "Win32_Graphics_Dwm",
     "Win32_Graphics_Gdi",
-    # `LockFileEx` for the single-instance file-lock guard.
+    # `LockFileEx` for the single-instance file-lock guard
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
 ] }
@@ -128,8 +128,8 @@ windows-sys = { version = "0.59", features = [
 notify-rust = { workspace = true }
 # X11 click-through + shape input region for Linux overlay windows.
 # x11-dl loads libX11 / libXfixes at runtime, so the Rust build doesn't need
-# X11 development headers installed — only the runtime libraries (which are
-# pre-installed on every X11 desktop distro).
+# X11 development headers installed; only the runtime libraries (which are
+# pre-installed on every X11 desktop distro)
 x11-dl = "2.21"
 # `tray-icon` on Linux is built on top of GTK + libayatana-appindicator;
 # GTK has to be initialised before any menu item is constructed and its
@@ -137,5 +137,5 @@ x11-dl = "2.21"
 # at startup and run a non-blocking iteration in `about_to_wait` so the
 # tray works without spinning up a second OS thread.  Same major version
 # `tray-icon` 0.19 transitively depends on, to avoid a duplicate gtk in
-# the dep graph.
+# the dep graph
 gtk = "0.18"

--- a/rust/crates/exhale-app/build.rs
+++ b/rust/crates/exhale-app/build.rs
@@ -2,18 +2,18 @@
 // `exhaleColorGradient512.png` icon to a multi-resolution `.ico` and
 // embeds it as a resource in the compiled `.exe` so Explorer / Start
 // menu / Alt-Tab show the proper exhale icon instead of the generic
-// Rust executable placeholder.
+// Rust executable placeholder
 //
 // On non-Windows targets this build script is a no-op.  On Windows
 // targets, if the host machine lacks a resource compiler (`rc.exe` /
-// `windres`), the build still succeeds — the `.exe` just falls back
+// `windres`), the build still succeeds; the `.exe` just falls back
 // to the generic icon and we emit a `cargo:warning` so the cause is
-// visible in build logs.
+// visible in build logs
 
 fn main() {
     // `CARGO_CFG_TARGET_OS` is set by Cargo for build scripts, telling
     // us what OS we're compiling FOR (the host OS comes from
-    // `std::env::consts::OS`, which is different).
+    // `std::env::consts::OS`, which is different)
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     let src_png = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -39,33 +39,33 @@ fn main() {
     // and the compositor otherwise falls back to a generic icon
     let rgba_path = std::path::PathBuf::from(&out_dir).join("icon.rgba");
     if let Err(e) = png_to_rgba_256(&src_png, &rgba_path) {
-        println!("cargo:warning=icon PNG→RGBA conversion failed: {e}; \
+        println!("cargo:warning=icon PNG -> RGBA conversion failed: {e}; \
                   binary windows will use the platform default icon");
     }
 
     // ── Windows: also produce a multi-resolution .ico and embed it
     // as an .exe resource so Explorer / Start / Alt-Tab pick it up
-    // (separate from the window icon — Windows uses BOTH)
+    // (separate from the window icon: Windows uses BOTH)
     if target_os != "windows" { return; }
     let ico_path = std::path::PathBuf::from(&out_dir).join("exhale.ico");
     if let Err(e) = png_to_ico(&src_png, &ico_path) {
-        println!("cargo:warning=PNG→ICO conversion failed: {e}; skipping embed");
+        println!("cargo:warning=PNG -> ICO conversion failed: {e}; skipping embed");
         return;
     }
     let mut res = winresource::WindowsResource::new();
     res.set_icon(ico_path.to_str().expect("ICO path is UTF-8"));
     if let Err(e) = res.compile() {
         // Most common cause: building from a non-Windows host without
-        // `windres` (from `mingw-w64`) installed.  Not fatal — the
+        // `windres` (from `mingw-w64`) installed.  Not fatal: the
         // `.exe` just gets the generic icon.  CI's Windows runner
-        // ships RC tools by default and always succeeds here.
+        // ships RC tools by default and always succeeds here
         println!("cargo:warning=icon resource embed failed: {e}; \
                   binary will have the default Windows icon");
     }
 }
 
 /// Decode the source PNG, resize to 256×256, write raw RGBA bytes
-/// (no headers — just `w*h*4` bytes) for the runtime to load.
+/// (no headers, just `w*h*4` bytes) for the runtime to load
 fn png_to_rgba_256(
     src: &std::path::Path,
     dst: &std::path::Path,
@@ -84,10 +84,10 @@ fn png_to_ico(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let src_img = image::open(src)?.to_rgba8();
     let mut icon_dir = ico::IconDir::new(ico::ResourceType::Icon);
-    // Standard Windows icon sizes — Explorer / Start use whichever
+    // Standard Windows icon sizes: Explorer / Start use whichever
     // one matches the display DPI best.  256 is the modern HiDPI
     // tile; 16/32/48 are the small/medium/large taskbar/notification
-    // sizes; 64/128 cover intermediate scales.
+    // sizes; 64/128 cover intermediate scales
     for size in [16u32, 32, 48, 64, 128, 256] {
         let resized = image::imageops::resize(
             &src_img, size, size, image::imageops::FilterType::Lanczos3,

--- a/rust/crates/exhale-app/src/app_icon.rs
+++ b/rust/crates/exhale-app/src/app_icon.rs
@@ -1,23 +1,23 @@
-//! App-icon embedding for window managers / dock / Alt-Tab / taskbar.
+//! App-icon embedding for window managers / dock / Alt-Tab / taskbar
 //!
 //! The build script (`build.rs`) pre-decodes the shared
 //! `exhaleColorGradient512.png` to a 256×256 RGBA buffer at compile
 //! time and writes it to `$OUT_DIR/icon.rgba`.  We `include_bytes!`
 //! that here so no PNG decoder is needed at run time and the icon
 //! travels inside the binary itself.  No external `.desktop` file is
-//! required for the icon to appear on Linux Wayland / X11 — the
-//! compositor uses the icon attached to the window directly.
+//! required for the icon to appear on Linux Wayland / X11: the
+//! compositor uses the icon attached to the window directly
 //!
 //! Windows has a separate path (the `.exe` resource set by `build.rs`)
 //! for the file-explorer / Start-menu / Alt-Tab icon, but we set the
 //! window icon here too so per-window UI (Alt-Tab tooltip on Win11,
-//! the title-bar app icon if shown) matches.
+//! the title-bar app icon if shown) matches
 //!
 //! macOS ignores window icons (`NSWindow` doesn't have a per-window
-//! icon concept) — the Dock / Cmd-Tab icon comes from the .app
+//! icon concept); the Dock / Cmd-Tab icon comes from the .app
 //! bundle's `Info.plist` + `.icns` instead.  Calling
-//! `WindowAttributes::with_window_icon` on macOS is a no-op, not an
-//! error.
+//! `WindowAttributes::with_window_icon` on macOS is a no-op that
+//! succeeds silently
 
 const ICON_RGBA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/icon.rgba"));
 const ICON_W: u32 = 256;
@@ -27,7 +27,7 @@ const ICON_H: u32 = 256;
 /// only if the build script failed to produce a valid 256×256 buffer
 /// (e.g. the source PNG was missing or unreadable); the binary still
 /// runs in that case, the windows just fall back to the platform's
-/// default icon.
+/// default icon
 pub(crate) fn window_icon() -> Option<winit::window::Icon> {
     if ICON_RGBA.len() != (ICON_W * ICON_H * 4) as usize {
         return None;

--- a/rust/crates/exhale-app/src/bootstrap.rs
+++ b/rust/crates/exhale-app/src/bootstrap.rs
@@ -1,5 +1,5 @@
 //! Process-bootstrap plumbing: logger setup, panic hook, single-instance
-//! guard, log-path picker.
+//! guard, log-path picker
 //!
 //! Nothing here references `App` or `AppEvent` directly: everything is
 //! either a one-shot side effect (logger, panic hook) or a pure
@@ -14,23 +14,23 @@ use winit::event_loop::EventLoopProxy;
 use crate::AppEvent;
 
 /// Outcome of [`single_instance_guard`].  See enum variants for
-/// platform behaviour.
+/// platform behaviour
 pub(crate) enum InstanceGuard {
     /// First instance; holds the lockfile alive for the process
     /// lifetime.  Releasing the file (drop) releases the OS-level
-    /// advisory lock so a subsequent launch can take over.
+    /// advisory lock so a subsequent launch can take over
     First(std::fs::File),
     /// Another instance is already running.  On macOS we asked the
     /// running instance to activate (which fires its
     /// `applicationShouldHandleReopen:` handler and shows the
     /// settings window); on Windows/Linux the OS-level dock/taskbar
     /// re-activation does the same thing when the user clicks the
-    /// existing app icon.  This process should exit immediately.
+    /// existing app icon.  This process should exit immediately
     Secondary,
-    /// Couldn't open the lockfile at all (permissions, full disk).
-    /// Proceed without the guard rather than refuse to start — the
+    /// Couldn't open the lockfile at all (permissions, full disk);
+    /// proceed without the guard rather than refuse to start: the
     /// duplicate-instance behaviour is degraded but the app still
-    /// runs.
+    /// runs
     Unavailable,
 }
 
@@ -73,8 +73,8 @@ pub(crate) fn single_instance_guard(_proxy: &EventLoopProxy<AppEvent>) -> Instan
     match try_lock_exclusive(&file) {
         Ok(true) => {
             // First instance.  Record our PID for debugging /
-            // future bring-to-front protocols, but don't rely on it
-            // — the lock itself is the source of truth.
+            // future bring-to-front protocols, but don't rely on it: the
+            // lock itself is the source of truth
             use std::io::Write;
             let _ = file.try_clone()
                 .and_then(|mut f| f.write_all(format!("{}\n", std::process::id()).as_bytes()));
@@ -82,13 +82,13 @@ pub(crate) fn single_instance_guard(_proxy: &EventLoopProxy<AppEvent>) -> Instan
         }
         Ok(false) => {
             // Lock is held by another running instance.  On macOS, ask
-            // the system to activate the existing app — that fires our
+            // the system to activate the existing app: that fires our
             // AppleEvent reopen handler which sets `DOCK_REOPEN`, which
             // the running event loop drains and dispatches as
             // `AppEvent::ShowSettings`.  On other platforms, OS-level
             // launcher behaviour (taskbar pin re-click, GNOME
             // Activities, etc.) brings the existing window to focus;
-            // we just exit.
+            // we just exit
             //
             // Print to stderr in addition to the log file so a
             // `cargo run --release` invocation surfaces "you're
@@ -96,7 +96,7 @@ pub(crate) fn single_instance_guard(_proxy: &EventLoopProxy<AppEvent>) -> Instan
             // still alive" instead of silently bringing the old
             // window forward.  Without this it's easy to mistake the
             // existing app reappearing for a successful relaunch of
-            // freshly-built code.
+            // freshly-built code
             eprintln!(
                 "exhale: another instance is already running; \
                  activating it and exiting.  Quit the running app first \
@@ -124,14 +124,14 @@ pub(crate) fn single_instance_guard(_proxy: &EventLoopProxy<AppEvent>) -> Instan
 /// Resolve the path used for the single-instance lock.  Picks a
 /// per-user location that's writable under every platform's default
 /// sandbox configuration:
-///   * **macOS** — `<config_dir>/exhale.lock` where `config_dir` is
+///   * **macOS**: `<config_dir>/exhale.lock` where `config_dir` is
 ///     `~/Library/Application Support/com.peterklingelhofer.exhale`
-///     (sandboxed apps get this auto-mapped to the container).
-///   * **Windows** — `%LOCALAPPDATA%\peterklingelhofer\exhale\exhale.lock`
-///     via the `directories` crate, same as `settings.toml`.
-///   * **Linux** — `$XDG_RUNTIME_DIR/exhale.lock` if set, else
+///     (sandboxed apps get this auto-mapped to the container)
+///   * **Windows**: `%LOCALAPPDATA%\peterklingelhofer\exhale\exhale.lock`
+///     via the `directories` crate, same as `settings.toml`
+///   * **Linux**: `$XDG_RUNTIME_DIR/exhale.lock` if set, else
 ///     `~/.config/exhale/exhale.lock` (writable under every
-///     mainstream sandbox / flatpak / snap configuration).
+///     mainstream sandbox / flatpak / snap configuration)
 fn instance_lock_path() -> Option<PathBuf> {
     #[cfg(all(unix, not(target_os = "macos")))]
     {
@@ -145,21 +145,21 @@ fn instance_lock_path() -> Option<PathBuf> {
     Some(dirs.config_dir().join("exhale.lock"))
 }
 
-/// Try to acquire an exclusive non-blocking advisory lock on `file`.
-/// Returns `Ok(true)` on success, `Ok(false)` if another process holds
-/// the lock, `Err(_)` on any other failure.
+/// Try to acquire an exclusive non-blocking advisory lock on `file`: returns
+/// `Ok(true)` on success, `Ok(false)` if another process holds
+/// the lock, `Err(_)` on any other failure
 fn try_lock_exclusive(file: &std::fs::File) -> std::io::Result<bool> {
     #[cfg(unix)]
     {
         use std::os::fd::AsRawFd;
         // `flock(2)` with `LOCK_EX | LOCK_NB`.  EWOULDBLOCK means
-        // another process holds the lock — that's our "secondary
-        // instance" signal, not an error.
+        // another process holds the lock, which we treat as our
+        // "secondary instance" signal rather than an error
         // SAFETY: `file.as_raw_fd()` returns a valid file descriptor
         // owned by `file` for the duration of this call (the borrow
-        // checker enforces it via the `&std::fs::File` argument).
+        // checker enforces it via the `&std::fs::File` argument);
         // `flock` has no other safety requirements beyond the fd
-        // being a valid open file descriptor.
+        // being a valid open file descriptor
         let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         if rc == 0 {
             Ok(true)
@@ -181,23 +181,23 @@ fn try_lock_exclusive(file: &std::fs::File) -> std::io::Result<bool> {
         use windows_sys::Win32::System::IO::OVERLAPPED;
         // `LockFileEx` with `EXCLUSIVE | FAIL_IMMEDIATELY` is the
         // Win32 equivalent.  ERROR_LOCK_VIOLATION (33) means held by
-        // another process.
+        // another process
         // SAFETY: `OVERLAPPED` is a plain POD struct documented as
-        // safe to zero-initialise — `Offset = 0` / `OffsetHigh = 0`
+        // safe to zero-initialise: `Offset = 0` / `OffsetHigh = 0`
         // is exactly what we want for "lock byte 0".  Other fields
-        // (`hEvent` etc.) are unused in the FAIL_IMMEDIATELY path.
+        // (`hEvent` etc.) are unused in the FAIL_IMMEDIATELY path
         let mut ovl: OVERLAPPED = unsafe { std::mem::zeroed() };
         // SAFETY: `file.as_raw_handle()` returns a valid `HANDLE`
         // owned by `file` for the duration of the call (borrow
         // checker enforces it).  All other arguments are integer
         // constants or a stack pointer to `ovl`.  `LockFileEx` has
-        // no Rust-level safety requirements beyond a valid handle.
+        // no Rust-level safety requirements beyond a valid handle
         let ok = unsafe {
             LockFileEx(
                 file.as_raw_handle() as _,
                 LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
                 0,
-                1, 0,  // lock one byte at offset 0 — enough for advisory
+                1, 0,  // lock one byte at offset 0: enough for advisory
                 &mut ovl,
             )
         };
@@ -217,19 +217,19 @@ fn try_lock_exclusive(file: &std::fs::File) -> std::io::Result<bool> {
 
 /// `Write` adapter that mirrors every byte to both stderr AND a backing
 /// file.  We use this as `env_logger`'s target so the same log output
-/// appears in the terminal (when there is one) AND on disk next to the
-/// exe — needed for windowed-app debugging where stderr is nowhere
+/// appears in the terminal (when there's one) AND on disk next to the
+/// exe: needed for windowed-app debugging where stderr is nowhere
 /// reachable, including the on-Windows scenario where a black-screen
 /// overlay bug renders every other window invisible until the process
 /// is force-killed.  Stderr writes are best-effort: if stderr is closed
-/// or piped to /dev/null we still want the file log to succeed.
+/// or piped to /dev/null we still want the file log to succeed
 pub(crate) struct TeeLogWriter {
     pub(crate) file: std::fs::File,
 }
 
 impl std::io::Write for TeeLogWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        // Best-effort stderr — ignore failures so file logging always works.
+        // Best-effort stderr: ignore failures so file logging always works
         let _ = std::io::Write::write_all(&mut std::io::stderr(), buf);
         self.file.write(buf)
     }
@@ -240,7 +240,7 @@ impl std::io::Write for TeeLogWriter {
 }
 
 /// Pick a path to write the log file at.  Preferred location is right
-/// next to the exe — most users running an unsigned dev build extract
+/// next to the exe: most users running an unsigned dev build extract
 /// to Downloads / Desktop / similar, which is writable.  Fallbacks
 /// progressively widen the net so we never silently lose logs:
 ///   1. `<exe-dir>/exhale.log`
@@ -270,7 +270,7 @@ pub(crate) fn pick_log_path() -> PathBuf {
 
 /// Install a panic hook that appends panic info + backtrace to the log
 /// file before delegating to the default hook.  Without this, panics
-/// only print to stderr and are lost when stderr isn't captured.
+/// only print to stderr and are lost when stderr isn't captured
 pub(crate) fn install_panic_logger(log_path: PathBuf) {
     use std::sync::OnceLock;
     static PATH: OnceLock<PathBuf> = OnceLock::new();
@@ -312,7 +312,7 @@ mod tests {
             "exhale-test-lock-{}-{}.lock",
             std::process::id(),
             // Combine PID with a nanosecond timestamp so parallel
-            // test runs don't collide.
+            // test runs don't collide
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos())
@@ -330,7 +330,7 @@ mod tests {
         assert!(!second, "second open should detect the lock held by the first");
 
         // Drop the first lock; the file system / OS releases the
-        // advisory lock.  A third open should then succeed.
+        // advisory lock.  A third open should then succeed
         drop(f1);
         let f3 = std::fs::OpenOptions::new()
             .read(true).write(true).create(true).truncate(false)
@@ -338,7 +338,7 @@ mod tests {
         let third = try_lock_exclusive(&f3).expect("third lock call");
         assert!(third, "third open after first released should acquire");
 
-        // Best-effort cleanup.
+        // Best-effort cleanup
         drop(f2);
         drop(f3);
         let _ = std::fs::remove_file(&tmp);
@@ -347,12 +347,12 @@ mod tests {
     #[test]
     fn instance_lock_path_resolves_to_writable_dir() {
         // We don't write to the file in the test, just verify the
-        // path resolver returns a value whose parent we can `mkdir -p`.
+        // path resolver returns a value whose parent we can `mkdir -p`
         let path = instance_lock_path().expect("path candidate");
         assert!(path.is_absolute(), "lock path should be absolute: {}", path.display());
         let parent = path.parent().expect("path has parent");
         // create_dir_all is idempotent; on a clean system it creates
-        // the dir, on a populated system it no-ops.
+        // the dir, on a populated system it no-ops
         std::fs::create_dir_all(parent)
             .unwrap_or_else(|e| panic!("could not create {}: {e}", parent.display()));
     }

--- a/rust/crates/exhale-app/src/hotkeys.rs
+++ b/rust/crates/exhale-app/src/hotkeys.rs
@@ -8,7 +8,7 @@ use global_hotkey::{
 /// Per-action ids returned by [`register_hotkeys`].  The dispatcher in
 /// `main.rs` matches incoming `GlobalHotKeyEvent`s by `id`, so
 /// missing actions (registration failed, or no key code matched) stay
-/// `None` and silently no-op rather than dispatching the wrong event.
+/// `None` and silently no-op rather than dispatching the wrong event
 ///
 /// `registered` keeps the original `HotKey` objects so the caller can
 /// call [`GlobalHotKeyManager::unregister`] when the user reassigns a
@@ -23,16 +23,16 @@ pub struct HotkeyIds {
 }
 
 /// Register every action in `shortcuts` as a global hotkey via the
-/// `global-hotkey` crate.
+/// `global-hotkey` crate
 ///
-/// Each hotkey is registered individually with its own error handling
-/// — if one fails (typically because the combination conflicts with a
+/// Each hotkey is registered individually with its own error handling: if
+/// one fails (typically because the combination conflicts with a
 /// system or other-app global hotkey), the remaining hotkeys are
 /// still registered.  An earlier version used `?` propagation which
 /// meant a single failed registration silently disabled every later
 /// one in the sequence; the user would see only "Reset works" with no
 /// log entry pointing at the root cause (e.g. another app holding
-/// Ctrl+Shift+A).
+/// Ctrl+Shift+A)
 ///
 /// Returns the ids regardless of partial failure so the dispatcher
 /// can match any that did register; failures are logged with enough
@@ -77,8 +77,8 @@ pub fn register_hotkeys(
             }
             Err(e) => {
                 log::warn!(
-                    "global hotkey {label} (id={id}) failed to register: {e} \
-                     — likely conflicts with a system or other-app shortcut; \
+                    "global hotkey {label} (id={id}) failed to register: {e}; \
+                     likely conflicts with a system or other-app shortcut; \
                      the rest of exhale's hotkeys will still work.  Right-click the \
                      matching button in the settings window to assign a different key"
                 );

--- a/rust/crates/exhale-app/src/keymap.rs
+++ b/rust/crates/exhale-app/src/keymap.rs
@@ -1,4 +1,4 @@
-// egui → internal key/modifier translators used by the shortcut-capture
+// egui -> internal key/modifier translators used by the shortcut-capture
 // overlay in `settings_window.rs`. Pulled out of `hotkeys.rs` so the MAS
 // build (`--no-default-features`, no global-hotkey crate) can still let
 // the user capture and persist a binding even when no system-level
@@ -67,8 +67,8 @@ pub fn egui_modifiers_to_mask(m: egui::Modifiers) -> u8 {
     if m.shift { mask |= KBD_MOD_SHIFT; }
     if m.alt   { mask |= KBD_MOD_ALT; }
     // On macOS, egui's `mac_cmd` is Command and `command` is also Command;
-    // on other OSes `command` aliases to Ctrl which we've already captured.
-    // Only count Meta explicitly via mac_cmd so non-macOS double-counts don't happen.
+    // on other OSes `command` aliases to Ctrl which we've already captured
+    // Only count Meta explicitly via mac_cmd so non-macOS double-counts don't happen
     #[cfg(target_os = "macos")]
     if m.mac_cmd { mask |= KBD_MOD_META; }
     mask

--- a/rust/crates/exhale-app/src/main.rs
+++ b/rust/crates/exhale-app/src/main.rs
@@ -1,10 +1,10 @@
 // On Windows, suppress the console window that pops up alongside the
 // app when launched from Explorer / Start.  `release` builds get the
 // `windows` subsystem (no console), `debug` builds keep the console so
-// `cargo run` and `RUST_LOG` output remain visible while developing.
+// `cargo run` and `RUST_LOG` output remain visible while developing
 //
-// Linux + macOS aren't affected — they don't have the implicit-console
-// behavior Windows does for entry-point executables.
+// Linux + macOS aren't affected: they don't have the implicit-console
+// behavior Windows does for entry-point executables
 #![cfg_attr(all(target_os = "windows", not(debug_assertions)), windows_subsystem = "windows")]
 
 mod app_icon;
@@ -62,14 +62,14 @@ enum AppEvent {
     ResetDefaultsWithConfirm,
     /// Re-read `settings.keyboard_shortcuts` and re-register every
     /// global hotkey.  Fired by the settings window after the user
-    /// completes a capture (right-click → Change Shortcut…) or
+    /// completes a capture (right-click -> Change Shortcut…) or
     /// resets a per-action shortcut to its default
     #[cfg(feature = "global-hotkeys")]
     RebindHotkeys,
     /// Open the settings window (creating it if necessary) and put
     /// it into shortcut-capture mode for the given action.  Fired
     /// from the tray menu's "Keyboard Shortcuts ▶" submenu so the
-    /// user can rebind any action — including Preferences, which
+    /// user can rebind any action, including Preferences, which
     /// has no settings-window button to right-click
     BeginCapturingShortcut(exhale_core::settings::ShortcutAction),
     Quit,
@@ -82,10 +82,10 @@ struct App {
     settings:         Arc<RwLock<Settings>>,
     settings_manager: Arc<SettingsManager>,
 
-    // GPU context — shared across all renderers.
+    // GPU context: shared across all renderers
     gpu: Option<Arc<GpuContext>>,
 
-    // One overlay per monitor.
+    // One overlay per monitor
     overlays:            HashMap<WindowId, OverlayHandle>,
 
     // Shared frame-sender list the controller's `request_draw` closure
@@ -93,13 +93,13 @@ struct App {
     // capture) so [`Self::rescan_monitors`] can mutate it when a
     // monitor is hot-plugged or unplugged without restarting the
     // controller thread.  `None` until the controller is started in
-    // `resumed()`.
+    // `resumed()`
     frame_senders:       Option<Arc<RwLock<Vec<FrameSender>>>>,
 
     // Shared breathing-state slot the controller writes each tick and
     // every overlay's render thread reads.  Stored on the App so the
     // hot-plug rescan path can hand a clone to newly-created overlays
-    // without needing to extract it from the controller.
+    // without needing to extract it from the controller
     breathing_state:     Option<Arc<std::sync::Mutex<Option<exhale_core::controller::BreathingState>>>>,
 
     // Earliest instant we'll next call `available_monitors()` to
@@ -109,17 +109,17 @@ struct App {
     // poll cost is negligible (~microseconds), the worst-case 2 s
     // delay before a new overlay appears is imperceptible to a user
     // who just plugged in a monitor, and a single polling path keeps
-    // hot-plug behaviour identical on macOS, Windows, and Linux.
+    // hot-plug behaviour identical on macOS, Windows, and Linux
     next_monitor_scan:   Option<Instant>,
 
-    // Snapshot of max(w,h)/min(w,h) for the primary monitor at startup.
-    // Shared across all overlay renderers so a circle on any display covers
-    // the same fraction it would on the primary — matching Swift's
+    // Snapshot of max(w,h)/min(w,h) for the primary monitor at startup;
+    // shared across all overlay renderers so a circle on any display covers
+    // the same fraction it would on the primary, matching Swift's
     // `getMaxCircleScale()` which snapshots `NSScreen.main` once at onAppear
-    // and never recomputes.
+    // and never recomputes
     primary_max_circle_scale: f32,
 
-    // Settings panel.
+    // Settings panel
     settings_win:        Option<SettingsWindow>,
     settings_win_id:     Option<WindowId>,
 
@@ -130,30 +130,30 @@ struct App {
     next_settings_repaint: Option<Instant>,
 
 
-    // Throttle for `platform::reassert_overlay_topmost` on Windows —
-    // Windows orders topmost windows by activation, so a newly-opened
+    // Throttle for `platform::reassert_overlay_topmost` on Windows: it
+    // orders topmost windows by activation, so a newly-opened
     // app can land above our overlay until we re-bump it to the front
     // of the topmost band.  We re-assert at most once per second
     // (negligible CPU vs every-frame, still imperceptible latency
     // before the overlay reclaims the top).  None = never re-asserted
-    // yet; gets set after the first call.
+    // yet; gets set after the first call
     #[cfg(target_os = "windows")]
     next_topmost_reassert: Option<Instant>,
 
-    // Breathing controller.
+    // Breathing controller
     controller: Option<BreathingController>,
 
-    // System tray.
+    // System tray
     _tray:    Option<tray_icon::TrayIcon>,
     tray_ids: Option<TrayMenuIds>,
 
-    // Global hotkeys.
+    // Global hotkeys
     #[cfg(feature = "global-hotkeys")]
     hotkey_manager: Option<GlobalHotKeyManager>,
     #[cfg(feature = "global-hotkeys")]
     hotkey_ids:     Option<hotkeys::HotkeyIds>,
 
-    // Timers.
+    // Timers
     timers: Timers,
 }
 
@@ -198,7 +198,7 @@ impl App {
             sw.window.focus_window();
             return;
         }
-        // First open: create the window.
+        // First open: create the window
         if let Some(gpu) = &self.gpu {
             let settings_snap = self.settings.read_or_recover().clone();
             // Quit callback: SettingsWindow fires this when the user
@@ -206,7 +206,7 @@ impl App {
             // through the event-loop proxy routes the click through the
             // same `AppEvent::Quit` path the tray-menu Quit uses, so
             // all teardown (settings flush, controller stop, tray
-            // destroy) runs in the canonical order.
+            // destroy) runs in the canonical order
             let proxy = self.proxy.clone();
             let on_quit = Box::new({
                 let proxy = proxy.clone();
@@ -218,7 +218,7 @@ impl App {
             // `settings.keyboard_shortcuts`.  Gated behind the
             // `global-hotkeys` feature so the Mac App Store build (which
             // ships without Carbon hotkey integration) doesn't end up
-            // sending an event variant whose dispatcher is also cfg-d out.
+            // sending an event variant whose dispatcher is also cfg-d out
             #[cfg(feature = "global-hotkeys")]
             let on_rebind_hotkeys = Box::new(move || {
                 let _ = proxy.send_event(AppEvent::RebindHotkeys);
@@ -246,13 +246,13 @@ impl App {
         self.update_tray_state(&s);
         drop(s);
         // Reset to inhale phase 0, matching Swift start() which always resets
-        // cycleCount=0 and currentPhase=.inhale before restarting the timer.
+        // cycleCount=0 and currentPhase=.inhale before restarting the timer
         if let Some(c) = &self.controller {
             c.restart();
         }
         // Windowed-mode (Wayland fallback): bring the animation
         // window back if Stop had hidden it.  No-op on threaded
-        // fullscreen-overlay windows (they were never hidden).
+        // fullscreen-overlay windows (they were never hidden)
         for h in self.overlays.values() {
             h.set_animation_visible(true);
         }
@@ -275,22 +275,22 @@ impl App {
             h.set_animation_visible(false);
         }
         // Force one final render so the shader sees display_mode=STOPPED and
-        // clears to transparent — matches Swift `window.backgroundColor = .clear`.
+        // clears to transparent, matches Swift `window.backgroundColor = .clear`
         for h in self.overlays.values() { h.wake_render(); }
         self.request_settings_redraw();
     }
 
     fn update_tray_state(&self, s: &exhale_core::settings::Settings) {
         if let Some(ids) = &self.tray_ids {
-            // Start disabled while animating (matches Swift AppDelegate).
+            // Start disabled while animating (matches Swift AppDelegate)
             ids.start_item.set_enabled(!s.is_animating);
-            // Stop enabled when animating OR paused (matches Swift AppDelegate).
+            // Stop enabled when animating OR paused (matches Swift AppDelegate)
             ids.stop_item.set_enabled(s.is_animating || s.is_paused);
         }
     }
 
     /// Matches Swift AppDelegate.applyAppVisibility: DockOnly removes the
-    /// status-bar item; TopBarOnly / Both show it.
+    /// status-bar item; TopBarOnly / Both show it
     fn sync_tray_to_visibility(&mut self, vis: exhale_core::types::AppVisibility) {
         use exhale_core::types::AppVisibility;
         let needs_tray = vis != AppVisibility::DockOnly;
@@ -322,10 +322,10 @@ impl App {
         drop(s);
         // `reset_preserving_runtime_state` also clears the
         // `keyboard_shortcuts` block back to its per-action default
-        // (None for everything except Preferences → ⌃⇧,).  Without
+        // (None for everything except Preferences -> ⌃⇧,).  Without
         // re-running the rebind path the global-hotkey manager
         // keeps the OLD bindings active and the tray menu keeps
-        // displaying them — both diverge from what the settings
+        // displaying them; both diverge from what the settings
         // panel and `settings.toml` claim are in effect.  Cover the
         // macOS NSAlert reset path (which feeds back into do_reset)
         // and the tray-menu Reset click; the egui in-window
@@ -339,18 +339,18 @@ impl App {
 
     /// Open the settings window (if hidden) and raise the inline
     /// Reset-confirmation card.  Used by the Reset global hotkey
-    /// (default Ctrl+Shift+D) on every OS.
+    /// (default Ctrl+Shift+D) on every OS
     ///
     /// Originally the macOS path here ran a native
     /// `NSAlert.runModal()` for the system look + Cmd-period / Cmd-
     /// Return shortcuts, but that diverged from the button-click
-    /// path the user sees in the settings panel — pressing the Reset
+    /// path the user sees in the settings panel: pressing the Reset
     /// button shows the inline card while pressing the hotkey
     /// showed a system alert, even though both meant the same
     /// thing.  Consolidated to the inline card on every OS so the
     /// confirmation chrome is consistent regardless of how the
     /// reset was initiated.  The card lives directly under the
-    /// button row inside the Controls section — Esc cancels, Tab +
+    /// button row inside the Controls section: Esc cancels, Tab +
     /// Enter / Space on either Cancel or Reset resolves it
     #[cfg(feature = "global-hotkeys")]
     fn do_reset_with_confirm(&mut self, event_loop: &ActiveEventLoop) {
@@ -370,8 +370,8 @@ impl App {
 
     /// Unregister every currently-bound global hotkey and re-register
     /// from `settings.keyboard_shortcuts`.  Triggered when the
-    /// settings window captures a new shortcut for any action.
-    /// Errors are logged but never propagated — a failed rebind
+    /// settings window captures a new shortcut for any action;
+    /// errors are logged but never propagated: a failed rebind
     /// leaves the dispatcher with whatever ids did register, which
     /// is preferable to a panic on a user action
     #[cfg(feature = "global-hotkeys")]
@@ -394,7 +394,7 @@ impl App {
         // Sync the tray menu's "Keyboard Shortcuts ▶" submenu and
         // top-level item labels in place so the user immediately
         // sees the new binding without having to close and reopen
-        // the tray menu.  Avoids a full tray rebuild — `set_text`
+        // the tray menu.  Avoids a full tray rebuild: `set_text`
         // on each MenuItem is cheap and doesn't flash the icon
         if let Some(tray_ids) = &self.tray_ids {
             tray_ids.refresh_labels(&shortcuts);
@@ -404,15 +404,15 @@ impl App {
     /// Open the settings window (creating it if necessary) and put
     /// it into shortcut-capture mode for `action`.  Used by the
     /// tray menu's "Keyboard Shortcuts ▶" submenu so the user can
-    /// rebind any action without first navigating to its button —
-    /// critical for Preferences, which has no button to right-click
+    /// rebind any action without first navigating to its button: critical
+    /// for Preferences, which has no button to right-click
     fn do_begin_capturing_shortcut(
         &mut self,
         event_loop: &ActiveEventLoop,
         action:     exhale_core::settings::ShortcutAction,
     ) {
         // Ensure the settings window is open and frontmost so the
-        // capture overlay it's about to draw is visible.
+        // capture overlay it's about to draw is visible
         let visible = self.settings_win
             .as_ref()
             .and_then(|sw| sw.window.is_visible())
@@ -427,7 +427,7 @@ impl App {
         }
     }
 
-    /// Re-assert topmost ordering at most once per second on Windows.
+    /// Re-assert topmost ordering at most once per second on Windows
     ///
     /// Windows orders topmost windows by activation, so a newly-opened
     /// app can land above our overlay until we re-bump it to the front
@@ -436,7 +436,7 @@ impl App {
     /// panel ends up ABOVE the overlay; otherwise `overlay_opacity =
     /// 1.0` would lock the user out by covering the controls.  No-op
     /// on non-Windows.  Driven from `about_to_wait` because overlay
-    /// rendering lives on dedicated threads.
+    /// rendering lives on dedicated threads
     ///
     /// Short-circuits via `platform::is_topmost_top()` when the
     /// "expected-top" window of our pair (settings if visible, else
@@ -450,12 +450,12 @@ impl App {
         if !due { return; }
         self.next_topmost_reassert = Some(now + Duration::from_secs(1));
 
-        // Determine which of our windows should be at the very top.
-        // If settings is visible, settings should be above the overlay
+        // Determine which of our windows should be at the top: if
+        // settings is visible, settings should be above the overlay
         // (so the user can interact with controls); otherwise the
         // overlay holds the top.  If nothing foreign sits above that
         // window, the entire reassert is a no-op and we can skip the
-        // SetWindowPos calls that would otherwise flicker the frame.
+        // SetWindowPos calls that would otherwise flicker the frame
         let expected_top: Option<&Window> = self.settings_win.as_ref()
             .filter(|sw| sw.window.is_visible().unwrap_or(false))
             .map(|sw| sw.window.as_ref())
@@ -476,17 +476,17 @@ impl App {
         }
     }
 
-    /// Request a settings-window redraw if the window exists and is visible.
-    /// Used after external state mutations (hotkeys, tray) so the panel
+    /// Request a settings-window redraw if the window exists and is visible;
+    /// used after external state mutations (hotkeys, tray) so the panel
     /// reflects the new `is_animating` / `is_paused` state without the old
-    /// per-tick redraw loop.
+    /// per-tick redraw loop
     fn request_settings_redraw(&mut self) {
         if let Some(sw) = &self.settings_win {
             if sw.window.is_visible().unwrap_or(false) {
                 sw.request_redraw();
                 // The next RedrawRequested will overwrite this with egui's
                 // fresh repaint_delay, but zero the deadline so about_to_wait
-                // doesn't also fire a redundant redraw in the meantime.
+                // doesn't also fire a redundant redraw in the meantime
                 self.next_settings_repaint = None;
             }
         }
@@ -497,7 +497,7 @@ impl App {
     /// connected monitor and drops the overlay for any monitor that's
     /// no longer present.  Updates the controller's shared
     /// `frame_senders` so newly-created overlays start receiving Frame
-    /// signals on the very next controller tick.
+    /// signals on the next controller tick
     ///
     /// Cheap to call repeatedly: `available_monitors()` is an OS query
     /// that resolves in microseconds, and when the monitor set is
@@ -563,7 +563,7 @@ impl ApplicationHandler<AppEvent> for App {
 
         // ── Bootstrap GPU ─────────────────────────────────────────────────────
         // Create a throw-away surface on an invisible window to pick an adapter,
-        // then build the real overlay surfaces below.
+        // then build the real overlay surfaces below
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends:             wgpu::Backends::all(),
             dx12_shader_compiler: Default::default(),
@@ -571,7 +571,7 @@ impl ApplicationHandler<AppEvent> for App {
             gles_minor_version:   wgpu::Gles3MinorVersion::Automatic,
         });
 
-        // Bootstrap: use a temporary window to negotiate device selection.
+        // Bootstrap: use a temporary window to negotiate device selection
         let bootstrap_attrs = winit::window::Window::default_attributes()
             .with_visible(false)
             .with_inner_size(winit::dpi::PhysicalSize::new(1u32, 1u32));
@@ -596,7 +596,7 @@ impl ApplicationHandler<AppEvent> for App {
         // Swift: getMaxCircleScale() = max(w,h) / min(w,h) of NSScreen.main,
         // taken once at ContentView onAppear. Mirror that: snapshot the primary
         // monitor's aspect ratio at startup and broadcast to every overlay so a
-        // 16:10 laptop display and a 16:9 external use the same scale constant.
+        // 16:10 laptop display and a 16:9 external use the same scale constant
         let primary = event_loop
             .primary_monitor()
             .or_else(|| event_loop.available_monitors().next());
@@ -613,11 +613,11 @@ impl ApplicationHandler<AppEvent> for App {
         //
         // Each overlay handle spawns a dedicated render thread that owns
         // its renderer.  The controller writes its state snapshot to a
-        // shared Arc and signals the render threads via channels — that
+        // shared Arc and signals the render threads via channels: that
         // bypass entirely circumvents the Windows main-thread message
         // queue, where WM_MOUSEMOVE storms over the settings window
         // would otherwise starve WM_PAINT for the overlay and cause
-        // animation stutter.
+        // animation stutter
         let breathing_state =
             Arc::new(std::sync::Mutex::new(None::<exhale_core::controller::BreathingState>));
         self.breathing_state = Some(Arc::clone(&breathing_state));
@@ -640,7 +640,7 @@ impl ApplicationHandler<AppEvent> for App {
         // hidden if the user quit the app while stopped, so they
         // come back to a clean "Stop"-state instead of a window
         // showing the stopped clear frame.  No-op for threaded
-        // fullscreen overlays.
+        // fullscreen overlays
         let initial_animating = self.settings.read_or_recover().is_animating;
         for h in &handles {
             h.set_animation_visible(initial_animating);
@@ -654,12 +654,12 @@ impl ApplicationHandler<AppEvent> for App {
         //
         // `request_draw` fans out a Frame message to every overlay's
         // render thread, bypassing the main event loop.  No WM_PAINT
-        // dance and no risk of WM_MOUSEMOVE starvation.
+        // dance and no risk of WM_MOUSEMOVE starvation
         //
         // The sender list is shared via `Arc<RwLock<...>>` rather than
         // captured by-value so [`Self::rescan_monitors`] can extend it
         // when a new monitor is hot-plugged without restarting the
-        // controller thread.
+        // controller thread
         let frame_senders = Arc::new(RwLock::new(initial_senders));
         let senders_for_cb = Arc::clone(&frame_senders);
         self.controller = Some(BreathingController::start(
@@ -674,7 +674,7 @@ impl ApplicationHandler<AppEvent> for App {
         self.frame_senders = Some(frame_senders);
         // Schedule the first hot-plug scan ~2 s out so startup isn't
         // doing redundant work; subsequent scans are paced inside
-        // `about_to_wait`.
+        // `about_to_wait`
         self.next_monitor_scan = Some(Instant::now() + Duration::from_secs(2));
 
         // ── System tray ───────────────────────────────────────────────────────
@@ -686,7 +686,7 @@ impl ApplicationHandler<AppEvent> for App {
         // ── Global hotkeys ────────────────────────────────────────────────────
         // Gated behind the `global-hotkeys` feature so the Mac App Store
         // build (`--no-default-features`) ships without the Carbon-based
-        // hotkey registration as a hedge against App Review flagging it.
+        // hotkey registration as a hedge against App Review flagging it
         #[cfg(feature = "global-hotkeys")]
         match GlobalHotKeyManager::new() {
             Ok(mgr) => {
@@ -709,10 +709,10 @@ impl ApplicationHandler<AppEvent> for App {
 
         // ── Standard macOS menu bar (Apple/Edit/Window/Help) ──────────────────
         // Without this winit's NSApplication has no `mainMenu` and the
-        // menu bar shows only the app name with no menus — Quit/Hide/
+        // menu bar shows only the app name with no menus: Quit/Hide/
         // Cmd-X/Cmd-C/etc all stop working.  Closes a Swift-parity gap
         // that's invisible until you try to copy text from a settings
-        // field.  No-op on Windows / Linux.
+        // field.  No-op on Windows / Linux
         platform::install_main_menu();
 
         // ── Dock-icon reopen handler (macOS-only internally; no-op elsewhere) ─
@@ -723,13 +723,13 @@ impl ApplicationHandler<AppEvent> for App {
             platform::request_notification_permission();
         }
 
-        // Show the settings window on first launch (creates it as a side effect).
+        // Show the settings window on first launch (creates it as a side effect)
         self.toggle_settings(event_loop);
 
         // ── Activation policy / taskbar presence ──────────────────────────────
         // Cross-platform: macOS toggles NSApp activation policy; Windows toggles
         // the settings window's taskbar entry; Linux toggles SKIP_TASKBAR/PAGER.
-        // Applied AFTER the settings window exists so Windows/Linux can see it.
+        // Applied AFTER the settings window exists so Windows/Linux can see it
         {
             let vis = self.settings.read_or_recover().app_visibility;
             let settings_win = self.settings_win.as_ref().map(|sw| sw.window.as_ref());
@@ -767,12 +767,12 @@ impl ApplicationHandler<AppEvent> for App {
             if let Some(sw) = &mut self.settings_win {
                 let (consumed, wants_repaint) = sw.on_window_event(&event);
                 // egui signals via `repaint` when it needs a fresh paint
-                // (mouse move, click, focus change, tooltip, etc).
+                // (mouse move, click, focus change, tooltip, etc)
                 //
                 // BUT egui_winit returns `repaint=true` for `RedrawRequested`
                 // itself: if we honour that, every paint schedules another
                 // paint and we spin at refresh rate.  Skip it: we're already
-                // about to render below, no second request needed.
+                // about to render below, no second request needed
                 if wants_repaint && !matches!(event, WindowEvent::RedrawRequested) {
                     // No app-level frame cap because wgpu's
                     // `PresentMode::Fifo` already bounds presentation at
@@ -790,7 +790,7 @@ impl ApplicationHandler<AppEvent> for App {
                         // points (settings window has a fixed width;
                         // logical-vs-physical matters because next
                         // launch feeds height back through
-                        // `LogicalSize::new(...)`).
+                        // `LogicalSize::new(...)`)
                         let placement = placement::capture_placement_logical_height(
                             event_loop, &sw.window,
                         );
@@ -800,19 +800,19 @@ impl ApplicationHandler<AppEvent> for App {
                     }
                     WindowEvent::RedrawRequested => {
                         // Snapshot settings into a local so the render pass
-                        // (egui build + GPU submit + present — several ms)
+                        // (egui build + GPU submit + present, several ms)
                         // never holds the shared RwLock.  All settings
                         // mutations happen on this thread, so the only
                         // concurrent access is readers (controller,
-                        // settings-writer) — they can run freely while egui
+                        // settings-writer); they can run freely while egui
                         // works on the clone.  Commit-back at the end is a
-                        // ~200-byte memcpy held for microseconds.
+                        // ~200-byte memcpy held for microseconds
                         //
                         // Before this fix: `settings.write()` was held for
                         // the entire paint pass and the controller's per-
                         // tick `settings.read()` hit `lock_contended` ~17 %
                         // of the time, which was the dominant component of
-                        // the idle CPU baseline.
+                        // the idle CPU baseline
                         let before = self.settings.read_or_recover().clone();
                         let mut settings = before.clone();
 
@@ -823,7 +823,7 @@ impl ApplicationHandler<AppEvent> for App {
 
                         // Quit-button clicks dispatch directly through the
                         // `on_quit` callback passed in at SettingsWindow
-                        // construction — no flag polling here
+                        // construction: no flag polling here
 
                         // Diff before/after in one pass.  Adding a new
                         // setting is a one-line edit to
@@ -831,21 +831,21 @@ impl ApplicationHandler<AppEvent> for App {
                         let diff = exhale_core::settings::SettingsDiff::from(&before, &settings);
 
                         // Commit the (possibly-mutated) snapshot back.  The
-                        // write lock is held only for a struct assignment,
-                        // not for the whole paint pass.
+                        // write lock is held only for a struct assignment: brief
+                        // compared to the whole paint pass
                         *self.settings.write_or_recover() = settings.clone();
 
                         // Schedule egui's requested next repaint via a
                         // deadline checked in about_to_wait.  `MAX` means
-                        // egui has nothing animating — the window can sit
-                        // idle until the next input event.
+                        // egui has nothing animating: the window can sit
+                        // idle until the next input event
                         self.next_settings_repaint = if repaint_delay == std::time::Duration::MAX {
                             None
                         } else {
                             Some(Instant::now() + repaint_delay)
                         };
 
-                        // Reschedule timers if relevant settings changed.
+                        // Reschedule timers if relevant settings changed
                         if diff.auto_stop_changed || diff.animating_changed {
                             self.timers.reschedule_auto_stop(&settings);
                             self.update_tray_state(&settings);
@@ -854,7 +854,7 @@ impl ApplicationHandler<AppEvent> for App {
                         // `is_animating`.  Settings-panel Start /
                         // Stop buttons mutate `is_animating` here and
                         // need the overlay's window to show / hide to
-                        // match — `do_start` / `do_stop` (the global
+                        // match: `do_start` / `do_stop` (the global
                         // hotkey, tray-menu, and close-X paths) call
                         // `set_animation_visible` themselves, so this
                         // line specifically covers the panel-button
@@ -871,7 +871,7 @@ impl ApplicationHandler<AppEvent> for App {
                         if diff.reminder_changed {
                             self.timers.reschedule_reminder(&settings);
                             // Request notification permission when reminders are first enabled
-                            // (macOS-only; no-op elsewhere).
+                            // (macOS-only; no-op elsewhere)
                             if settings.reminder_interval_minutes > 0.0 {
                                 platform::request_notification_permission();
                             }
@@ -881,33 +881,33 @@ impl ApplicationHandler<AppEvent> for App {
                         let should_redraw  = diff.should_redraw_overlay();
 
                         // Apply platform-specific visibility: macOS activation policy,
-                        // Windows taskbar entry, Linux SKIP_TASKBAR/SKIP_PAGER.
+                        // Windows taskbar entry, Linux SKIP_TASKBAR/SKIP_PAGER
                         if diff.visibility_changed {
                             let settings_win = self.settings_win.as_ref().map(|sw| sw.window.as_ref());
                             platform::apply_app_visibility(diff.new_visibility, settings_win);
                             self.sync_tray_to_visibility(diff.new_visibility);
                         }
 
-                        // Restart animation from inhale-phase-0 when visual settings change —
-                        // matches Swift ContentView's triggerAnimationReset() behavior.
+                        // Restart animation from inhale-phase-0 when visual settings
+                        // change: matches Swift ContentView's triggerAnimationReset() behavior
                         if should_restart {
                             if let Some(c) = &self.controller { c.restart(); }
                         }
                         // Only fire an immediate redraw when we are
-                        // NOT also restarting the controller.
+                        // NOT also restarting the controller
                         //
                         // `c.restart()` now wakes the controller via
                         // `unpark()` and produces a fresh frame
                         // through its own `request_draw` path with
                         // the post-reset `BreathingState`.  If we
                         // ALSO `wake_render` here, the render thread
-                        // receives our message first — reads whatever
+                        // receives our message first, reads whatever
                         // stale state is still sitting in the shared
                         // mutex from before the Stop, paints it, and
                         // the user sees a one-frame flash of the
                         // previous cycle's animation before the
-                        // controller's reset-driven frame arrives.
-                        // Skipping `wake_render` in the restart case
+                        // controller's reset-driven frame arrives;
+                        // skipping `wake_render` in the restart case
                         // means the next visible frame is always the
                         // post-reset one.  Non-restart redraws
                         // (visual / paused changes while idle) still
@@ -920,19 +920,19 @@ impl ApplicationHandler<AppEvent> for App {
                     }
                     WindowEvent::CloseRequested => {
                         // Platform-conventional behavior:
-                        //   macOS / Windows — closing the settings
+                        //   macOS / Windows: closing the settings
                         //     window HIDES it; the menu bar (mac) / tray
                         //     icon (win) keeps the app alive. Matches
-                        //     NSApp + tray-resident-app conventions.
-                        //   Linux — closing the window QUITS the app.
-                        //     Tray-icon support is unreliable across DEs
+                        //     NSApp + tray-resident-app conventions
+                        //   Linux: closing the window QUITS the app;
+                        //     tray-icon support is unreliable across DEs
                         //     (Ubuntu has it via AppIndicator extension;
                         //     many distros / sessions don't show the
                         //     tray icon at all), and on Wayland sessions
                         //     where overlay click-through isn't honored,
                         //     the close button may be the only way the
                         //     user can dismiss the app.  Quit-on-close
-                        //     gives them a guaranteed escape hatch.
+                        //     gives them a guaranteed escape hatch
                         #[cfg(all(unix, not(target_os = "macos")))]
                         {
                             self.shutdown(event_loop);
@@ -959,8 +959,8 @@ impl ApplicationHandler<AppEvent> for App {
         // the renderer lives on the handle and is driven from
         // `RedrawRequested` here, because wgpu's surface acquisition
         // must run synchronized with the compositor's frame_callback
-        // protocol which only arrives through this event loop —
-        // bypassing it from a background thread leaves the
+        // protocol which only arrives through this event loop: bypassing
+        // it from a background thread leaves the
         // xdg_toplevel in a "configured but unmapped" state
         if let Some(handle) = self.overlays.get(&window_id) {
             // Persist windowed-mode placement on every Moved /
@@ -968,7 +968,7 @@ impl ApplicationHandler<AppEvent> for App {
             // fullscreen overlay windows: they're sized to the
             // monitor at creation and the user can't drag them, so
             // their `Moved` / `Resized` only fires on monitor
-            // hot-plug — already handled by `rescan_monitors`,
+            // hot-plug: already handled by `rescan_monitors`,
             // doesn't need to bleed into the placement file
             let is_windowed_mode = !handle.alpha_capable;
             let persist_placement = is_windowed_mode && matches!(
@@ -982,7 +982,7 @@ impl ApplicationHandler<AppEvent> for App {
             // close on a movable app window dismisses it; treating
             // that as a Stop press (hide window, halt animation,
             // tray + settings stay alive) matches every other "Stop"
-            // input source — keyboard hotkey, tray menu, Stop
+            // input source: keyboard hotkey, tray menu, Stop
             // button.  Fullscreen click-through overlays (alpha-
             // capable path) never receive `CloseRequested` because
             // they have no chrome to close from
@@ -1003,7 +1003,7 @@ impl ApplicationHandler<AppEvent> for App {
             if was_close && is_windowed_mode {
                 // Route through `do_stop` (not raw `set_visible`) so
                 // we also clear `is_animating`, reschedule auto-stop,
-                // update tray menu state, etc. — identical effect to
+                // update tray menu state, etc.: identical effect to
                 // pressing the Stop button in the settings panel
                 self.do_stop();
             }
@@ -1017,18 +1017,18 @@ impl ApplicationHandler<AppEvent> for App {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        // macOS: show settings when the user clicks the Dock icon while running.
-        // DOCK_REOPEN is always defined but only ever set by the macOS handler.
+        // macOS: show settings when the user clicks the Dock icon while running;
+        // DOCK_REOPEN is always defined but only ever set by the macOS handler
         if platform::DOCK_REOPEN.swap(false, std::sync::atomic::Ordering::Relaxed) {
             let _ = self.proxy.send_event(AppEvent::ShowSettings);
         }
 
         // Re-assert topmost ordering on a 1-second cadence.  Used to ride
         // along with each overlay render pass, but now that overlays
-        // render on their own threads, the main thread owns this beat.
-        // Windows-only — the underlying `reassert_overlay_topmost` is a
+        // render on their own threads, the main thread owns this beat;
+        // Windows-only: the underlying `reassert_overlay_topmost` is a
         // no-op elsewhere, so don't bother waking the loop at 1 Hz on
-        // macOS / Linux for nothing.
+        // macOS / Linux for nothing
         #[cfg(target_os = "windows")]
         self.maybe_reassert_topmost();
 
@@ -1050,8 +1050,8 @@ impl ApplicationHandler<AppEvent> for App {
         // theme changes.  We run GTK on the main thread alongside winit
         // (instead of on a dedicated thread) because tray-icon's API
         // requires the menu to be built and serviced from the same
-        // thread that called `gtk::init()` — which is the main thread
-        // for us.
+        // thread that called `gtk::init()`, which is the main thread
+        // for us
         #[cfg(all(unix, not(target_os = "macos")))]
         {
             while gtk::events_pending() {
@@ -1059,15 +1059,15 @@ impl ApplicationHandler<AppEvent> for App {
             }
         }
 
-        // Poll tray menu events — drain the channel so multiple
+        // Poll tray menu events: drain the channel so multiple
         // queued events (rare but possible if the user clicks
         // through several menu items between event-loop ticks)
-        // get processed in one pass instead of one per call.
+        // get processed in one pass instead of one per call
         while let Ok(event) = MenuEvent::receiver().try_recv() {
             if let Some(ids) = &self.tray_ids {
                 let id = &event.id;
-                // Check the "Keyboard Shortcuts ▶" submenu first —
-                // those items don't execute the action, they open
+                // Check the "Keyboard Shortcuts ▶" submenu first: those
+                // items don't execute the action, they open
                 // the settings window in capture mode for the
                 // matching `ShortcutAction`.  `kb_action_for`
                 // returns `None` for any non-submenu id, falling
@@ -1097,7 +1097,7 @@ impl ApplicationHandler<AppEvent> for App {
         // result was "the first hotkey works, later ones lag by
         // seconds or never get processed if the loop kept finding
         // other things to do."  Draining here turns that into
-        // batch dispatch on the next tick instead.
+        // batch dispatch on the next tick instead
         //
         // Within a single drain we also COALESCE duplicate ids so
         // mashing the same hotkey twice in the same tick only
@@ -1109,7 +1109,7 @@ impl ApplicationHandler<AppEvent> for App {
         #[cfg(feature = "global-hotkeys")]
         {
             // Suppress action dispatch while the settings window is in
-            // shortcut-capture mode — otherwise pressing the user's
+            // shortcut-capture mode: otherwise pressing the user's
             // currently-bound combo to "see what it does" or as part
             // of rebinding would fire BOTH the captured-key handler
             // (which writes a new binding) and the existing global
@@ -1123,12 +1123,12 @@ impl ApplicationHandler<AppEvent> for App {
                 use global_hotkey::HotKeyState;
                 // We only act on Pressed; Released events for the same
                 // hotkey still get drained here (just no-op'd) so they
-                // don't queue up indefinitely.
+                // don't queue up indefinitely
                 if event.state != HotKeyState::Pressed {
                     continue;
                 }
                 if suppress {
-                    log::debug!("global hotkey id={} ignored — capture overlay active", event.id);
+                    log::debug!("global hotkey id={} ignored: capture overlay active", event.id);
                     continue;
                 }
                 let Some(ids) = &self.hotkey_ids else { continue; };
@@ -1152,7 +1152,7 @@ impl ApplicationHandler<AppEvent> for App {
             }
         }
 
-        // Tick timers.
+        // Tick timers
         let events = {
             let s = self.settings.read_or_recover();
             self.timers.tick(&s)
@@ -1165,14 +1165,14 @@ impl ApplicationHandler<AppEvent> for App {
         }
 
         // Fire a settings-window redraw only if egui has asked for one via
-        // its `repaint_delay` (tooltip fade, button-press animation, etc.).
-        // Previously this block unconditionally called `sw.request_redraw()`
+        // its `repaint_delay` (tooltip fade, button-press animation, etc.);
+        // previously this block unconditionally called `sw.request_redraw()`
         // every idle tick, which spun the event loop at the display's
         // refresh rate and drove a full egui + GPU paint pass ~60 times per
-        // second while the settings window was open — the dominant cause of
+        // second while the settings window was open: the dominant cause of
         // the ~18 % idle CPU baseline.  Now the window sits idle until
-        // there's an input event or a scheduled animation frame.
-        // Handle a fired settings-repaint deadline first.
+        // there's an input event or a scheduled animation frame; handle a
+        // fired settings-repaint deadline first
         if let Some(deadline) = self.next_settings_repaint {
             if Instant::now() >= deadline {
                 if let Some(sw) = &self.settings_win {
@@ -1184,17 +1184,17 @@ impl ApplicationHandler<AppEvent> for App {
             }
         }
 
-        // Compute the earliest deadline we need the event loop to wake for:
-        // an egui-requested repaint OR an auto-stop/reminder firing.  With
+        // Compute the earliest deadline we need the event loop to wake for: an
+        // egui-requested repaint OR an auto-stop/reminder firing.  With
         // `ControlFlow::Wait` alone the loop would sleep indefinitely and
-        // miss these, since nothing else wakes it on an idle desktop.
+        // miss these, since nothing else wakes it on an idle desktop
         let timer_deadline = {
             let s = self.settings.read_or_recover();
             self.timers.next_deadline(&s)
         };
         // Windows: include the topmost re-assert beat in the wake schedule
         // so the loop wakes once per second to bump our overlay (and
-        // settings, when visible) back to the top of the topmost band.
+        // settings, when visible) back to the top of the topmost band
         #[cfg(target_os = "windows")]
         let topmost_deadline = self.next_topmost_reassert;
         #[cfg(not(target_os = "windows"))]
@@ -1217,7 +1217,7 @@ impl ApplicationHandler<AppEvent> for App {
 
 impl App {
     fn shutdown(&mut self, event_loop: &ActiveEventLoop) {
-        info!("shutting down — flushing settings");
+        info!("shutting down, flushing settings");
         if let Some(c) = self.controller.as_mut() { c.stop(); }
         if let Err(e) = self.settings_manager.flush_sync() { error!("flush: {e}"); }
         event_loop.exit();
@@ -1239,19 +1239,19 @@ fn main() -> Result<()> {
     // submission index N` chatter doesn't flood the log file at ~10
     // fps.  `wgpu_hal::metal::adapter` is pinned to ERROR
     // specifically to suppress the per-frame "Unable to get the
-    // current view dimensions on a non-main thread" WARN — that
+    // current view dimensions on a non-main thread" WARN; that
     // warning is benign for our use case (wgpu's fallback uses the
     // cached size from the last `configure()`, which we DO call
-    // from the main thread on every Resized event).
+    // from the main thread on every Resized event)
     //
     // `sctk_adwaita` is the Wayland client-side decoration crate;
     // some compositors send button events it doesn't recognise and
-    // it logs a WARN per event ("Ignoring unknown button type:").
-    // Not actionable from our side, so capped at ERROR.
+    // it logs a WARN per event ("Ignoring unknown button type:");
+    // not actionable from our side, so capped at ERROR
     //
     // Override via `RUST_LOG=info` to see everything when actually
     // debugging wgpu/naga/wayland issues.  Re-enable just the metal
-    // adapter chatter with `RUST_LOG=wgpu_hal::metal=warn`.
+    // adapter chatter with `RUST_LOG=wgpu_hal::metal=warn`
     let mut builder = env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or(
             "info,\
@@ -1274,12 +1274,12 @@ fn main() -> Result<()> {
     install_panic_logger(log_path.clone());
     info!("logging to {}", log_path.display());
 
-    // Linux: initialise GTK before anything in the tray-icon path runs.
+    // Linux: initialise GTK before anything in the tray-icon path runs;
     // `tray-icon` builds on top of GTK + libayatana-appindicator on
     // Linux; constructing menu items without a prior `gtk::init()`
-    // panics with "GTK has not been initialized".  This call is
+    // panics with "GTK hasn't been initialized".  This call is
     // cheap when GTK is already up, and we pump its event loop
-    // non-blockingly inside `about_to_wait` so menu clicks dispatch.
+    // non-blockingly inside `about_to_wait` so menu clicks dispatch
     #[cfg(all(unix, not(target_os = "macos")))]
     {
         if let Err(e) = gtk::init() {

--- a/rust/crates/exhale-app/src/overlay.rs
+++ b/rust/crates/exhale-app/src/overlay.rs
@@ -20,12 +20,12 @@ use winit::{
 /// set of currently-connected monitors against the set we already have
 /// overlays for, so hot-plug events (connect / disconnect) can be
 /// detected by polling `available_monitors()` without relying on the
-/// `MonitorHandle`'s own identity (which is not guaranteed stable
-/// across calls on every platform).
+/// `MonitorHandle`'s own identity (which isn't guaranteed stable
+/// across calls on every platform)
 pub type MonitorKey = (i32, i32, u32, u32);
 
-/// Derive a stable key from a monitor's physical position + size.
-/// Two monitors can't share the same rectangle, so the tuple is unique
+/// Derive a stable key from a monitor's physical position + size;
+/// two monitors can't share the same rectangle, so the tuple is unique
 /// per session and survives DPI changes (it's all physical pixels)
 pub fn monitor_key(m: &MonitorHandle) -> MonitorKey {
     let p = m.position();
@@ -40,13 +40,13 @@ use crate::platform;
 /// Messages the main thread (or controller thread) sends to a per-overlay
 /// render thread.  The render thread owns the wgpu surface + renderer and
 /// processes one message at a time, coalescing duplicate `Frame` requests
-/// so it never falls behind under controller bursts.
+/// so it never falls behind under controller bursts
 pub enum RenderMsg {
     /// Wake up and render the latest controller state.  The controller
     /// writes its state slot BEFORE sending this, so a `Frame` always
     /// observes the most recent breathing snapshot via the Mutex barrier
     Frame,
-    /// Window resized — re-configure the swap chain.  Coalesced: if
+    /// Window resized: re-configure the swap chain.  Coalesced: if
     /// multiple resizes are pending, only the latest dimensions take
     /// effect
     Resize(PhysicalSize<u32>),
@@ -58,17 +58,17 @@ pub enum RenderMsg {
 
 /// Wake handle for an overlay.  Clone-friendly so the controller can
 /// hold one per overlay and fan out frame signals without owning the
-/// [`OverlayHandle`].
+/// [`OverlayHandle`]
 ///
 /// Has two variants because overlays use two different rendering
 /// architectures depending on the platform:
 ///
-///   - [`FrameSender::Channel`] — fires a `Frame` message into the
+///   - [`FrameSender::Channel`]: fires a `Frame` message into the
 ///     per-window render thread's mpsc channel, bypassing the main
 ///     event loop's message queue entirely.  Used on macOS / Windows
 ///     / Linux X11 where wgpu can acquire a swap-chain texture from
-///     any thread.
-///   - [`FrameSender::Redraw`] — calls `window.request_redraw()`
+///     any thread
+///   - [`FrameSender::Redraw`]: calls `window.request_redraw()`
 ///     which causes winit to emit a `RedrawRequested` event on the
 ///     main thread.  Used on Wayland where the compositor's
 ///     frame-callback protocol requires `surface.get_current_texture()`
@@ -85,7 +85,7 @@ impl FrameSender {
     /// state.  Coalesced on the receiving side (channel: thread loop;
     /// redraw: winit's per-frame `request_redraw` dedup), so calling
     /// this faster than the renderer can keep up just folds into a
-    /// single render pass against the latest controller state.
+    /// single render pass against the latest controller state
     pub fn send_frame(&self) {
         match self {
             Self::Channel(tx) => { let _ = tx.send(RenderMsg::Frame); }
@@ -96,7 +96,7 @@ impl FrameSender {
 
 // ─── Public handle (main-thread side) ─────────────────────────────────────────
 
-/// One transparent overlay covering a single monitor.
+/// One transparent overlay covering a single monitor
 ///
 /// The main thread keeps only the [`Arc<Window>`] and a channel to the
 /// per-overlay render thread.  The render thread owns the
@@ -106,8 +106,8 @@ impl FrameSender {
 /// main-thread message pump, WM_PAINT being the lowest-priority message
 /// in the queue, so when WM_MOUSEMOVE floods the queue (hover storm over
 /// the settings window), a main-thread render loop would have its
-/// WM_PAINT slots starved and the breath animation would stutter.
-/// With render threads, the controller signals the thread via an mpsc
+/// WM_PAINT slots starved and the breath animation would stutter;
+/// with render threads, the controller signals the thread via an mpsc
 /// channel that bypasses the Windows message queue entirely
 pub struct OverlayHandle {
     pub window: Arc<Window>,
@@ -117,7 +117,7 @@ pub struct OverlayHandle {
     /// `true` when the swap chain supports per-pixel alpha and the
     /// window is acting as a true click-through overlay.  `false`
     /// when the compositor / GPU only exposed Opaque alpha and we
-    /// reconfigured the window as a regular windowed app — used by
+    /// reconfigured the window as a regular windowed app: used by
     /// `create_all` to avoid spawning duplicate fallback windows on
     /// every monitor
     pub alpha_capable: bool,
@@ -126,12 +126,12 @@ pub struct OverlayHandle {
     mode:        HandleMode,
 }
 
-/// How this overlay's renderer is driven.
+/// How this overlay's renderer is driven
 ///
 /// `Threaded` keeps a per-window background thread that owns the
 /// renderer outright and renders in response to `Frame` channel
-/// messages — the original architecture, used everywhere wgpu can
-/// safely acquire swap-chain textures from a non-main thread.
+/// messages, the original architecture, used everywhere wgpu can
+/// safely acquire swap-chain textures from a non-main thread
 ///
 /// `MainThread` keeps the renderer in a [`Mutex`] on the handle so
 /// it can be locked and called from `main.rs`'s `RedrawRequested`
@@ -140,18 +140,18 @@ pub struct OverlayHandle {
 /// protocol, which winit only delivers via `RedrawRequested` on the
 /// main thread.  A background-thread render on Wayland returns
 /// `Outdated` indefinitely and never commits a buffer, leaving the
-/// xdg_toplevel in a "configured but unmapped" state — visible in
+/// xdg_toplevel in a "configured but unmapped" state, visible in
 /// the dock but with nothing to display
 enum HandleMode {
     Threaded {
         /// Sender to the render thread.  Cloned for the controller's
         /// `request_draw` callback so frame signals go straight to
         /// the renderer without touching the main thread's message
-        /// queue.
+        /// queue
         msg_tx: Sender<RenderMsg>,
         /// Join handle for the render thread.  Taken on shutdown so
         /// we can wait for the thread to drop the renderer / wgpu
-        /// resources before the app exits.
+        /// resources before the app exits
         thread: Option<JoinHandle<()>>,
     },
     /// Boxed because the `Mutex<OverlayRenderer>` payload is much
@@ -175,7 +175,7 @@ impl OverlayHandle {
         self.monitor_key
     }
 
-    /// Create one overlay per connected monitor, all sharing `gpu`.
+    /// Create one overlay per connected monitor, all sharing `gpu`
     pub fn create_all(
         event_loop: &ActiveEventLoop,
         gpu:        Arc<GpuContext>,
@@ -198,8 +198,8 @@ impl OverlayHandle {
                     // `create_one`).  Spawning more "overlays" on
                     // additional monitors in this mode would just
                     // produce duplicate windowed copies of the
-                    // animation, none of which act as overlays.
-                    // Bail out after the first
+                    // animation, none of which act as overlays;
+                    // bail out after the first
                     let opaque_only = !h.alpha_capable;
                     handles.push(h);
                     if opaque_only { break; }
@@ -208,7 +208,7 @@ impl OverlayHandle {
             }
         }
 
-        // Fallback: at least one window on the primary monitor.
+        // Fallback: at least one window on the primary monitor
         if handles.is_empty() {
             match Self::create_one(
                 event_loop, Arc::clone(&gpu), None,
@@ -237,15 +237,15 @@ impl OverlayHandle {
         // Wayland's security model doesn't expose a portable
         // always-on-top or click-through protocol to winit, so the
         // fullscreen-overlay model fundamentally doesn't work the
-        // way it does on macOS / Windows / X11.  Additionally,
-        // Mutter / GNOME (Ubuntu's default compositor) only exposes
-        // Opaque alpha to wgpu, so even an AlwaysOnBottom overlay
-        // would render as a solid-black rectangle covering the
-        // whole screen.  The right answer here is a regular
-        // windowed app the user can move / resize like anything
-        // else, rendered on the main thread so wgpu's surface
-        // acquisition stays synchronized with the compositor's
-        // frame-callback protocol (see `HandleMode` doc).
+        // way it does on macOS / Windows / X11.  Mutter / GNOME
+        // (Ubuntu's default compositor) also only exposes Opaque
+        // alpha to wgpu, so even an AlwaysOnBottom overlay would
+        // render as a solid-black rectangle covering the whole
+        // screen.  The right answer here is a regular windowed app
+        // the user can move / resize like anything else, rendered
+        // on the main thread so wgpu's surface acquisition stays
+        // synchronized with the compositor's frame-callback
+        // protocol (see `HandleMode` doc)
         #[cfg(all(unix, not(target_os = "macos")))]
         let is_wayland = std::env::var("XDG_SESSION_TYPE")
             .map(|s| s.eq_ignore_ascii_case("wayland"))
@@ -259,14 +259,14 @@ impl OverlayHandle {
                  app (no fullscreen overlay).  Rendering on the main \
                  thread via RedrawRequested so wgpu surface acquisition \
                  stays in sync with the compositor's frame_callback \
-                 protocol — move / resize / Alt-Tab the window like \
+                 protocol; move / resize / Alt-Tab the window like \
                  any other app; the breath animation renders as its \
                  content."
             );
             let (window, renderer, alpha_capable) =
                 create_windowed_app(event_loop, &gpu, monitor.as_ref(), &settings)?;
             // Kick off the first frame.  Wayland needs an initial
-            // RedrawRequested → render → buffer commit cycle for the
+            // RedrawRequested -> render -> buffer commit cycle for the
             // xdg_toplevel to actually map; without this the window
             // sits in the dock but never appears on screen.  This
             // request lands on the main thread's event queue and
@@ -300,7 +300,7 @@ impl OverlayHandle {
             })
             .map_err(|e| anyhow::anyhow!(
                 "spawn overlay render thread for {:?}: {} \
-                 (system thread limit hit — skipping this monitor's overlay)",
+                 (system thread limit hit; skipping this monitor's overlay)",
                 window.id(), e,
             ))?;
 
@@ -312,9 +312,9 @@ impl OverlayHandle {
         })
     }
 
-    /// Build a [`FrameSender`] tuned to this overlay's render mode —
+    /// Build a [`FrameSender`] tuned to this overlay's render mode:
     /// channel send for threaded overlays, `request_redraw` for
-    /// main-thread (Wayland) overlays.  See [`FrameSender`] doc.
+    /// main-thread (Wayland) overlays.  See [`FrameSender`] doc
     pub fn frame_sender(&self) -> FrameSender {
         match &self.mode {
             HandleMode::Threaded { msg_tx, .. } =>
@@ -339,19 +339,19 @@ impl OverlayHandle {
     /// controller state.  Used by main-thread code paths that mutate
     /// settings outside of a controller tick (Start/Stop, theme
     /// change, etc.) and want the overlay to reflect the change
-    /// immediately.
+    /// immediately
     pub fn wake_render(&self) {
         self.frame_sender().send_frame();
     }
 
     /// Show or hide the underlying window.  Only meaningful for
     /// windowed-mode (MainThread) overlays: when the user hits Stop
-    /// the window should close, and Start should bring it back.
-    /// On threaded fullscreen-overlay windows (macOS / Windows /
+    /// the window should close, and Start should bring it back;
+    /// on threaded fullscreen-overlay windows (macOS / Windows /
     /// Linux X11) hiding would just remove the always-on-top
-    /// breath animation while the app keeps running — not what
-    /// Stop means on those platforms, where the render thread
-    /// instead paints a "stopped" clear frame.  So we gate this on
+    /// breath animation while the app keeps running.  On those
+    /// platforms Stop instead means the render thread paints a
+    /// "stopped" clear frame.  So we gate this on
     /// `alpha_capable`: threaded overlays ignore the toggle, the
     /// windowed-app shows / hides
     pub fn set_animation_visible(&self, visible: bool) {
@@ -361,20 +361,20 @@ impl OverlayHandle {
         self.window.set_visible(visible);
         if visible {
             // Wayland needs an explicit redraw request after a
-            // hide → show cycle to re-commit a buffer; without it
+            // hide -> show cycle to re-commit a buffer; without it
             // the xdg_toplevel comes back to the dock but the
-            // surface stays unattached.
+            // surface stays unattached
             self.window.request_redraw();
         }
     }
 
     /// Render synchronously on the calling thread.  No-op for
-    /// threaded overlays (their render thread owns the renderer).
-    /// Called from `main.rs`'s `RedrawRequested` handler for
-    /// `MainThread` overlays — the only path that drives Wayland
+    /// threaded overlays (their render thread owns the renderer);
+    /// called from `main.rs`'s `RedrawRequested` handler for
+    /// `MainThread` overlays: the only path that drives Wayland
     /// rendering, since the compositor's frame_callback arrives
     /// through the event loop and not via the controller's
-    /// background-thread `Frame` channel.
+    /// background-thread `Frame` channel
     pub fn render_on_main(&self) {
         if let HandleMode::MainThread(mt) = &self.mode {
             let mut r = mt.renderer.lock_or_recover();
@@ -428,7 +428,7 @@ fn create_windowed_app(
     if placement.x.is_none() {
         // First launch / no saved position: centre on the assigned
         // monitor explicitly so X11 / Windows / macOS don't fall back
-        // to (0, 0).  Wayland still ignores this.
+        // to (0, 0).  Wayland still ignores this
         if let Some(m) = monitor {
             let mp = m.position();
             let ms = m.size();
@@ -462,10 +462,10 @@ fn create_overlay_or_fallback(
     monitor:    Option<&MonitorHandle>,
     settings:   &Arc<RwLock<Settings>>,
 ) -> Result<(Arc<Window>, OverlayRenderer, bool)> {
-    // Borderless, transparent, fullscreen on the target monitor.
-    // The `with_visible(false)` keeps the probe window off-screen
+    // Borderless, transparent, fullscreen on the target monitor;
+    // the `with_visible(false)` keeps the probe window off-screen
     // until we've decided which path to take, so the user never sees
-    // a brief flash of a fullscreen transparent shell.
+    // a brief flash of a fullscreen transparent shell
     let mut attrs = Window::default_attributes()
         .with_title("exhale-overlay")
         .with_transparent(true)
@@ -479,7 +479,7 @@ fn create_overlay_or_fallback(
         // On Windows, shrink the overlay by 1 px on the bottom edge
         // so Windows doesn't classify the topmost window as an
         // "exclusive fullscreen application" and suspend the
-        // auto-hide taskbar reveal logic.
+        // auto-hide taskbar reveal logic
         let win_h = if cfg!(target_os = "windows") {
             size.height.saturating_sub(1).max(1)
         } else {
@@ -506,12 +506,12 @@ fn create_overlay_or_fallback(
         // (it only sets it when `IGNORE_CURSOR_EVENT` is on, which
         // we don't toggle via winit's API), so any
         // `WS_EX_TRANSPARENT` we OR-in BEFORE the visibility toggle
-        // gets silently stripped on the way to the screen — visible
+        // gets silently stripped on the way to the screen, visible
         // overlay, no click-through (the originally-reported
         // regression).  Calling `setup_overlay_window` AFTER
         // `set_visible` makes our raw `SetWindowLongPtrW` the LAST
         // write to the EX-style word, so the flag survives.  No-op
-        // on non-Windows platforms — both calls are pure on macOS
+        // on non-Windows platforms: both calls are pure on macOS
         // and Linux
         probe_window.set_visible(true);
         platform::setup_overlay_window(&probe_window);
@@ -541,7 +541,7 @@ fn create_overlay_or_fallback(
         let _ = probe_window.request_inner_size(PhysicalSize::new(1, 1));
         probe_window.set_outer_position(PhysicalPosition::new(-32000, -32000));
         // Order matters: drop renderer (releases the surface) before
-        // the window so the surface releases its reference cleanly.
+        // the window so the surface releases its reference cleanly
         drop(probe_renderer);
         drop(probe_window);
         create_windowed_app(event_loop, gpu, monitor, settings)
@@ -552,8 +552,8 @@ impl Drop for OverlayHandle {
     fn drop(&mut self) {
         // Threaded mode: tell the render thread to exit and wait for
         // it so the wgpu device + queue + surface release cleanly
-        // before the app exits.  MainThread mode has no thread —
-        // the renderer drops with the handle automatically.
+        // before the app exits.  MainThread mode has no thread: the
+        // renderer drops with the handle automatically
         if let HandleMode::Threaded { msg_tx, thread } = &mut self.mode {
             let _ = msg_tx.send(RenderMsg::Shutdown);
             if let Some(h) = thread.take() {
@@ -596,7 +596,7 @@ fn render_thread_loop(
     loop {
         // Block until at least one message arrives.  `recv` returns
         // `Err` only when every sender has been dropped (overlay handle
-        // gone), which means the app is shutting down regardless.
+        // gone), which means the app is shutting down regardless
         let first = match msg_rx.recv() {
             Ok(m)  => m,
             Err(_) => break,
@@ -613,7 +613,7 @@ fn render_thread_loop(
             renderer.resize(s.width, s.height);
         }
 
-        // Render on every Frame message regardless of `alpha_capable`.
+        // Render on every Frame message regardless of `alpha_capable`
         //
         // Earlier this branch skipped rendering when
         // `alpha_capable == false` under the (now-stale) assumption
@@ -624,16 +624,16 @@ fn render_thread_loop(
         // app".  Skipping the render in that case left the fallback
         // window painted with whatever the GPU cleared at startup
         // (typically white) and pressing Start did nothing user-
-        // visible — exactly the symptom reported on Windows 10
-        // systems where Vulkan reports only the `Opaque` alpha mode.
-        // Rendering is cheap (we already coalesce Frame bursts in
+        // visible: exactly the symptom reported on Windows 10
+        // systems where Vulkan reports only the `Opaque` alpha mode;
+        // rendering is cheap (we already coalesce Frame bursts in
         // `coalesce_messages`) and the Opaque-only swap chain accepts
         // whatever colour we present, so just paint unconditionally
         if should_render {
             // Read the latest snapshot and settings.  The controller
             // writes its state BEFORE sending us the Frame, and the
             // Mutex acquire here provides the matching release/acquire
-            // barrier so we observe the most recent values.
+            // barrier so we observe the most recent values
             let state_snap = state.lock_or_recover().unwrap_or_else(|| {
                 BreathingState {
                     phase:     exhale_core::types::BreathingPhase::Inhale,
@@ -656,7 +656,7 @@ fn render_thread_loop(
 /// Output of `coalesce_messages`: a flattened view of what the render
 /// thread should do for this iteration of the loop.  Extracted so the
 /// coalescing logic can be unit-tested without a real `OverlayRenderer`
-/// (which needs a GPU surface).
+/// (which needs a GPU surface)
 #[derive(Debug, Default, PartialEq, Eq)]
 struct CoalescedBatch {
     should_render: bool,

--- a/rust/crates/exhale-app/src/placement.rs
+++ b/rust/crates/exhale-app/src/placement.rs
@@ -1,22 +1,22 @@
 //! Shared window-placement helpers used by both the settings window
-//! and the windowed-mode animation window (Wayland fallback path).
+//! and the windowed-mode animation window (Wayland fallback path)
 //!
 //! Each window persists its position as an offset relative to a named
-//! monitor — when that monitor is still connected on next launch the
+//! monitor: when that monitor is still connected on next launch the
 //! window comes back where you left it, and when the monitor's gone
 //! (laptop unplugged from a dock, resolution shrunk, external display
 //! disconnected) we clamp the rect to whichever monitor is closest
 //! rather than restoring to dead coordinates that put the window
-//! mostly or entirely off-screen.
+//! mostly or entirely off-screen
 //!
 //! Two halves:
 //!
-//!   - **Pure geometry** ([`clamp_position_against_monitors`]) — no
-//!     winit dependency, unit-testable.
+//!   - **Pure geometry** ([`clamp_position_against_monitors`]): no
+//!     winit dependency, unit-testable
 //!   - **Winit glue** ([`apply_placement`] / [`capture_placement`] /
-//!     [`clamp_position_to_visible`]) — reads from / writes to the
+//!     [`clamp_position_to_visible`]): reads from / writes to the
 //!     live `Window` and `ActiveEventLoop`, used by both windows
-//!     from `main.rs` and from each window's constructor.
+//!     from `main.rs` and from each window's constructor
 
 use exhale_core::WindowPlacement;
 use winit::{
@@ -27,7 +27,7 @@ use winit::{
 
 /// A monitor's physical rectangle in screen coordinates.  Used by
 /// [`clamp_position_against_monitors`] so its geometry logic can be
-/// unit-tested without a winit event loop.
+/// unit-tested without a winit event loop
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct MonitorRect {
     pub x: i32,
@@ -42,31 +42,31 @@ pub(crate) struct MonitorRect {
 /// origin so a rearranged display arrangement still puts the window
 /// on the right screen.  When the saved monitor is gone, falls back
 /// to treating the offset as absolute and then clamps via
-/// [`clamp_position_to_visible`].
+/// [`clamp_position_to_visible`]
 ///
 /// Size is intentionally NOT restored here.  Each window already
 /// passes its restored size to `Window::default_attributes()
 /// .with_inner_size(...)` at creation time, using the right
 /// `LogicalSize` / `PhysicalSize` variant for the units its
 /// placement field stores in (settings window persists height in
-/// logical points; animation window persists in physical pixels).
-/// Re-applying via `request_inner_size(PhysicalSize::new(...))` here
+/// logical points; animation window persists in physical pixels);
+/// re-applying via `request_inner_size(PhysicalSize::new(...))` here
 /// would treat the logical points as physical pixels, halving the
-/// height on Retina / 2× displays.
+/// height on Retina / 2× displays
 pub fn apply_placement(
     event_loop: &ActiveEventLoop,
     window:     &Window,
     placement:  &WindowPlacement,
 ) {
     // Without a saved position we let the OS / compositor place the
-    // window — on macOS / X11 / Windows this lands centred on the
+    // window: on macOS / X11 / Windows this lands centred on the
     // primary monitor; on Wayland the compositor places however it
-    // likes.
+    // likes
     let (Some(x), Some(y)) = (placement.x, placement.y) else { return; };
 
     // Resolve the offset against the saved monitor when it's still
-    // present.  When it's gone, treat the offset as absolute — the
-    // clamp step below pulls it back onto a visible monitor regardless.
+    // present.  When it's gone, treat the offset as absolute; the
+    // clamp step below pulls it back onto a visible monitor regardless
     let (abs_x, abs_y) = match &placement.screen {
         Some(name) => {
             let matching = event_loop.available_monitors()
@@ -85,7 +85,7 @@ pub fn apply_placement(
     // Use the window's CURRENT outer size (just set by the caller's
     // `with_inner_size` attr) so the clamp respects the actual
     // window dimensions in physical pixels regardless of which units
-    // the placement is stored in.
+    // the placement is stored in
     let outer = window.outer_size();
     let (clamped_x, clamped_y) =
         clamp_position_to_visible(event_loop, abs_x, abs_y, outer.width, outer.height);
@@ -97,7 +97,7 @@ pub fn apply_placement(
 /// [`exhale_core::Settings`].  Position is stored as an offset
 /// relative to the monitor the window's centre currently lies on, so
 /// a saved placement survives the monitor being moved in the OS
-/// display-arrangement panel.
+/// display-arrangement panel
 pub fn capture_placement(
     event_loop: &ActiveEventLoop,
     window:     &Window,
@@ -107,10 +107,10 @@ pub fn capture_placement(
     // The settings window persists its height in LOGICAL points (so
     // a 2x display doesn't re-apply scale on next launch).  This
     // helper persists in PHYSICAL pixels, which is fine for the
-    // animation window — the next launch's monitor will have the
+    // animation window: the next launch's monitor will have the
     // same physical pixel dimensions, and DPI-affected windows can
     // override `width` / `height` via the placement they pass back
-    // through `set_*_window_placement`.
+    // through `set_*_window_placement`
     let (x, y, screen) = current_monitor_offset(event_loop, &outer, &inner);
 
     WindowPlacement {
@@ -147,7 +147,7 @@ pub fn capture_placement_logical_height(
 
 /// Find the monitor the window's centre currently sits on, then
 /// return position as an offset relative to that monitor's origin
-/// plus the monitor's name (for serialisation).
+/// plus the monitor's name (for serialisation)
 fn current_monitor_offset(
     event_loop: &ActiveEventLoop,
     outer:      &PhysicalPosition<i32>,
@@ -173,12 +173,12 @@ fn current_monitor_offset(
 // ─── Clamp helpers ────────────────────────────────────────────────────────────
 
 /// Return `(x, y)` adjusted so the window rectangle is fully contained
-/// inside one of the available monitors.
+/// inside one of the available monitors
 ///
 /// Algorithm: pick the monitor closest to the window's center point
 /// (zero distance when the center is already inside a monitor; positive
 /// distance when off-screen).  Then clamp `(x, y)` so the entire window
-/// rect fits inside that monitor's bounds.
+/// rect fits inside that monitor's bounds
 ///
 /// Handles every shape of "saved position is no longer good":
 ///   - Window dragged partially off-screen by accident, then reopened:
@@ -227,12 +227,12 @@ pub(crate) fn clamp_position_against_monitors(
     (nx, ny)
 }
 
-/// Cross-platform safety net for the persisted-position restore path:
-/// a user who quit exhale on a laptop+external setup and re-opens it
+/// Cross-platform safety net for the persisted-position restore path: a
+/// user who quit exhale on a laptop+external setup and re-opens it
 /// on the laptop alone can land with the saved coords pointing
 /// firmly off-screen (the old external display's coordinate space no
 /// longer exists).  Falls through to [`clamp_position_against_monitors`]
-/// after collecting the live monitor list from `event_loop`.
+/// after collecting the live monitor list from `event_loop`
 pub fn clamp_position_to_visible(
     event_loop: &ActiveEventLoop,
     x: i32, y: i32, width: u32, height: u32,

--- a/rust/crates/exhale-app/src/platform.rs
+++ b/rust/crates/exhale-app/src/platform.rs
@@ -1,20 +1,20 @@
-//! Platform-specific overlay / settings window setup.
+//! Platform-specific overlay / settings window setup
 //!
 //! Public surface (identical on every target so main.rs doesn't need cfgs):
 //!   - `setup_overlay_window`: make window click-through, always-on-top,
-//!     spans every workspace/Space.
-//!   - `setup_settings_window`: float above overlay, don't appear in taskbar.
-//!   - `apply_app_visibility`: TopBarOnly/DockOnly/Both (tray vs taskbar).
-//!   - `request_notification_permission`: no-op off macOS.
-//!   - `register_reopen_handler`: no-op off macOS.
-//!   - `DOCK_REOPEN`: atomic flag (always defined; only macOS sets it).
+//!     spans every workspace/Space
+//!   - `setup_settings_window`: float above overlay, don't appear in taskbar
+//!   - `apply_app_visibility`: TopBarOnly/DockOnly/Both (tray vs taskbar)
+//!   - `request_notification_permission`: no-op off macOS
+//!   - `register_reopen_handler`: no-op off macOS
+//!   - `DOCK_REOPEN`: atomic flag (always defined; only macOS sets it)
 //!
 //! The per-OS implementations live in submodules
-//! (`platform/{mac,win,linux}.rs`).  This file is the API layer:
-//! it owns the cross-platform globals, declares the submodules
+//! (`platform/{mac,win,linux}.rs`).  This file is the API layer: it
+//! owns the cross-platform globals, declares the submodules
 //! conditionally, re-exports the right submodule's symbols, and
 //! supplies no-op stubs for symbols that only exist on a subset of
-//! platforms.  That keeps `main.rs` and `settings_window.rs` cfg-free.
+//! platforms.  That keeps `main.rs` and `settings_window.rs` cfg-free
 
 use std::sync::atomic::AtomicBool;
 
@@ -23,15 +23,16 @@ use exhale_core::types::AppVisibility;
 #[allow(unused_imports)]
 use winit::window::Window;
 
-/// Set when the macOS Dock icon is clicked while the app is already running.
-/// Defined unconditionally so callers don't need `cfg` around the read.
+/// Set when the macOS Dock icon is clicked while the app is already
+/// running; defined unconditionally so callers don't need `cfg` around
+/// the read
 pub static DOCK_REOPEN: AtomicBool = AtomicBool::new(false);
 
 /// True after `install_settings_vibrancy` has successfully attached a blur
 /// effect to the settings window on the current platform (macOS VEV
 /// child-window, Windows DWM acrylic, Linux KDE blur-behind).  Read from
 /// the egui render path so we know whether to clear at alpha 0 + paint
-/// transparent panels (blur active) or fall back to opaque rendering.
+/// transparent panels (blur active) or fall back to opaque rendering
 static BLUR_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Public read-side accessor for [`BLUR_ACTIVE`].
@@ -79,13 +80,13 @@ pub use linux::{
 // ─── Cross-platform stubs for symbols that only exist on a subset of OSes ────
 
 /// Non-macOS stub for `install_main_menu`.  Windows and Linux apps
-/// don't have a unified menu-bar concept — the settings window's own
-/// in-window controls are the UI surface there.
+/// don't have a unified menu-bar concept: the settings window's own
+/// in-window controls are the UI surface there
 #[cfg(not(target_os = "macos"))]
 pub fn install_main_menu() {}
 
-/// Non-macOS stub for `render_sf_symbol` — SF Symbols are AppKit-only.
-/// Callers fall back to Unicode glyphs when this returns `None`.
+/// Non-macOS stub for `render_sf_symbol`: SF Symbols are AppKit-only;
+/// callers fall back to Unicode glyphs when this returns `None`
 #[cfg(not(target_os = "macos"))]
 pub fn render_sf_symbol(_name: &str, _point_size: f64, _dark_mode: bool) -> Option<(Vec<u8>, u32, u32)> {
     None
@@ -93,21 +94,21 @@ pub fn render_sf_symbol(_name: &str, _point_size: f64, _dark_mode: bool) -> Opti
 
 /// Non-Windows no-op for `reassert_overlay_topmost`.  Only Windows
 /// orders topmost-windows by activation in a way that lets a newly-
-/// opened app rise above ours — macOS pins by window level, Linux X11
+/// opened app rise above ours; macOS pins by window level, Linux X11
 /// pins by EWMH state, neither needs periodic re-assertion.  Callers
 /// are themselves cfg-gated to Windows (see `App::maybe_reassert_topmost`
 /// and the `topmost_deadline` wake schedule in `about_to_wait`), so
 /// this stub is only used in the rare cross-platform code path that
 /// shouldn't ever fire.  `allow(dead_code)` because the call sites
 /// are walled off by cfg and the linter can't see they don't exist
-/// on this target.
+/// on this target
 #[cfg(not(target_os = "windows"))]
 #[allow(dead_code)]
 pub fn reassert_overlay_topmost(_window: &winit::window::Window) {}
 
 // ─── Opening a URL in the user's browser ─────────────────────────────────────
 
-/// Hand `url` to the user's default browser.
+/// Hand `url` to the user's default browser
 ///
 /// This is the only outbound-link path in the app, so the scheme
 /// check lives here rather than at each call site: anything that
@@ -116,8 +117,8 @@ pub fn reassert_overlay_topmost(_window: &winit::window::Window) {}
 /// happily launch a local executable for a `file:` URL, and
 /// `xdg-open` will hand an arbitrary scheme to whatever handler
 /// claims it, so the allowlist is load-bearing rather than
-/// decorative — even though every current caller passes a
-/// compile-time constant.
+/// decorative, even though every current caller passes a
+/// compile-time constant
 ///
 /// Best-effort by design.  A machine with no browser, no
 /// `xdg-open`, or a refused `NSWorkspace` open is a fully working
@@ -138,12 +139,12 @@ pub fn open_url(url: &str) {
 }
 
 /// The allowlist [`open_url`] enforces, split out so it can be tested
-/// without launching a browser.
+/// without launching a browser
 ///
 /// Rejecting on the whole `https://` prefix (rather than "starts with
 /// http") also rules out `https:/evil` and scheme-relative junk, and
 /// the control-character check keeps anything unprintable out of a
-/// command argument on the Linux path.  There is deliberately no
+/// command argument on the Linux path.  There's deliberately no
 /// `http://` escape hatch: every destination this app links to is a
 /// GitHub URL that redirects to TLS anyway
 fn is_openable(url: &str) -> bool {
@@ -187,7 +188,7 @@ mod tests {
             crate::tray::RESEARCH_URL.ends_with("#gaps-and-unsupported-choices"),
             "the anchor is the feature: pointing at the top of CITATIONS.md \
              lands the reader in 48 references instead of the fourteen \
-             things they do not support"
+             things they don't support"
         );
     }
 }

--- a/rust/crates/exhale-app/src/platform/linux.rs
+++ b/rust/crates/exhale-app/src/platform/linux.rs
@@ -1,15 +1,15 @@
-//! Linux (X11) implementation of the platform layer.
-//! See the parent `platform` module for the public API surface and
-//! cross-platform stubs.
+//! Linux (X11) implementation of the platform layer; see the parent
+//! `platform` module for the public API surface and cross-platform
+//! stubs
 
 use super::*;
 
     use std::ffi::CString;
     use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
     // x11-dl's `x11_link!` macro generates a type named `Xlib` in every
-    // module it's invoked in (including `xfixes`), so the Xfixes handle is
-    // `x11_dl::xfixes::Xlib`, not `x11_dl::xfixes::Xfixes`. Alias it for
-    // readability.
+    // module it's invoked in (including `xfixes`), so the Xfixes handle's
+    // real type is `x11_dl::xfixes::Xlib`; the intuitively-named
+    // `x11_dl::xfixes::Xfixes` doesn't exist.  Alias it for readability
     use x11_dl::{xfixes::Xlib as Xfixes, xlib::{Display, Xlib, XClientMessageEvent, XEvent, ClientMessage}};
 
     struct X11<'a> {
@@ -31,13 +31,13 @@ use super::*;
             // byte-string literal; none contain interior NULs.  If a
             // future caller passes user input here, `CString::new`
             // returning `Err` would yield `Atom(0)` (the X11 sentinel
-            // for "no such atom") rather than panicking — same as
-            // any other lookup miss.
+            // for "no such atom") rather than panicking, same as
+            // any other lookup miss
             let Ok(c) = CString::new(name) else { return 0; };
             unsafe { (self.xlib.XInternAtom)(self.display, c.as_ptr(), 0) }
         }
 
-        /// ClientMessage to root for `_NET_WM_STATE_{ADD,REMOVE}`.
+        /// ClientMessage to root for `_NET_WM_STATE_{ADD,REMOVE}`
         fn set_wm_state(&self, atom_name: &[u8], add: bool) {
             let state_atom = self.atom(b"_NET_WM_STATE");
             let target     = self.atom(atom_name);
@@ -66,12 +66,12 @@ use super::*;
             }
         }
 
-        /// Empty input-region via XFixes = click-through.
+        /// Empty input-region via XFixes = click-through
         fn set_click_through(&self) {
             let Some(xfixes) = self.xfixes else { return; };
             unsafe {
                 let region = (xfixes.XFixesCreateRegion)(self.display, std::ptr::null_mut(), 0);
-                // ShapeInput = 2 per XFixes spec.
+                // ShapeInput = 2 per XFixes spec
                 (xfixes.XFixesSetWindowShapeRegion)(
                     self.display, self.window, 2, 0, 0, region,
                 );
@@ -107,10 +107,10 @@ use super::*;
         // the panel / dock on EWMH-compliant window managers.  Without
         // it, GNOME-Shell / Mutter / Xfwm reserve the dock area and
         // force our window into the work-area rectangle, leaving a
-        // visible gap where the dock sits — even when we requested
+        // visible gap where the dock sits, even when we requested
         // monitor-spanning geometry from winit.  `_NET_WM_STATE_ABOVE`
         // (kept below) is for stacking against other normal windows;
-        // FULLSCREEN is for covering struts / panels.
+        // FULLSCREEN is for covering struts / panels
         x.set_wm_state(b"_NET_WM_STATE_FULLSCREEN",   true);
         x.set_wm_state(b"_NET_WM_STATE_ABOVE",        true);
         x.set_wm_state(b"_NET_WM_STATE_STICKY",       true);
@@ -121,50 +121,50 @@ use super::*;
     pub fn setup_settings_window(window: &Window) {
         // Mark the settings window `_NET_WM_STATE_ABOVE` so it can rise
         // above the breathing overlay (also `ABOVE`).  X11 has no
-        // explicit window levels — among `ABOVE` windows, activation
+        // explicit window levels: among `ABOVE` windows, activation
         // order determines z-stacking, so opening preferences activates
         // it and brings it forward.  Without this hint, EWMH-compliant
         // window managers permanently order the overlay (which is
         // ABOVE) on top of the settings (NORMAL), even when settings is
         // focused.  Wayland compositors that ignore EWMH will fall back
-        // to their own stacking — documented limitation, same as the
-        // overlay's click-through hint.
+        // to their own stacking, documented limitation, same as the
+        // overlay's click-through hint
         //
         // `apply_app_visibility` still handles `SKIP_TASKBAR/SKIP_PAGER`
-        // for the Top-Bar-only mode, independent of this hint.
+        // for the Top-Bar-only mode, independent of this hint
         let Some(xwin) = x11_window(window) else { return; };
         let Ok(xlib)   = Xlib::open() else { return; };
         let Some(x)    = X11::open(&xlib, None, xwin) else { return; };
         x.set_wm_state(b"_NET_WM_STATE_ABOVE", true);
     }
 
-    /// No-op on Linux: the settings window is OPAQUE on every Linux DE.
+    /// No-op on Linux: the settings window is OPAQUE on every Linux DE;
     /// KDE/KWin's `_KDE_NET_WM_BLUR_BEHIND_REGION` would give a frosted
     /// settings window on Plasma but produces the same compositing
     /// regressions seen on Windows DWM acrylic (overlay stacking above
     /// the controls, mouse-hover lag).  `BLUR_ACTIVE` stays `false`, so
     /// the egui clear colour + panel fill render the themed solid
     /// background.  macOS is the only platform with a translucent
-    /// settings backdrop.
+    /// settings backdrop
     pub fn install_settings_vibrancy(_window: &Window, _dark_mode: bool) -> usize {
         0
     }
 
-    /// No theme-dependent state to update on X11 — KDE follows the
-    /// system theme automatically once the blur property is set.
+    /// No theme-dependent state to update on X11: KDE follows the
+    /// system theme automatically once the blur property is set
     pub fn update_settings_vibrancy(_vev_ptr: usize, _dark_mode: bool) {}
 
-    /// No-op on X11 (no backdrop window to keep in sync — the blur
-    /// region attaches to the settings window itself).
+    /// No-op on X11 (no backdrop window to keep in sync: the blur
+    /// region attaches to the settings window itself)
     pub fn sync_settings_backdrop_frame(_backdrop_ptr: usize) {}
 
-    /// No-op on Linux — `install_settings_vibrancy` returned 0, no
+    /// No-op on Linux: `install_settings_vibrancy` returned 0, no
     /// backdrop NSWindow to release.  KDE blur attaches to the
-    /// settings window itself and is cleaned up when the window drops.
+    /// settings window itself and is cleaned up when the window drops
     pub fn uninstall_settings_vibrancy(_backdrop_ptr: usize) {}
 
     pub fn request_notification_permission() {
-        // D-Bus org.freedesktop.Notifications needs no per-app permission.
+        // D-Bus org.freedesktop.Notifications needs no per-app permission
     }
 
     pub fn register_reopen_handler() { /* no analog */ }
@@ -181,13 +181,13 @@ use super::*;
     }
 
     /// Linux half of [`super::open_url`].  Scheme validation happens
-    /// in the caller.
+    /// in the caller
     ///
     /// `xdg-open` is the desktop-agnostic handler every target
     /// desktop ships, and `snapcraft.yaml` already plugs `desktop`,
     /// which is what makes it reachable from inside the snap
-    /// confinement.  The URL goes through `Command::arg`, not a
-    /// shell, so it is never word-split or expanded.
+    /// confinement.  The URL goes through `Command::arg`, bypassing
+    /// the shell entirely, so it's never word-split or expanded
     ///
     /// We `spawn` rather than `status` so a browser cold-start can't
     /// stall the event loop.  That leaves the child unreaped until

--- a/rust/crates/exhale-app/src/platform/mac.rs
+++ b/rust/crates/exhale-app/src/platform/mac.rs
@@ -1,55 +1,55 @@
-//! macOS implementation of the platform layer.
-//! See the parent `platform` module for the public API surface and
-//! cross-platform stubs.
+//! macOS implementation of the platform layer; see the parent
+//! `platform` module for the public API surface and cross-platform
+//! stubs
 
 use super::*;
 
 
-    // ─── AppKit constants — named here so the call sites read like the
-    //     Apple docs rather than as bare ints.
+    // ─── AppKit constants: named here so the call sites read like the
+    //     Apple docs rather than as bare ints
 
-    /// `NSScreenSaverWindowLevel` — overlay floats just below the
+    /// `NSScreenSaverWindowLevel`: overlay floats just below the
     /// screensaver layer, above fullscreen apps.  Matches Swift's
-    /// `NSWindow.Level.screenSaver.rawValue` (`1000`).
+    /// `NSWindow.Level.screenSaver.rawValue` (`1000`)
     const NS_WINDOW_LEVEL_SCREEN_SAVER:  NSWindowLevel = 1000;
     /// Settings window sits one level above the overlay so it
-    /// remains visible at any `overlay_opacity` — including 1.0,
+    /// remains visible at any `overlay_opacity`, including 1.0,
     /// where the user would otherwise be stuck unable to see the
     /// controls to lower opacity or quit the app.  Popup menus
     /// would normally hide behind a window at this level, so
     /// [`register_menu_tracking_observer`] raises any
     /// `NSPopUpMenuWindowLevel` window above settings while it's
-    /// tracking — modifying the menu's own NSWindow rather than the
+    /// tracking: modifying the menu's own NSWindow rather than the
     /// settings NSWindow, which keeps NSMenu from interpreting the
     /// reorder as a focus-loss and cancelling tracking
     const NS_WINDOW_LEVEL_SETTINGS:      NSWindowLevel = 1001;
 
-    /// `NSVisualEffectMaterial.popover` (6) — neutral dark blur, used
+    /// `NSVisualEffectMaterial.popover` (6): neutral dark blur, used
     /// behind the settings panel in Dark mode
     const VEV_MATERIAL_POPOVER:          i64 = 6;
-    /// `NSVisualEffectMaterial.hudWindow` (8) — strong blur with
+    /// `NSVisualEffectMaterial.hudWindow` (8): strong blur with
     /// subtle tint, used in Light mode
     const VEV_MATERIAL_HUD_WINDOW:       i64 = 8;
-    /// `NSVisualEffectBlendingMode.behindWindow` (0) — composite the
-    /// blur against whatever is behind the VEV's window, not behind
-    /// the VEV inside its window
+    /// `NSVisualEffectBlendingMode.behindWindow` (0): composite the
+    /// blur against whatever is behind the VEV's window; `withinWindow`
+    /// mode would blur sibling content inside its own window instead
     const VEV_BLENDING_BEHIND_WINDOW:    i64 = 0;
-    /// `NSVisualEffectState.active` (1) — always render the full blur
+    /// `NSVisualEffectState.active` (1): always render the full blur
     /// regardless of window-key state.  Required because the backdrop
     /// is `ignoresMouseEvents` + borderless, so it can never become
     /// key (and `followsWindowActiveState` would render an inactive
     /// flat appearance forever)
     const VEV_STATE_ACTIVE:              i64 = 1;
-    /// `NSAutoresizingMaskOptions.{width,height}Sizable` = 2 | 16 = 18
-    /// — VEV fills its superview as the backdrop resizes
+    /// `NSAutoresizingMaskOptions.{width,height}Sizable` = 2 | 16 = 18,
+    /// so the VEV fills its superview as the backdrop resizes
     const VEV_AUTORESIZE_WIDTH_HEIGHT:   u64 = 18;
 
-    /// `NSCompositingOperation.sourceAtop` (5) — used to tint a
+    /// `NSCompositingOperation.sourceAtop` (5): used to tint a
     /// rasterised SF Symbol while preserving its alpha channel
     const NS_COMPOSITING_SOURCE_ATOP:    i64 = 5;
     /// `NSImageResizingMode.stretch` (1)
     const NS_IMAGE_RESIZING_STRETCH:     i64 = 1;
-    /// `NSBitmapFormat.alphaNonpremultiplied` (2) — matches egui's
+    /// `NSBitmapFormat.alphaNonpremultiplied` (2): matches egui's
     /// `from_rgba_unmultiplied` expectation
     const NS_BITMAP_ALPHA_NONPREMULT:    u64 = 2;
     /// `UNAuthorizationOptions.alert | .sound` (4 | 2 = 6)
@@ -59,7 +59,7 @@ use super::*;
 
     /// Look up the `NSWindow` hosting a winit window.  Returns `None`
     /// when the window's raw handle isn't an AppKit one (shouldn't
-    /// happen on macOS in practice, but the winit API permits it).
+    /// happen on macOS in practice, but the winit API permits it)
     ///
     /// Uses objc2's typed bindings so the caller gets a
     /// `Retained<NSWindow>` that auto-releases on drop and method
@@ -69,17 +69,17 @@ use super::*;
         use objc2_app_kit::{NSView, NSWindow};
         use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
-        // `window_handle()` is fallible — a closed/destroyed window
-        // during cleanup returns `Err(HandleError::Unavailable)`.
-        // Treat that as "no NSWindow available" rather than panicking,
+        // `window_handle()` is fallible: a closed/destroyed window
+        // during cleanup returns `Err(HandleError::Unavailable)`;
+        // treat that as "no NSWindow available" rather than panicking,
         // so platform helpers called from shutdown paths degrade
-        // gracefully.
+        // gracefully
         let handle = window.window_handle().ok()?;
         let RawWindowHandle::AppKit(h) = handle.as_raw() else { return None; };
         // SAFETY: winit guarantees the NSView pointer is valid for the
         // lifetime of the winit Window we're borrowing from.  `window`
         // on NSView returns the hosting NSWindow (the receiver-typed
-        // dispatch via objc2 retains the result for us).
+        // dispatch via objc2 retains the result for us)
         unsafe {
             let ns_view: *mut NSView = h.ns_view.as_ptr() as *mut NSView;
             let win: Option<objc2::rc::Retained<NSWindow>> = msg_send![ns_view, window];
@@ -91,7 +91,7 @@ use super::*;
         use objc2_app_kit::NSWindowCollectionBehavior;
 
         let Some(ns_win) = get_ns_window(window) else { return; };
-        // Float above fullscreen apps, join every Space, stay out of Cmd+Tab.
+        // Float above fullscreen apps, join every Space, stay out of Cmd+Tab
         let behavior = NSWindowCollectionBehavior::CanJoinAllSpaces
             | NSWindowCollectionBehavior::IgnoresCycle
             | NSWindowCollectionBehavior::FullScreenAuxiliary;
@@ -102,8 +102,8 @@ use super::*;
         // compositor renders the shadow along the visible-alpha boundaries
         // of our transparent overlay (i.e. wherever the breathing shape
         // fades into transparency), which shows up as a thin grey line at
-        // the top + bottom of the rectangle / outer edge of the circle.
-        // Pre-Tahoe this default shadow was effectively invisible on a
+        // the top + bottom of the rectangle / outer edge of the circle;
+        // pre-Tahoe this default shadow was effectively invisible on a
         // borderless transparent window; the new compositor is more
         // aggressive about painting it. Same fix as the settings backdrop
         // window uses (`install_settings_vibrancy`)
@@ -111,10 +111,10 @@ use super::*;
     }
 
     pub fn setup_settings_window(window: &Window) {
-        // Window level only — the vibrancy install runs post-wgpu-surface via
+        // Window level only: the vibrancy install runs post-wgpu-surface via
         // `install_settings_vibrancy` so we don't re-parent winit's NSView
         // before its CAMetalLayer has been attached (which would crash wgpu
-        // with a 0×0 initial drawable and a detached layer hierarchy).
+        // with a 0×0 initial drawable and a detached layer hierarchy)
         let Some(ns_win) = get_ns_window(window) else { return; };
         ns_win.setLevel(NS_WINDOW_LEVEL_SETTINGS);
         // Settings sits at 1001 to stay visible above the overlay at
@@ -129,7 +129,7 @@ use super::*;
     /// Idempotently install an `ExhaleMenuTracker` observer that
     /// hoists every popup-menu window above the settings window the
     /// moment it begins tracking.  Modifies the MENU's own NSWindow
-    /// rather than the settings NSWindow — mutating settings
+    /// rather than the settings NSWindow: mutating settings
     /// mid-tracking caused NSMenu to interpret the resulting
     /// window-order event as a focus loss and immediately cancel
     /// tracking ("menu needs three clicks to stick" regression),
@@ -142,14 +142,14 @@ use super::*;
         use std::sync::Once;
 
         /// Walk every visible NSWindow owned by this app and promote
-        /// anything below the overlay (level 1000) up to 1002 — past
+        /// anything below the overlay (level 1000) up to 1002, past
         /// the settings window at 1001.  Status-bar popup menus on
         /// macOS don't necessarily open at the nominal
         /// `NSPopUpMenuWindowLevel` (101); some AppKit revisions
         /// route them through a different NSCarbonMenuWindow
         /// instance whose level depends on the status item's owning
-        /// menu bar.  A precise `level == 101` filter missed those.
-        /// Broad sweep matches the menu regardless of which level
+        /// menu bar.  A precise `level == 101` filter missed those;
+        /// broad sweep matches the menu regardless of which level
         /// AppKit chose, while still leaving our own windows
         /// (overlay 1000, settings 1001, reset alert / about panel
         /// 1002) untouched
@@ -171,8 +171,8 @@ use super::*;
 
                 // Diagnostic: identify the window's class name via
                 // the documented `class_getName(Class)` runtime
-                // function — NOT via `[class name]`, which isn't a
-                // standard Class method.  An earlier revision used
+                // function, the correct API since `[class name]`
+                // isn't a standard Class method.  An earlier revision used
                 // `msg_send![cls, name]` and crashed because the
                 // bogus selector returned register garbage that got
                 // reinterpreted as a C string pointer and panicked
@@ -191,9 +191,9 @@ use super::*;
                 log::debug!("menu tracker: visible NSWindow class={cls_str} level={level}");
 
                 // Skip our own windows: overlay (1000), settings
-                // (1001), reset alert / about panel (1002).
-                // Anything else that's visible and below 1000 is a
-                // popup of some flavour — promote it
+                // (1001), reset alert / about panel (1002);
+                // anything else that's visible and below 1000 is a
+                // popup of some flavour: promote it
                 if level < 1000 {
                     let _: () = msg_send![win, setLevel: 1002_i64];
                     raised += 1;
@@ -213,7 +213,7 @@ use super::*;
 
         static INIT: Once = Once::new();
         INIT.call_once(|| unsafe {
-            // Allocate `ExhaleMenuTracker` NSObject subclass — same
+            // Allocate `ExhaleMenuTracker` NSObject subclass: same
             // pattern as `ExhaleAEHandler` (dock reopen) and
             // `ExhaleMenuHandler` (about-panel options), avoiding
             // any swizzle of system classes for MAS-review safety
@@ -232,14 +232,14 @@ use super::*;
             // Type encoding `v@:@` = void return, (self, _cmd,
             // NSNotification* notif).  AppKit's notification payload
             // would let us inspect the specific NSMenu, but we
-            // don't need to — every popup menu in the app gets the
+            // don't need to: every popup menu in the app gets the
             // same level-promotion treatment
             let begin_sel = objc2::sel!(menuDidBeginTracking:);
             let begin_imp: objc2::runtime::Imp = std::mem::transmute(handle_menu_begin as *const ());
             objc2::ffi::class_addMethod(new_cls as *mut _, begin_sel, begin_imp, c"v@:@".as_ptr());
             objc2::ffi::objc_registerClassPair(new_cls as *mut _);
 
-            // Leak the instance — NSNotificationCenter retains
+            // Leak the instance: NSNotificationCenter retains
             // observers weakly, so a Rust-side drop here would mean
             // a dead observer on the next menu open
             let instance: *mut AnyObject = msg_send![new_cls, alloc];
@@ -260,10 +260,11 @@ use super::*;
             }
 
             // Subscribe to `NSMenuDidBeginTrackingNotification` with
-            // `object: null` — match against ANY NSMenu in the app,
-            // not just the tray's, so the Apple menu / Edit menu /
-            // Window menu / submenus all get the same treatment.
-            // No corresponding end-tracking observer — the menu's
+            // `object: null`: match against every NSMenu in the app
+            // so the Apple menu / Edit menu / Window menu / submenus
+            // all get the same treatment
+            //
+            // No corresponding end-tracking observer: the menu's
             // NSWindow is OS-managed; AppKit destroys or recycles
             // it on close, so there's nothing to restore
             let begin_name = NSString::from_str("NSMenuDidBeginTrackingNotification");
@@ -278,18 +279,18 @@ use super::*;
     }
 
     /// Reconstruct a `Retained<NSWindow>` from a backdrop pointer the
-    /// caller stashed via [`install_settings_vibrancy`] as a `usize`.
-    /// Returns `None` for the zero sentinel (no backdrop was installed
-    /// — env-disabled blur path) or if the runtime says the pointer
-    /// can't be retained (very rare; would mean the object was
-    /// somehow already released).
+    /// caller stashed via [`install_settings_vibrancy`] as a `usize`;
+    /// returns `None` for the zero sentinel (no backdrop was
+    /// installed, env-disabled blur path) or if the runtime says the
+    /// pointer can't be retained (rare; would mean the object was
+    /// somehow already released)
     ///
     /// SAFETY: relies on the invariant that the only producer of these
     /// `usize` values is `install_settings_vibrancy` (which writes a
     /// +1-retained NSWindow*), and that the parent settings window
     /// hasn't been dropped (it owns the child via
     /// `addChildWindow:ordered:`, so as long as `SettingsWindow` is
-    /// alive, the backdrop is too).
+    /// alive, the backdrop is too)
     fn backdrop_from_ptr(backdrop_ptr: usize) -> Option<objc2::rc::Retained<objc2_app_kit::NSWindow>> {
         if backdrop_ptr == 0 { return None; }
         // SAFETY: `backdrop_ptr` is the value written by
@@ -297,15 +298,15 @@ use super::*;
         // which leaves a +1 retain on a valid `NSWindow*`.  The
         // window lives as long as the parent settings window
         // (added via `addChildWindow:ordered:`), and the parent
-        // window outlives every call site here — `SettingsWindow`
+        // window outlives every call site here: `SettingsWindow`
         // owns the `usize` in `vev_ptr` and zeros it in `Drop`
         // before the parent NSWindow itself releases, so any
         // non-zero pointer reaching this line is guaranteed to
-        // still point at a valid retained NSWindow.
-        // `Retained::retain` adds a +1 to that retain count;
-        // dropping the returned `Retained` later releases it.
-        // The cast `usize → *mut NSWindow` is just a numeric
-        // round-trip — `usize` is the same width as `*mut _` on
+        // still point at a valid retained NSWindow;
+        // `Retained::retain` adds a +1 to that retain count, and
+        // dropping the returned `Retained` later releases it.  The
+        // cast `usize -> *mut NSWindow` is just a numeric
+        // round-trip: `usize` is the same width as `*mut _` on
         // every macOS target we support
         unsafe { objc2::rc::Retained::retain(backdrop_ptr as *mut objc2_app_kit::NSWindow) }
     }
@@ -314,7 +315,7 @@ use super::*;
     /// appearance when the system theme changes.  Called from the settings
     /// window's render loop when `window.theme()` reports a different value
     /// than before.  `backdrop_ptr` is the NSWindow* returned by
-    /// `install_settings_vibrancy`.
+    /// `install_settings_vibrancy`
     pub fn update_settings_vibrancy(backdrop_ptr: usize, dark_mode: bool) {
         use objc2::msg_send;
         use objc2::runtime::AnyObject;
@@ -327,16 +328,16 @@ use super::*;
         // parity uses `.hudWindow` for both dark and light).  The
         // appearance + theme-aware material lookup happens via the
         // raw `setMaterial:` dispatch below using the int-coded
-        // `VEV_MATERIAL_*` constants — split dark/light there if
-        // future tweaks need divergent materials.
+        // `VEV_MATERIAL_*` constants: split dark/light there if
+        // future tweaks need divergent materials
 
         unsafe {
             // NSVisualEffectView lives in the AppKit binding crate but
-            // `contentView` returns the more generic NSView — we need a
+            // `contentView` returns the more generic NSView: we need a
             // typed downcast or message send.  The setMaterial: selector
             // exists on NSVisualEffectView only, so dispatch directly
             // through the raw object pointer (typed AppKit method
-            // lookups don't include this selector on NSView).
+            // lookups don't include this selector on NSView)
             let vev_obj: *const AnyObject = &*vev as *const _ as *const AnyObject;
             let mat_raw: i64 = if dark_mode { VEV_MATERIAL_POPOVER } else { VEV_MATERIAL_HUD_WINDOW };
             let _: () = msg_send![vev_obj, setMaterial: mat_raw];
@@ -350,7 +351,7 @@ use super::*;
                 // `setAppearance:` comes from the NSAppearanceCustomization
                 // informal protocol; objc2-app-kit doesn't surface it on
                 // NSView's generated bindings, so dispatch through the
-                // raw object.
+                // raw object
                 let _: () = msg_send![vev_obj, setAppearance: &*appearance];
             }
         }
@@ -358,38 +359,38 @@ use super::*;
 
     /// Keep the backdrop NSWindow's frame in lockstep with its parent
     /// (the settings window).  macOS auto-tracks position for child
-    /// windows via `addChildWindow:ordered:`, but NOT size — we call this
-    /// on every `WindowEvent::Resized` to copy the parent's frame over.
+    /// windows via `addChildWindow:ordered:`, but NOT size: we call this
+    /// on every `WindowEvent::Resized` to copy the parent's frame over
     pub fn sync_settings_backdrop_frame(backdrop_ptr: usize) {
         let Some(backdrop) = backdrop_from_ptr(backdrop_ptr) else { return; };
         let Some(parent)   = backdrop.parentWindow() else { return; };
         let frame = parent.frame();
         // `display: true` so the VEV renders at the new size on this
-        // same frame — otherwise there's a one-frame lag where the blur
-        // rect doesn't track the window edge during a drag.
+        // same frame: otherwise there's a one-frame lag where the blur
+        // rect doesn't track the window edge during a drag
         backdrop.setFrame_display(frame, true);
     }
 
     /// Install a vibrancy effect behind the settings window by creating a
     /// second borderless NSWindow (the "backdrop"), anchoring it as a
     /// child of the settings window via `addChildWindow:ordered:NSWindowBelow`,
-    /// and using an NSVisualEffectView as the backdrop's contentView.
+    /// and using an NSVisualEffectView as the backdrop's contentView
     ///
     /// This gives us the same `.behindWindow` blur the Swift app has, but
-    /// the settings NSWindow itself is untouched — winit's NSView stays
+    /// the settings NSWindow itself is untouched: winit's NSView stays
     /// exactly where winit put it, so the `objc_loadWeakRetained` /
     /// `cursor_state.borrow_mut` crashes we saw with in-window reparenting
-    /// can't trigger.
+    /// can't trigger
     ///
     /// Returns the backdrop NSWindow pointer (or 0 on failure) so callers
     /// can:
     ///   • call `update_settings_vibrancy(ptr, dark)` on theme change
     ///   • call `sync_settings_backdrop_frame(ptr)` on resize (position
-    ///     auto-tracks via child-window, but size does not).
+    ///     auto-tracks via child-window, but size doesn't)
     ///
-    /// Opt-out: set `EXHALE_DISABLE_BLUR=1` to skip the backdrop window.
-    /// The window then uses the wgpu tinted-translucent look from
-    /// `clear_color_for_theme` alone.
+    /// Opt-out: set `EXHALE_DISABLE_BLUR=1` to skip the backdrop window;
+    /// the window then uses the wgpu tinted-translucent look from
+    /// `clear_color_for_theme` alone
     pub fn install_settings_vibrancy(window: &Window, dark_mode: bool) -> usize {
         use objc2::msg_send;
         use objc2::runtime::AnyObject;
@@ -406,32 +407,32 @@ use super::*;
 
         let Some(ns_win) = get_ns_window(window) else { return 0; };
         // SAFETY: install_settings_vibrancy runs from `SettingsWindow::new`
-        // on the winit event-loop thread, which is the macOS main thread.
+        // on the winit event-loop thread, which is the macOS main thread
         let mtm = unsafe { MainThreadMarker::new_unchecked() };
 
         unsafe {
             // Settings window itself: transparent + clear background so
             // wgpu's alpha passes through to whatever the compositor
             // chooses to render behind (in our case, the backdrop
-            // NSWindow's blurred VEV).
+            // NSWindow's blurred VEV)
             ns_win.setOpaque(false);
             ns_win.setBackgroundColor(Some(&NSColor::clearColor()));
 
             // Explicitly mark winit's NSView layer non-opaque.  wgpu-hal
             // calls `render_layer.set_opaque(false)` when the surface
             // alpha_mode is `PostMultiplied`, but that's been observed to
-            // sometimes get reset / not take effect — the layer stays
+            // sometimes get reset / not take effect: the layer stays
             // opaque and paints a solid rectangle over the backdrop
             // window, hiding the VEV blur completely.  Re-asserting
-            // `opaque = NO` here makes the transparency reliable.
+            // `opaque = NO` here makes the transparency reliable
             if let Ok(handle) = window.window_handle() {
                 if let RawWindowHandle::AppKit(h) = handle.as_raw() {
                     let ns_view: *mut NSView = h.ns_view.as_ptr() as *mut NSView;
                     if !ns_view.is_null() {
                         if let Some(layer) = (&*ns_view).layer() {
                             // CALayer's `setOpaque:` isn't surfaced as a
-                            // typed method on QuartzCore's binding either —
-                            // fall through to raw dispatch.
+                            // typed method on QuartzCore's binding
+                            // either: fall through to raw dispatch
                             let layer_obj: *const AnyObject =
                                 &*layer as *const _ as *const AnyObject;
                             let _: () = msg_send![layer_obj, setOpaque: false];
@@ -442,10 +443,10 @@ use super::*;
 
             // Use the settings window's current screen-space frame so the
             // backdrop starts out exactly overlapping.  AppKit then keeps
-            // position locked via addChildWindow; we lock size from Rust.
+            // position locked via addChildWindow; we lock size from Rust
             let frame: NSRect = ns_win.frame();
 
-            // NSBackingStoreBuffered, NSWindowStyleMaskBorderless.
+            // NSBackingStoreBuffered, NSWindowStyleMaskBorderless
             let backdrop = {
                 let alloc = mtm.alloc::<NSWindow>();
                 NSWindow::initWithContentRect_styleMask_backing_defer(
@@ -457,10 +458,10 @@ use super::*;
                 )
             };
 
-            // Behave like a passive backdrop — never steal focus, never
+            // Behave like a passive backdrop: never steal focus, never
             // eat events, no shadow duplication, follow the parent into
             // every Space.  `releasedWhenClosed = false` so the NSWindow
-            // survives hide/show cycles.
+            // survives hide/show cycles
             backdrop.setOpaque(false);
             backdrop.setBackgroundColor(Some(&NSColor::clearColor()));
             backdrop.setHasShadow(false);
@@ -468,19 +469,19 @@ use super::*;
             backdrop.setReleasedWhenClosed(false);
             // Match parent's window level (NS_WINDOW_LEVEL_SETTINGS = 1001
             // set by setup_settings_window) so addChildWindow ordering
-            // isn't fighting a level mismatch.
+            // isn't fighting a level mismatch
             backdrop.setLevel(ns_win.level());
             // CanJoinAllSpaces | FullScreenAuxiliary so the backdrop
-            // follows the parent across workspaces / fullscreen.
+            // follows the parent across workspaces / fullscreen
             backdrop.setCollectionBehavior(
                 NSWindowCollectionBehavior::CanJoinAllSpaces
                     | NSWindowCollectionBehavior::FullScreenAuxiliary,
             );
 
-            // NSVisualEffectView filling the backdrop's contentView.
-            // Material + blending + state mirror the old in-window install,
+            // NSVisualEffectView filling the backdrop's contentView;
+            // material + blending + state mirror the old in-window install,
             // except now it composites AppKit-natively against the desktop
-            // behind the backdrop window.
+            // behind the backdrop window
             let content_bounds = NSRect {
                 origin: NSPoint { x: 0.0, y: 0.0 },
                 size:   frame.size,
@@ -491,19 +492,19 @@ use super::*;
             };
 
             // Per-theme material:
-            //   Dark  → popover   (6)  — neutral, translucent blur.
-            //   Light → hudWindow (8)  — strong blur + subtle tint.
+            //   Dark -> popover   (6): neutral, translucent blur
+            //   Light -> hudWindow (8): strong blur + subtle tint
             let vev_obj: *const AnyObject = &*vev as *const _ as *const AnyObject;
             let material: i64 = if dark_mode { VEV_MATERIAL_POPOVER } else { VEV_MATERIAL_HUD_WINDOW };
             let _: () = msg_send![vev_obj, setMaterial:        material];
             let _: () = msg_send![vev_obj, setBlendingMode:    VEV_BLENDING_BEHIND_WINDOW];
-            // State must be `active` (1), not `followsWindowActiveState`
-            // (0).  The backdrop is an `ignoresMouseEvents` + borderless
-            // child window, so it can never become key; under
-            // `followsWindowActiveState` the VEV would render its
-            // INACTIVE (flat desaturated) appearance permanently,
+            // State must be `active` (1): the backdrop is an
+            // `ignoresMouseEvents` + borderless child window, so it can
+            // never become key; under `followsWindowActiveState` (0)
+            // the VEV would render its INACTIVE (flat desaturated)
+            // appearance permanently,
             // painting a solid grey under the transparent settings
-            // window above and looking identical to an opaque window.
+            // window above and looking identical to an opaque window;
             // CPU cost of always-active is bounded because the VEV
             // only covers the settings window's ~360x880 pt area
             let _: () = msg_send![vev_obj, setState:           VEV_STATE_ACTIVE];
@@ -512,7 +513,7 @@ use super::*;
             // Pin appearance explicitly: blocks AppKit's appearance
             // propagation through tracking-area / cursor-rect walkers
             // that can crash when they hit layer setups they weren't
-            // built to walk.
+            // built to walk
             let appearance_name = if dark_mode {
                 NSString::from_str("NSAppearanceNameDarkAqua")
             } else {
@@ -520,47 +521,47 @@ use super::*;
             };
             if let Some(appearance) = NSAppearance::appearanceNamed(&appearance_name) {
                 // `setAppearance:` lives on the NSAppearanceCustomization
-                // informal protocol, not on NSView's generated bindings.
+                // informal protocol; NSView's generated bindings don't surface it
                 let _: () = msg_send![vev_obj, setAppearance: &*appearance];
             }
 
-            // `setContentView:` typed binding accepts NSView (VEV is a subclass).
+            // `setContentView:` typed binding accepts NSView (VEV is a subclass)
             let vev_as_view: &NSView = &vev;
             backdrop.setContentView(Some(vev_as_view));
 
             // Apply a rounded-rect mask to the NSVisualEffectView so the
             // backdrop's blur clips to the same ~10 pt corner radius as
-            // the settings NSWindow above it — without this, the
+            // the settings NSWindow above it: without this, the
             // backdrop's borderless square corners poke past the
             // settings window's rounded bottom and the user sees a
-            // pointy-cornered blur rectangle behind the cards.
+            // pointy-cornered blur rectangle behind the cards
             //
             // NSVisualEffectView's documented hook for this is `maskImage`
             // (a 9-part stretchable NSImage whose alpha channel becomes
             // the clip mask).  We use this instead of `layer.cornerRadius`
             // because NSVisualEffectView rebuilds its internal layer
-            // hierarchy on resize and clobbers any cornerRadius we set —
-            // `maskImage` survives those rebuilds because it's a
-            // first-class VEV property the framework owns.
+            // hierarchy on resize and clobbers any cornerRadius we
+            // set: `maskImage` survives those rebuilds because it's a
+            // first-class VEV property the framework owns
             let mask = make_rounded_mask_image(10.0);
             if !mask.is_null() {
                 let _: () = msg_send![vev_obj, setMaskImage: mask];
                 // `make_rounded_mask_image` returned a +1-retained
                 // NSImage.  `setMaskImage:` is a retaining setter (the
                 // VEV now owns its own +1), so the caller's +1 is the
-                // leak — release it here.  Each settings-window
-                // install leaked one NSImage without this.
+                // leak: release it here.  Each settings-window
+                // install leaked one NSImage without this
                 let _: () = msg_send![mask, release];
             }
 
-            // NSWindowOrderingMode::Below = -1 — order the backdrop just
+            // NSWindowOrderingMode::Below = -1: order the backdrop just
             // under the settings window.  AppKit docs: "When invoked, if
             // the child window isn't visible, this method shows it as
-            // part of its ordering logic." — so no separate orderFront
+            // part of its ordering logic."; so no separate orderFront
             // call needed, and adding one before `addChildWindow` could
             // briefly put the backdrop IN FRONT of the settings window,
             // which would occlude the egui content until the next
-            // ordering pass.
+            // ordering pass
             ns_win.addChildWindow_ordered(&backdrop, NSWindowOrderingMode::Below);
 
             log::info!(
@@ -593,39 +594,39 @@ use super::*;
         // SAFETY: caller passes back exactly the pointer
         // `install_settings_vibrancy` returned, which is a +1-retained
         // NSWindow created with `init…`.  Reconstructing the Retained
-        // and letting it drop releases that refcount.
+        // and letting it drop releases that refcount
         let backdrop: objc2::rc::Retained<NSWindow> = unsafe {
             objc2::rc::Retained::from_raw(backdrop_ptr as *mut NSWindow)
                 .expect("uninstall_settings_vibrancy: pointer was non-null")
         };
 
         // Detach from parent so AppKit doesn't keep a strong reference
-        // via the child-windows array.  No-op if already detached.
+        // via the child-windows array.  No-op if already detached
         if let Some(parent) = backdrop.parentWindow() {
             parent.removeChildWindow(&backdrop);
         }
         backdrop.orderOut(None);
         super::set_blur_active(false);
-        // Retained drops here, releasing the original +1 from `into_raw`.
+        // Retained drops here, releasing the original +1 from `into_raw`
     }
 
     /// Rasterise an SF Symbol into a pixel buffer egui can upload as a
     /// texture.  Returns `(rgba_bytes, width_px, height_px)` on success
-    /// or `None` if the symbol isn't found / rasterisation fails.
+    /// or `None` if the symbol isn't found / rasterisation fails
     ///
     /// The bytes are interleaved RGBA, **non-premultiplied** alpha, 8
-    /// bits per channel — egui's `ColorImage::from_rgba_unmultiplied`
+    /// bits per channel: egui's `ColorImage::from_rgba_unmultiplied`
     /// can ingest them directly.  Drawing happens at 2× scale relative
     /// to `point_size` so the texture stays crisp on Retina displays;
     /// at egui-paint time the image is sized back down to its point
-    /// dimensions, and the GPU sampler handles the downsample.
+    /// dimensions, and the GPU sampler handles the downsample
     ///
     /// `dark_mode` controls the tint colour: white in dark, black in
-    /// light — matching `Color.primary` from SwiftUI's ControlButton.
-    /// We tint by drawing the symbol into a graphics context with
+    /// light, matching `Color.primary` from SwiftUI's ControlButton;
+    /// we tint by drawing the symbol into a graphics context with
     /// default `sourceOver`, then filling the same rect with the tint
     /// colour using `sourceAtop` so only the alpha-non-zero pixels of
-    /// the symbol get coloured in.
+    /// the symbol get coloured in
     pub fn render_sf_symbol(
         name: &str,
         point_size: f64,
@@ -671,25 +672,25 @@ use super::*;
             // hierarchical rendering by default (primary layer at full
             // opacity + secondary layer at ~45% opacity drawn on top),
             // which composites into a near-solid disk after our
-            // `SourceAtop` tint pass and hides the inner glyph cutout.
+            // `SourceAtop` tint pass and hides the inner glyph cutout;
             // `setTemplate:` is macOS 10.6+ so no runtime check is
             // needed; the resulting NSImage matches what SwiftUI's
             // `Image(systemName:)` with no explicit rendering mode
             // produces for the same symbol
             let _: () = msg_send![image, setTemplate: true];
 
-            // Render at 2x for Retina; egui downsamples at sample time.
+            // Render at 2x for Retina; egui downsamples at sample time
             let size: NSSize = msg_send![image, size];
             const SCALE: f64 = 2.0;
             let pixel_w = ((size.width  * SCALE).ceil() as u32).max(1);
             let pixel_h = ((size.height * SCALE).ceil() as u32).max(1);
 
-            // NSBitmapImageRep — `initWithBitmapDataPlanes:..:bitmapFormat:..`
+            // NSBitmapImageRep: `initWithBitmapDataPlanes:..:bitmapFormat:..`
             // variant lets us request `NSBitmapFormatAlphaNonpremultiplied`
             // (= 2), which is the format egui's `from_rgba_unmultiplied`
             // expects.  The default init (without bitmapFormat) gives
             // premultiplied alpha and would force us to unpremultiply
-            // every pixel after the fact.
+            // every pixel after the fact
             let cs_name = c"NSCalibratedRGBColorSpace".as_ptr();
             let space: *mut AnyObject = msg_send![
                 ns_string_cls, stringWithUTF8String: cs_name
@@ -710,22 +711,22 @@ use super::*;
             ];
             if rep.is_null() { return None; }
 
-            // Logical point size on the rep — drawing routines render at
-            // points and the rep's pixel buffer is 2× that.
+            // Logical point size on the rep: drawing routines render at
+            // points and the rep's pixel buffer is 2× that
             let _: () = msg_send![rep, setSize: size];
 
-            // Bind a graphics context backed by the rep, save state.
+            // Bind a graphics context backed by the rep, save state
             let ctx_cls = class!(NSGraphicsContext);
             let ctx: *mut AnyObject = msg_send![ctx_cls, graphicsContextWithBitmapImageRep: rep];
             if ctx.is_null() {
-                // Release the +1 retain from alloc/init before bailing.
+                // Release the +1 retain from alloc/init before bailing
                 let _: () = msg_send![rep, release];
                 return None;
             }
             let _: () = msg_send![ctx_cls, saveGraphicsState];
             let _: () = msg_send![ctx_cls, setCurrentContext: ctx];
 
-            // Draw the symbol.
+            // Draw the symbol
             let dst = NSRect {
                 origin: NSPoint { x: 0.0, y: 0.0 },
                 size,
@@ -734,7 +735,7 @@ use super::*;
 
             // Tint via `NSCompositingOperationSourceAtop` (= 5): fills
             // only the pixels the symbol drew into, preserving its alpha
-            // channel for anti-aliased edges.
+            // channel for anti-aliased edges
             let tint_color: *mut AnyObject = if dark_mode {
                 msg_send![class!(NSColor), whiteColor]
             } else {
@@ -745,10 +746,10 @@ use super::*;
             let path: *mut AnyObject = msg_send![class!(NSBezierPath), bezierPathWithRect: dst];
             let _: () = msg_send![path, fill];
 
-            // Restore.
+            // Restore
             let _: () = msg_send![ctx_cls, restoreGraphicsState];
 
-            // Pull bytes out.
+            // Pull bytes out
             let bitmap_data: *const u8 = msg_send![rep, bitmapData];
             if bitmap_data.is_null() {
                 let _: () = msg_send![rep, release];
@@ -757,13 +758,13 @@ use super::*;
             let total = (pixel_w * pixel_h * 4) as usize;
             let bytes = std::slice::from_raw_parts(bitmap_data, total).to_vec();
 
-            // Release the +1 retain we acquired via `alloc/init…`.
+            // Release the +1 retain we acquired via `alloc/init…`;
             // `graphicsContextWithBitmapImageRep:` only borrowed `rep`
             // for the duration of `saveGraphicsState`…`restoreGraphicsState`;
             // by the time we copy the bitmap bytes the GC is done with
             // it and the rep can drop.  Without this `release` each
             // call leaked one `NSBitmapImageRep` (~16 KB at 24 pt @ 2×),
-            // accumulating as the user opened the settings window.
+            // accumulating as the user opened the settings window
             let _: () = msg_send![rep, release];
 
             Some((bytes, pixel_w, pixel_h))
@@ -779,9 +780,9 @@ use super::*;
     /// bounds change: the four corners stay rounded at exactly `radius`
     /// pt while the four edges and the center stretch flat.  This is
     /// the same pattern Apple's own apps use for vibrancy with rounded
-    /// edges — survives VEV resize because the image is stored on the
+    /// edges: survives VEV resize because the image is stored on the
     /// VEV (not its layer) and AppKit re-applies the mask on every
-    /// re-layout.
+    /// re-layout
     unsafe fn make_rounded_mask_image(radius: f64) -> *mut objc2::runtime::AnyObject {
         use objc2::{class, msg_send};
         use objc2::runtime::AnyObject;
@@ -831,7 +832,7 @@ use super::*;
     /// Fallback setup used when `EXHALE_DISABLE_BLUR=1`.  Just makes the
     /// settings window transparent so the wgpu tinted clear colour is
     /// visible; no vibrancy, no child window.  Returns 0 so all the
-    /// vibrancy update/resize hooks are no-ops.
+    /// vibrancy update/resize hooks are no-ops
     fn setup_transparent_settings_window(window: &Window) -> usize {
         use objc2_app_kit::NSColor;
         let Some(ns_win) = get_ns_window(window) else { return 0; };
@@ -844,7 +845,7 @@ use super::*;
     // (these are aliased to `CGPoint` / `CGRect` underneath and already
     // implement `objc2::Encode` for free round-tripping).  `NSSize` is
     // available too but referenced only by callers via the typed-NSWindow
-    // methods.
+    // methods
     use objc2_foundation::{NSPoint, NSRect, NSSize};
 
     // `NSEdgeInsets` isn't in objc2-foundation's surface, so define it
@@ -867,16 +868,16 @@ use super::*;
     }
 
     /// `.alert` + `.sound` authorization request.  Matches Swift AppDelegate
-    /// `requestNotificationPermission()`.
+    /// `requestNotificationPermission()`
     pub fn request_notification_permission() {
         use block2::StackBlock;
         use objc2::msg_send;
         use objc2::runtime::{AnyClass, AnyObject};
 
-        // SAFETY: the framework class lookup is fallible — guard with
+        // SAFETY: the framework class lookup is fallible: guard with
         // `AnyClass::get` (returns `Option`) instead of `class!()` which
         // would panic if `UserNotifications.framework` isn't linked
-        // (typical for a non-bundled `cargo test` binary).
+        // (typical for a non-bundled `cargo test` binary)
         let Some(cls) = AnyClass::get(c"UNUserNotificationCenter") else { return; };
 
         unsafe {
@@ -884,14 +885,14 @@ use super::*;
             if center.is_null() { return; }
 
             let options = UN_AUTH_ALERT_AND_SOUND;
-            // Closure signature matches Apple's `void (^)(BOOL, NSError*)`.
-            // We don't surface the result anywhere; the user can retry
-            // via the system's permission UI if they denied.
+            // Closure signature matches Apple's `void (^)(BOOL, NSError*)`;
+            // we don't surface the result anywhere; the user can retry
+            // via the system's permission UI if they denied
             let block = StackBlock::new(
                 |_granted: objc2::runtime::Bool, _err: *mut AnyObject| {},
             );
             // Promote to heap-allocated RcBlock so the async callback
-            // can fire after this function returns without dangling.
+            // can fire after this function returns without dangling
             let block = block.copy();
             let _: () = msg_send![
                 center,
@@ -902,7 +903,7 @@ use super::*;
     }
 
     // `show_reset_alert` was removed when the macOS Reset confirm
-    // path was consolidated onto the in-window inline egui card —
+    // path was consolidated onto the in-window inline egui card:
     // the panel's button-click and global-hotkey paths now share
     // the same confirmation UI on every OS, eliminating the
     // platform-specific NSAlert that used to spawn for the hotkey
@@ -911,10 +912,10 @@ use super::*;
     /// Install a minimal `NSMainMenu` so the menu bar shows the
     /// standard Apple, Edit, Window, and Help menus.  Without this
     /// winit-created apps appear in the menu bar with no menus at
-    /// all — `Cmd-Q` / `Cmd-H` / `Cmd-W` / Services / Hide Others
+    /// all: `Cmd-Q` / `Cmd-H` / `Cmd-W` / Services / Hide Others
     /// don't work, and the app reads as "broken" to anyone who
     /// expects Mac conventions.  Mirrors what Swift apps get for free
-    /// via their `NSApplicationMain`-installed main menu.
+    /// via their `NSApplicationMain`-installed main menu
     ///
     /// We install:
     ///   - Apple menu (auto-named after the app): About, Services,
@@ -928,11 +929,11 @@ use super::*;
     /// About-panel content is sourced from the bundle's `Info.plist`
     /// via the standard `orderFrontStandardAboutPanel:` selector:
     /// `CFBundleShortVersionString` / `CFBundleVersion` /
-    /// `NSHumanReadableCopyright` populate the panel automatically.
-    /// We deliberately avoid attaching a custom
+    /// `NSHumanReadableCopyright` populate the panel automatically;
+    /// we deliberately avoid attaching a custom
     /// `exhale_orderFrontAboutPanel:` via `class_addMethod` on the
     /// NSApp delegate because adding methods to system classes can
-    /// trip Mac App Store static-analysis flags during review.
+    /// trip Mac App Store static-analysis flags during review
     ///
     /// Safe to call multiple times; replaces the existing main menu
     /// each call.  Called once from app startup
@@ -944,13 +945,13 @@ use super::*;
         use objc2_foundation::{MainThreadMarker, NSString};
 
         // SAFETY: called once at app startup from the winit event loop's
-        // main-thread `resumed()` invocation.
+        // main-thread `resumed()` invocation
         let mtm = unsafe { MainThreadMarker::new_unchecked() };
         let app = NSApplication::sharedApplication(mtm);
 
         // Use the app's process name as the Apple-menu title.  AppKit
         // auto-formats anything attached to the leftmost menu in the
-        // main menu as "<App Name>" with bold weight.
+        // main menu as "<App Name>" with bold weight
         let app_name = std::env::current_exe()
             .ok()
             .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()))
@@ -958,7 +959,7 @@ use super::*;
         let app_name_ns = NSString::from_str(&app_name);
 
         // SAFETY: NSMenu / NSMenuItem constructors are documented to be
-        // main-thread-only.  We're on main per the MainThreadMarker above.
+        // main-thread-only.  We're on main per the MainThreadMarker above
         unsafe {
             let main_menu = NSMenu::new(mtm);
 
@@ -1009,7 +1010,7 @@ use super::*;
             apple_menu.addItem(&NSMenuItem::separatorItem(mtm));
 
             // Services submenu: AppKit wires this up automatically if we
-            // hand it an NSMenu via `setServicesMenu:`.
+            // hand it an NSMenu via `setServicesMenu:`
             let services_title = NSString::from_str("Services");
             let services_item = NSMenuItem::initWithTitle_action_keyEquivalent(
                 mtm.alloc::<NSMenuItem>(),
@@ -1021,7 +1022,7 @@ use super::*;
             services_item.setSubmenu(Some(&services_menu));
             apple_menu.addItem(&services_item);
             // `setServicesMenu:` is on NSApplication; objc2-app-kit
-            // exposes it as a typed method.
+            // exposes it as a typed method
             app.setServicesMenu(Some(&services_menu));
             apple_menu.addItem(&NSMenuItem::separatorItem(mtm));
 
@@ -1040,7 +1041,7 @@ use super::*;
                 Some(sel!(hideOtherApplications:)),
                 &NSString::from_str("h"),
             );
-            // Alt+Cmd-H — modifier mask 0x80000 | 0x100000 = NSEvent
+            // Alt+Cmd-H: modifier mask 0x80000 | 0x100000 = NSEvent
             // ModifierFlags.option | .command = 524288 | 1048576 = 1572864
             let _: () = msg_send![&hide_others, setKeyEquivalentModifierMask: 1_572_864_u64];
             apple_menu.addItem(&hide_others);
@@ -1074,7 +1075,7 @@ use super::*;
             let mk = |title: &str, action: &str, key: &str| -> Retained<NSMenuItem> {
                 // SAFETY: each selector below is a documented standard
                 // first-responder action; the objc runtime routes it
-                // through the first responder chain at click time.
+                // through the first responder chain at click time
                 let sel = match action {
                     "undo:"           => sel!(undo:),
                     "redo:"           => sel!(redo:),
@@ -1141,13 +1142,13 @@ use super::*;
             window_item.setTitle(&window_menu_title);
             main_menu.addItem(&window_item);
             // Tell AppKit this is the Window menu so it auto-populates
-            // with open-window entries.
+            // with open-window entries
             app.setWindowsMenu(Some(&window_menu));
 
             // ── Help menu ──────────────────────────────────────────────
-            // Standard macOS app gets a Help menu in the menu bar.
+            // Standard macOS app gets a Help menu in the menu bar;
             // AppKit auto-routes the menu-bar search field through this
-            // menu, so users hitting Cmd-? get the system Help search.
+            // menu, so users hitting Cmd-? get the system Help search
             let help_item = NSMenuItem::new(mtm);
             let help_menu_title = NSString::from_str("Help");
             let help_menu = NSMenu::initWithTitle(mtm.alloc::<NSMenu>(), &help_menu_title);
@@ -1166,7 +1167,7 @@ use super::*;
             main_menu.addItem(&help_item);
             // `setHelpMenu:` tells AppKit which menu to mark as the
             // help menu so Cmd-? routing works (also marks it visually
-            // distinct on some macOS releases).
+            // distinct on some macOS releases)
             app.setHelpMenu(Some(&help_menu));
 
             // ── Install ────────────────────────────────────────────────
@@ -1175,36 +1176,36 @@ use super::*;
             // item uses AppKit's documented `orderFrontStandardAboutPanel:`
             // selector which routes through the first responder chain
             // and is auto-handled by NSApplication.  No `class_addMethod`
-            // calls on a system-class — App Store static analysis is
+            // calls on a system-class: App Store static analysis is
             // happiest when we don't touch the runtime metaclass for
-            // built-in classes.
+            // built-in classes
             app.setMainMenu(Some(&main_menu));
             // Tell AppKit which menu is the Services menu so the
             // Services submenu auto-populates.  Already set above; this
             // is the standalone hint that pairs with the parent menu's
-            // app_name title resolution.
+            // app_name title resolution
             let _ = app_name_ns;
         }
     }
 
     /// Install `applicationShouldHandleReopen:hasVisibleWindows:` on the
     /// existing NSApplication delegate so `DOCK_REOPEN` is set when the user
-    /// clicks the Dock icon while the app is already running.
+    /// clicks the Dock icon while the app is already running
     ///
-    /// Bring an already-running `exhale` instance to the foreground.
-    /// Called from `single_instance_guard` when the file-lock acquire
-    /// fails (i.e. another instance owns the lock).
+    /// Bring an already-running `exhale` instance to the foreground;
+    /// called from `single_instance_guard` when the file-lock acquire
+    /// fails (i.e. another instance owns the lock)
     ///
     /// Uses `NSRunningApplication.runningApplicationsWithBundleIdentifier:`
     /// to locate the existing process, then `activateWithOptions:` to
     /// raise it.  That fires `applicationShouldHandleReopen:` on the
-    /// running instance's NSApp delegate — our existing handler sets
+    /// running instance's NSApp delegate: our existing handler sets
     /// `DOCK_REOPEN`, which `App::about_to_wait` drains and dispatches
-    /// as `AppEvent::ShowSettings`.
+    /// as `AppEvent::ShowSettings`
     ///
-    /// Sandbox-safe (no entitlements required — NSWorkspace /
-    /// NSRunningApplication are public, unentitled APIs).  Idempotent
-    /// — calling on a non-existent instance is a no-op
+    /// Sandbox-safe (no entitlements required, NSWorkspace /
+    /// NSRunningApplication are public, unentitled APIs).  Idempotent: calling
+    /// on a non-existent instance is a no-op
     pub fn activate_running_exhale() {
         use objc2::msg_send;
         use objc2::runtime::AnyObject;
@@ -1213,22 +1214,22 @@ use super::*;
         // Match the CFBundleIdentifier used in `scripts/bundle-mas.sh`
         // and the Swift app's Info.plist.  When running as a raw
         // binary (no .app bundle) `NSRunningApplication` won't find a
-        // match; that's fine, the function silently no-ops.
+        // match; that's fine, the function silently no-ops
         let bundle_id = NSString::from_str("peterklingelhofer.exhale");
         unsafe {
             let cls = objc2::class!(NSRunningApplication);
             // `runningApplicationsWithBundleIdentifier:` returns an
             // `NSArray<NSRunningApplication *>` of matching processes
-            // (usually 0 or 1).  Iterate and activate any.
+            // (usually 0 or 1).  Iterate and activate any
             let apps: *mut AnyObject = msg_send![
                 cls,
                 runningApplicationsWithBundleIdentifier: &*bundle_id,
             ];
             if apps.is_null() { return; }
             let count: usize = msg_send![apps, count];
-            // `NSApplicationActivationOptions.activateAllWindows = 1`
-            // — bring every window of the running app forward, not
-            // just the most-recent.
+            // `NSApplicationActivationOptions.activateAllWindows = 1`: bring
+            // every window of the running app forward, including windows
+            // beyond the most-recently used one
             const ACTIVATE_ALL_WINDOWS: u64 = 1;
             for i in 0..count {
                 let app: *mut AnyObject = msg_send![apps, objectAtIndex: i];
@@ -1249,8 +1250,8 @@ use super::*;
     // selector `orderFrontStandardAboutPanelWithOptions:` and
     // passing an explicit options dictionary keyed by the
     // documented `NSAboutPanelOption*` constants (their underlying
-    // NSString values are literally the suffix after the prefix —
-    // `"ApplicationName"`, `"ApplicationVersion"`, …).  The version
+    // NSString values are literally the suffix after the prefix: `"ApplicationName"`,
+    // `"ApplicationVersion"`, …).  The version
     // string comes from `env!("CARGO_PKG_VERSION")` so it tracks
     // `Cargo.toml` at compile time without any runtime plist lookup
     static MENU_HANDLER: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
@@ -1276,7 +1277,7 @@ use super::*;
 
     /// Idempotently define the `ExhaleMenuHandler` NSObject
     /// subclass, allocate one instance, and stash it in
-    /// `MENU_HANDLER`.  Safe to call multiple times — the inner
+    /// `MENU_HANDLER`.  Safe to call multiple times: the inner
     /// `Once` guards against double-registration
     pub(super) fn ensure_menu_handler_registered() {
         use objc2::msg_send;
@@ -1284,9 +1285,9 @@ use super::*;
         use objc2_foundation::NSString;
         use std::sync::Once;
 
-        // The actual menu-item action — assembles an options
-        // dictionary and forwards to AppKit's standard about panel.
-        // Signature follows objc method dispatch: (self, _cmd, sender).
+        // The actual menu-item action: assembles an options
+        // dictionary and forwards to AppKit's standard about panel;
+        // signature follows objc method dispatch: (self, _cmd, sender)
         extern "C" fn show_about(
             _this:   &AnyObject,
             _cmd:    objc2::runtime::Sel,
@@ -1332,8 +1333,8 @@ use super::*;
                 let _: () = msg_send![app, orderFrontStandardAboutPanelWithOptions: dict];
                 let _: () = msg_send![dict, release];
                 // After AppKit shows the panel, hoist its window to
-                // settings-window-plus-one so it can't get covered.
-                // The about panel is owned by AppKit; we look it up
+                // settings-window-plus-one so it can't get covered;
+                // the about panel is owned by AppKit; we look it up
                 // via its shared key window because the app just
                 // activated and brought it to the foreground
                 let win: *mut AnyObject = msg_send![app, keyWindow];
@@ -1346,7 +1347,7 @@ use super::*;
 
         // The second menu-item action. Same class, because both items
         // live in the app menu and a second leaked NSObject to hold one
-        // more selector would be ceremony for nothing.
+        // more selector would be ceremony for nothing
         //
         // Sends the URL through `super::open_url`, so the macOS menu bar
         // and the tray menu go through one `https://`-only allowlist
@@ -1376,7 +1377,7 @@ use super::*;
                 return;
             }
 
-            // 2. Add `exhaleShowAbout:` — type encoding `v@:@` = void
+            // 2. Add `exhaleShowAbout:`; type encoding `v@:@` = void
             //    return, (self, _cmd, NSObject* sender).  AppKit
             //    passes the menu item as `sender` per the standard
             //    target/action protocol
@@ -1405,8 +1406,8 @@ use super::*;
 
             // 3. Allocate one instance; leak it for the app's
             //    lifetime (menu-item target+action stores the target
-            //    as a weak reference, so this leak is load-bearing —
-            //    a dropped instance would mean a dead "About"
+            //    as a weak reference, so this leak is load-bearing: a
+            //    dropped instance would mean a dead "About"
             //    selector and the menu item would silently no-op)
             let instance: *mut AnyObject = msg_send![new_cls, alloc];
             let instance: *mut AnyObject = msg_send![instance, init];
@@ -1424,18 +1425,18 @@ use super::*;
     /// class winit's delegate happened to be via `class_addMethod`,
     /// which is technically public Obj-C runtime API but is the kind
     /// of pattern Mac App Store static analysis sometimes flags
-    /// during review.
+    /// during review
     ///
-    /// New design — equivalent at the AppleEvent layer (which is
+    /// New design: equivalent at the AppleEvent layer (which is
     /// what AppKit's `applicationShouldHandleReopen:` is itself built
     /// on top of):
     ///   1. Define a brand-new Obj-C class `ExhaleAEHandler` at
-    ///      runtime (`objc_allocateClassPair` — adds to our own
-    ///      namespace, doesn't touch any system class).
-    ///   2. Add an `aevtReopen:withReplyEvent:` method to it.
-    ///   3. Allocate one instance; leak it so it lives forever.
+    ///      runtime (`objc_allocateClassPair`, which adds to our own
+    ///      namespace, doesn't touch any system class)
+    ///   2. Add an `aevtReopen:withReplyEvent:` method to it
+    ///   3. Allocate one instance; leak it so it lives forever
     ///   4. Register that instance with `NSAppleEventManager` for
-    ///      the `kCoreEventClass / kAEReopenApplication` event.
+    ///      the `kCoreEventClass / kAEReopenApplication` event
     ///
     /// When the user clicks the Dock icon for an already-running
     /// instance, the system fires `kAEReopenApplication` (which
@@ -1463,27 +1464,27 @@ use super::*;
         // class `ExhaleAEHandler`.  Each unsafe operation is justified
         // inline by the surrounding comment.  Aggregate invariants:
         //   * `INIT: Once` guarantees the block runs exactly once per
-        //     process — no double-allocation of the class pair (which
-        //     would `objc_registerClassPair` a duplicate name).
+        //     process: no double-allocation of the class pair (which
+        //     would `objc_registerClassPair` a duplicate name)
         //   * `super_cls` is `objc2::class!(NSObject)`, a statically-
-        //     valid Class pointer — `objc_allocateClassPair` accepts
-        //     any valid Class as the superclass.
+        //     valid Class pointer: `objc_allocateClassPair` accepts
+        //     any valid Class as the superclass
         //   * `handle_reopen` matches the AppKit-documented signature
         //     `void (^)(NSAppleEventDescriptor*, NSAppleEventDescriptor*)`
         //     when prepended with the implicit `(self, _cmd, …)`
-        //     receiver/selector args that every Obj-C method takes.
-        //     `transmute(fn ptr → Imp)` is layout-compatible because
-        //     both are `unsafe extern "C" fn` pointers.
+        //     receiver/selector args that every Obj-C method takes;
+        //     `transmute(fn ptr -> Imp)` is layout-compatible because
+        //     both are `unsafe extern "C" fn` pointers
         //   * The `Retained::into_raw`-equivalent leak at the end is
-        //     intentional and documented — NSAppleEventManager's
+        //     intentional and documented: NSAppleEventManager's
         //     handler table needs the instance to outlive the
-        //     registration.
+        //     registration
         static INIT: Once = Once::new();
         INIT.call_once(|| unsafe {
             // 1. Create our own NSObject subclass.  Adding methods to
-            //    a class WE created — not a system class — is the
-            //    canonical, App-Store-safe pattern for runtime-defined
-            //    objc classes.
+            //    a class WE created, distinct from any system class,
+            //    is the canonical, App-Store-safe pattern for
+            //    runtime-defined objc classes
             let super_cls = objc2::class!(NSObject);
             let name = c"ExhaleAEHandler";
             let new_cls = objc2::ffi::objc_allocateClassPair(
@@ -1492,19 +1493,19 @@ use super::*;
                 0,
             );
             if new_cls.is_null() {
-                // Class with this name already exists — re-entrant
+                // Class with this name already exists: re-entrant
                 // call (only happens if `register_reopen_handler` is
                 // called twice, which `Once` already guards against,
-                // but we're defensive).
+                // but we're defensive)
                 log::warn!("register_reopen_handler: objc_allocateClassPair returned null");
                 return;
             }
 
             // 2. Add the AppleEvent handler method.  Type encoding
-            //    `v@:@@` = void return, (self, _cmd, NSAppleEventDescriptor*, NSAppleEventDescriptor*).
+            //    `v@:@@` = void return, (self, _cmd, NSAppleEventDescriptor*, NSAppleEventDescriptor*);
             //    `c"…"` is a compile-time-nul-terminated C string so
             //    there's no runtime `CString::new` allocation or
-            //    interior-NUL panic risk.
+            //    interior-NUL panic risk
             let sel    = objc2::sel!(aevtReopen:withReplyEvent:);
             let imp: objc2::runtime::Imp = std::mem::transmute(handle_reopen as *const ());
             let added  = objc2::ffi::class_addMethod(
@@ -1516,8 +1517,8 @@ use super::*;
             objc2::ffi::objc_registerClassPair(new_cls as *mut _);
 
             // 3. Allocate one instance; leak it for the app's lifetime
-            //    (Box::leak would be wrong here — this is an Obj-C
-            //    object, not a Rust heap allocation).
+            //    (Box::leak would be wrong here: this is an Obj-C
+            //    object owned by the runtime, unlike a Rust heap allocation)
             let instance: *mut AnyObject = msg_send![new_cls, alloc];
             let instance: *mut AnyObject = msg_send![instance, init];
             if instance.is_null() {
@@ -1529,7 +1530,7 @@ use super::*;
             //    constants are `'aevt'` (kCoreEventClass) and `'rapp'`
             //    (kAEReopenApplication) packed big-endian.  Use u32
             //    bit-shift to spell them out without
-            //    target-endianness ambiguity.
+            //    target-endianness ambiguity
             const K_CORE_EVENT_CLASS:      u32 =
                   (b'a' as u32) << 24 | (b'e' as u32) << 16
                 | (b'v' as u32) <<  8 |  b't' as u32;
@@ -1551,17 +1552,17 @@ use super::*;
                 andEventID:      K_AE_REOPEN_APPLICATION,
             ];
 
-            // `instance` is leaked intentionally — it lives for the
+            // `instance` is leaked intentionally: it lives for the
             // app's lifetime and is referenced internally by
-            // NSAppleEventManager's handler table.
+            // NSAppleEventManager's handler table
             let _ = instance;
         });
     }
 
-    /// Toggle the macOS activation policy.
-    ///   DockOnly / Both → regular (Dock icon shown; tray still works because
+    /// Toggle the macOS activation policy:
+    ///   DockOnly / Both -> regular (Dock icon shown; tray still works because
     ///                     NSStatusItem is independent of activation policy)
-    ///   TopBarOnly      → accessory (menu-bar only, no Dock)
+    ///   TopBarOnly -> accessory (menu-bar only, no Dock)
     pub fn apply_app_visibility(vis: AppVisibility, _settings: Option<&Window>) {
         use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
         use objc2_foundation::MainThreadMarker;
@@ -1574,7 +1575,7 @@ use super::*;
         // SAFETY: this is called from the winit event loop on the main
         // thread (winit invokes our ApplicationHandler on the platform's
         // UI thread, which is main on macOS).  In test contexts we
-        // accept a slightly looser guarantee — AppKit tolerates
+        // accept a slightly looser guarantee: AppKit tolerates
         // `setActivationPolicy:` from any thread in practice
         let mtm  = unsafe { MainThreadMarker::new_unchecked() };
         let app  = NSApplication::sharedApplication(mtm);
@@ -1582,14 +1583,14 @@ use super::*;
     }
 
     /// macOS half of [`super::open_url`].  Scheme validation happens
-    /// in the caller.
+    /// in the caller
     ///
     /// `NSWorkspace` and `NSURL` are public, unentitled APIs, so this
-    /// works unchanged inside the App Sandbox — `bundle-mas.sh` ships
+    /// works unchanged inside the App Sandbox: `bundle-mas.sh` ships
     /// only app-sandbox + user-selected read-only and needs no new
     /// entitlement for it.  Reached via `class!` + `msg_send!` rather
     /// than the typed `objc2-app-kit` bindings so no new cargo
-    /// feature is needed, matching [`activate_running_exhale`] above.
+    /// feature is needed, matching [`activate_running_exhale`] above
     ///
     /// `URLWithString:` returns nil for a string AppKit can't parse;
     /// we null-check rather than passing nil into `openURL:`
@@ -1619,21 +1620,21 @@ use super::*;
     // Cover the parts of the AppKit surface that can be verified without
     // a winit event loop and a human looking at the screen:
     //   - `render_sf_symbol`: pure data function, easy to check
-    //     dimensions / pixel non-zero-ness / dark-vs-light variance.
+    //     dimensions / pixel non-zero-ness / dark-vs-light variance
     //   - `apply_app_visibility`: round-trips through the global
     //     `NSApp.activationPolicy`; the test reads back through an
     //     INDEPENDENT objc path so a regression in either direction
-    //     surfaces.
+    //     surfaces
     //   - `register_reopen_handler`, `request_notification_permission`:
     //     smoke tests (just that they don't panic in a non-bundled
-    //     `cargo test` process).
+    //     `cargo test` process)
     //
     // The window-mutating functions (`setup_overlay_window`,
     // `install_settings_vibrancy`, etc.) need a real winit `Window`
-    // which requires an event loop, not feasible inside the rust test
+    // which requires an event loop, unavailable inside the rust test
     // harness, so they're intentionally NOT covered here.  Smoke
     // verification of those falls to launching the app and clicking
-    // around.
+    // around
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -1645,7 +1646,7 @@ use super::*;
         /// `NSBitmapImageRep` graphics-context pipeline used by
         /// `render_sf_symbol`) silently return nil if AppKit hasn't
         /// been bootstrapped via `[NSApplication sharedApplication]`
-        /// in the current process — production code goes through this
+        /// in the current process: production code goes through this
         /// implicitly via winit's app delegate, but the rust test
         /// harness doesn't.  Calling once at test start lets the
         /// render tests run in a bare `cargo test` invocation
@@ -1661,9 +1662,9 @@ use super::*;
             });
         }
 
-        /// Read `NSApp.activationPolicy` directly via raw objc2 dispatch.
-        /// This is the verification-side counterpart to
-        /// `apply_app_visibility`'s setter — kept separate (and
+        /// Read `NSApp.activationPolicy` directly via raw objc2 dispatch;
+        /// this is the verification-side counterpart to
+        /// `apply_app_visibility`'s setter: kept separate (and
         /// deliberately using the lower-level runtime API rather than
         /// the typed `NSApplicationActivationPolicy` enum) so a
         /// regression in either path produces a mismatched int and
@@ -1689,7 +1690,7 @@ use super::*;
         // `render_unknown_symbol_returns_none` test below works in
         // either environment because both return None
         #[test]
-        #[ignore = "needs AppKit graphics-context (bundled app) — run manually"]
+        #[ignore = "needs AppKit graphics-context (bundled app); run manually"]
         fn render_known_symbol_returns_data() {
             ensure_nsapp_initialised();
             let out = render_sf_symbol("play.circle.fill", 13.0, false);
@@ -1708,7 +1709,7 @@ use super::*;
         }
 
         #[test]
-        #[ignore = "needs AppKit graphics-context (bundled app) — run manually"]
+        #[ignore = "needs AppKit graphics-context (bundled app); run manually"]
         fn dark_and_light_modes_produce_different_pixels() {
             let dark  = render_sf_symbol("play.circle.fill", 13.0, true)
                 .expect("dark render");
@@ -1721,7 +1722,7 @@ use super::*;
         }
 
         #[test]
-        #[ignore = "needs AppKit graphics-context (bundled app) — run manually"]
+        #[ignore = "needs AppKit graphics-context (bundled app); run manually"]
         fn larger_point_size_produces_larger_buffer() {
             let small = render_sf_symbol("play.circle.fill", 12.0, false)
                 .expect("small render");
@@ -1735,21 +1736,21 @@ use super::*;
         }
 
         #[test]
-        #[ignore = "needs AppKit graphics-context (bundled app) — run manually"]
+        #[ignore = "needs AppKit graphics-context (bundled app); run manually"]
         fn drawn_pixels_are_non_zero() {
             let (bytes, _, _) = render_sf_symbol("play.circle.fill", 24.0, false)
                 .expect("rasterise");
-            // At least one pixel must have non-zero alpha — otherwise nothing was drawn
+            // At least one pixel must have non-zero alpha: otherwise nothing was drawn
             let any_drawn = bytes.chunks_exact(4).any(|px| px[3] != 0);
             assert!(any_drawn,
-                "rasterised buffer is fully transparent — the symbol wasn't actually drawn");
+                "rasterised buffer is fully transparent: the symbol wasn't actually drawn");
         }
 
         #[test]
-        #[ignore = "needs AppKit graphics-context (bundled app) — run manually"]
+        #[ignore = "needs AppKit graphics-context (bundled app); run manually"]
         fn point_size_scaling_is_at_least_pixel_dense() {
             // Buffer is rendered at 2× point size (Retina); allow tiny SF
-            // Symbol bounding-box padding above the bare point dimension.
+            // Symbol bounding-box padding above the bare point dimension
             let (_, w, _) = render_sf_symbol("play.circle.fill", 20.0, false)
                 .expect("rasterise");
             assert!(w >= 32,
@@ -1765,7 +1766,7 @@ use super::*;
         fn apply_app_visibility_roundtrip() {
             ensure_nsapp_initialised();
             // Save the original so we don't leave the test process with
-            // a different activation policy than it started with.
+            // a different activation policy than it started with
             let original = read_activation_policy();
 
             apply_app_visibility(AppVisibility::TopBarOnly, None);
@@ -1799,7 +1800,7 @@ use super::*;
         fn register_reopen_handler_does_not_panic() {
             // Without a delegate (no winit event loop running in the
             // test harness), the function should bail out via its
-            // `delegate.is_null()` early return.  Idempotent — calling
+            // `delegate.is_null()` early return.  Idempotent: calling
             // a second time should also be a no-op because
             // `class_addMethod` is a no-op if the selector already
             // exists on the class
@@ -1808,7 +1809,7 @@ use super::*;
         }
 
         #[test]
-        #[ignore = "needs UserNotifications.framework (bundled app) — run manually"]
+        #[ignore = "needs UserNotifications.framework (bundled app); run manually"]
         fn request_notification_permission_does_not_panic() {
             // In a non-bundled test process the system will silently
             // deny / drop the request; we just want to confirm the

--- a/rust/crates/exhale-app/src/platform/win.rs
+++ b/rust/crates/exhale-app/src/platform/win.rs
@@ -1,6 +1,6 @@
-//! Windows implementation of the platform layer.
-//! See the parent `platform` module for the public API surface and
-//! cross-platform stubs.
+//! Windows implementation of the platform layer; see the parent
+//! `platform` module for the public API surface and cross-platform
+//! stubs
 
 use super::*;
 
@@ -13,7 +13,7 @@ use super::*;
             // tried for the settings-window acrylic look but produced
             // worse results than the WS_EX_LAYERED path we now use
             // for the overlay.  Kept in the import comment to flag
-            // they exist if someone wants to revisit.
+            // they exist if someone wants to revisit
             DWMWA_USE_IMMERSIVE_DARK_MODE,
         },
         UI::WindowsAndMessaging::{
@@ -26,9 +26,9 @@ use super::*;
     };
 
     fn hwnd(window: &Window) -> HWND {
-        // Fallible on a closing/destroyed window — return a null HWND
+        // Fallible on a closing/destroyed window: return a null HWND
         // so callers that null-check (most of this module) become
-        // no-ops instead of panicking during shutdown.
+        // no-ops instead of panicking during shutdown
         let Ok(handle) = window.window_handle() else { return std::ptr::null_mut(); };
         if let RawWindowHandle::Win32(h) = handle.as_raw() {
             h.hwnd.get() as HWND
@@ -47,15 +47,15 @@ use super::*;
             //   - `WS_EX_LAYERED` makes the window composite per-pixel
             //     alpha through DWM so the breath animation is
             //     actually VISIBLE.  Without it, a transparent
-            //     window is just an invisible window — the wgpu
+            //     window is just an invisible window: the wgpu
             //     surface paints but the user sees nothing
             //     (regression observed when LAYERED was removed in
-            //     pursuit of better click-through).
+            //     pursuit of better click-through)
             //   - `WS_EX_TRANSPARENT` makes the window hit-test
             //     transparent so clicks pass through to whatever
             //     window sits behind it (the desktop, browser,
             //     editor, etc.).  Without it the user can see the
-            //     breath animation but can't click anything behind.
+            //     breath animation but can't click anything behind
             // winit's `with_transparent(true)` already sets LAYERED
             // up via `DwmEnableBlurBehindWindow`; we re-assert it
             // here as a no-op-on-success defensive measure
@@ -84,9 +84,9 @@ use super::*;
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_FRAMECHANGED,
             );
 
-            // Diagnostic — log the final extended style so we can verify
+            // Diagnostic: log the final extended style so we can verify
             // in the running app's log file which transparency path is
-            // in effect.  `0x80000` = LAYERED, `0x200000` = NRB.
+            // in effect.  `0x80000` = LAYERED, `0x200000` = NRB
             let final_ex = GetWindowLongPtrW(h, GWL_EXSTYLE) as u32;
             log::info!(
                 "overlay extended-style after setup: 0x{final_ex:08x} \
@@ -97,28 +97,28 @@ use super::*;
                 (final_ex & WS_EX_TOPMOST)     != 0,
             );
         }
-        // NOTE: do NOT call `window.set_cursor_hittest(false)` here.
+        // NOTE: do NOT call `window.set_cursor_hittest(false)` here;
         // winit's implementation reads its own internal `WindowFlags`
         // bitset (which does NOT track `WS_EX_LAYERED`), computes a
         // new EX-style word from that bitset alone, and writes it
         // back via `SetWindowLongPtrW`.  That overwrite drops the
         // `WS_EX_LAYERED` bit we just set above and the window goes
-        // invisible — observed regression.  The manual
+        // invisible: observed regression.  The manual
         // `SetWindowLongPtrW` + `SWP_FRAMECHANGED` flow above is
         // sufficient for hit-test transparency on its own
     }
 
-    /// Re-bump the overlay HWND to the front of the topmost z-band.
+    /// Re-bump the overlay HWND to the front of the topmost z-band;
     /// Windows orders topmost windows by activation, so a newly-opened
-    /// app — even one without `WS_EX_TOPMOST` — can land above our
+    /// app, even one without `WS_EX_TOPMOST`, can land above our
     /// overlay if the user activates it (the OS treats activation as a
     /// foreground promotion).  Calling `SetWindowPos(HWND_TOPMOST, …)`
     /// with `SWP_NOACTIVATE` re-asserts overlay topmost without
-    /// stealing focus from whatever the user is currently working in.
+    /// stealing focus from whatever the user is currently working in
     ///
-    /// We don't reset window styles or geometry — just the z-order
-    /// position — so the call is cheap (a few microseconds) and safe
-    /// to invoke on a regular cadence from the overlay render loop.
+    /// We don't reset window styles or geometry, just the z-order
+    /// position, so the call is cheap (a few microseconds) and safe
+    /// to invoke on a regular cadence from the overlay render loop
     pub fn reassert_overlay_topmost(window: &Window) {
         let h = hwnd(window);
         if h.is_null() { return; }
@@ -128,15 +128,15 @@ use super::*;
         }
     }
 
-    /// Returns `true` when no window sits above `window` in z-order.
-    /// Used by the per-second topmost-reassert path to skip the full
-    /// `SetWindowPos` round-trip when our window is already on top:
-    /// `SetWindowPos(HWND_TOPMOST, ...)` is technically a no-op in that
-    /// case but Windows still fires `WM_WINDOWPOSCHANGED`, which DWM
-    /// composites as a brief title-bar / frame redraw (visible to the
-    /// user as light flickering once per second).  `GetWindow` /
-    /// `GW_HWNDPREV` is a cheap kernel lookup (~1 µs) that lets us
-    /// avoid the SetWindowPos entirely on the happy path
+    /// Returns `true` when no window sits above `window` in z-order;
+    /// used by the per-second topmost-reassert path to skip the full
+    /// `SetWindowPos` round-trip when our window is already on top: the
+    /// call is technically a no-op in that case, but Windows still
+    /// fires `WM_WINDOWPOSCHANGED`, which DWM composites as a brief
+    /// title-bar / frame redraw (visible to the user as light
+    /// flickering once per second).  `GetWindow` / `GW_HWNDPREV` is a
+    /// cheap kernel lookup (~1 µs) that lets us avoid the SetWindowPos
+    /// entirely on the happy path
     pub fn is_topmost_top(window: &Window) -> bool {
         let h = hwnd(window);
         if h.is_null() { return true; }
@@ -152,13 +152,13 @@ use super::*;
         // breathing overlay (which is also `WS_EX_TOPMOST`).  Windows
         // doesn't expose explicit z-bands like macOS's window levels, so
         // both windows share the topmost band and the most-recently-
-        // activated one wins — when the user opens preferences, the
+        // activated one wins: when the user opens preferences, the
         // settings window comes to front; when the overlay later starts
         // animating, settings stays interactable until the user clicks
         // away from it.  Without `WS_EX_TOPMOST`, the settings window
         // would render permanently behind the topmost overlay's
-        // (translucent) layer — invisible to the user despite still
-        // technically being focused.
+        // (translucent) layer, invisible to the user despite still
+        // technically being focused
         let h = hwnd(window);
         if h.is_null() { return; }
         unsafe {
@@ -175,53 +175,53 @@ use super::*;
     /// Set the settings-window title bar to dark mode when the OS is in
     /// dark appearance.  We deliberately do NOT install the DWM acrylic
     /// backdrop (`DWMWA_SYSTEMBACKDROP_TYPE`) here even though it would
-    /// produce a frosted-glass settings window — every attempt at that
+    /// produce a frosted-glass settings window; every attempt at that
     /// path on Windows produced two visible regressions:
     ///
     ///   1. The breath overlay composited above the settings window's
     ///      DWM-translucent client area in the z-stack, so the
     ///      animation rendered IN FRONT of the controls (and at
-    ///      opacity = 1 hid them entirely with no way to recover).
+    ///      opacity = 1 hid them entirely with no way to recover)
     ///   2. Mouse hover over the acrylic settings window triggered
     ///      a per-cursor-move recomposition of the whole DWM acrylic
-    ///      stack, producing severe overlay-animation lag.
+    ///      stack, producing severe overlay-animation lag
     ///
-    /// The dark-titlebar attribute is independent of compositing — it
-    /// just changes the non-client area's tint — so we keep that.  The
+    /// The dark-titlebar attribute is independent of compositing, it
+    /// just changes the non-client area's tint, so we keep that.  The
     /// `BLUR_ACTIVE` flag stays `false`, which makes the egui render
     /// path paint the settings window OPAQUELY (clear colour =
     /// themed panel, panel fill = themed panel), avoiding both
-    /// regressions above.
+    /// regressions above
     pub fn install_settings_vibrancy(window: &Window, dark_mode: bool) -> usize {
         let h = hwnd(window);
         if h.is_null() { return 0; }
         apply_dark_titlebar(h, dark_mode);
         // Return the HWND so the theme-change path can re-apply the
-        // dark-titlebar attribute via `update_settings_vibrancy`.
-        // `BLUR_ACTIVE` stays false → opaque rendering everywhere.
+        // dark-titlebar attribute via `update_settings_vibrancy`;
+        // `BLUR_ACTIVE` stays false -> opaque rendering everywhere
         h as usize
     }
 
     /// On Windows the only theme-dependent property is the title bar
-    /// dark-mode flag — re-apply it when the OS appearance changes.
-    /// `handle` is the HWND returned by `install_settings_vibrancy`.
+    /// dark-mode flag: re-apply it when the OS appearance changes;
+    /// `handle` is the HWND returned by `install_settings_vibrancy`
     pub fn update_settings_vibrancy(handle: usize, dark_mode: bool) {
         if handle == 0 { return; }
         apply_dark_titlebar(handle as HWND, dark_mode);
     }
 
-    /// Set the dark-mode title-bar attribute on `h` via DWM.
+    /// Set the dark-mode title-bar attribute on `h` via DWM;
     /// `DWMWA_USE_IMMERSIVE_DARK_MODE` is silently ignored ("feature
     /// not present" error) on Win10 builds older than 1809, so this
     /// is no-op-safe on earlier OSes
     fn apply_dark_titlebar(h: HWND, dark_mode: bool) {
-        // Pass a Win32 BOOL — `i32` 1 / 0 — by pointer.
+        // Pass a Win32 BOOL, `i32` 1 / 0, by pointer
         let dark_bool: i32 = if dark_mode { 1 } else { 0 };
         // SAFETY: `h` is a valid HWND (caller null-checked or
         // unwrapped from the live winit window via `hwnd()`).  The
         // pointer + size pair describe a stack-local i32, in scope
         // for the duration of the call.  `DwmSetWindowAttribute` has
-        // no Rust-level safety requirements beyond a valid HWND.
+        // no Rust-level safety requirements beyond a valid HWND
         unsafe {
             let _ = DwmSetWindowAttribute(
                 h,
@@ -232,24 +232,24 @@ use super::*;
         }
     }
 
-    /// No-op on Windows — DWM tracks window size via the HWND, no
-    /// separate backdrop window to resize.
+    /// No-op on Windows: DWM tracks window size via the HWND, no
+    /// separate backdrop window to resize
     pub fn sync_settings_backdrop_frame(_backdrop_ptr: usize) {}
 
-    /// No-op on Windows — `install_settings_vibrancy` returned 0, no
-    /// backdrop NSWindow to release.
+    /// No-op on Windows: `install_settings_vibrancy` returned 0, no
+    /// backdrop NSWindow to release
     pub fn uninstall_settings_vibrancy(_backdrop_ptr: usize) {}
 
     pub fn request_notification_permission() {
         // notify-rust on Windows uses WinRT ToastNotifications which don't
-        // require explicit permission from the app.
+        // require explicit permission from the app
     }
 
     pub fn register_reopen_handler() { /* no analog */ }
 
-    /// On Windows "Dock" == taskbar entry on the settings window.
-    ///   DockOnly → show in taskbar (remove WS_EX_TOOLWINDOW, add WS_EX_APPWINDOW)
-    ///   others   → hide from taskbar (add WS_EX_TOOLWINDOW, drop WS_EX_APPWINDOW)
+    /// On Windows "Dock" == taskbar entry on the settings window:
+    ///   DockOnly -> show in taskbar (remove WS_EX_TOOLWINDOW, add WS_EX_APPWINDOW)
+    ///   others -> hide from taskbar (add WS_EX_TOOLWINDOW, drop WS_EX_APPWINDOW)
     pub fn apply_app_visibility(vis: AppVisibility, settings: Option<&Window>) {
         let Some(win) = settings else { return; };
         let h = hwnd(win);
@@ -272,14 +272,14 @@ use super::*;
 
     /// Windows half of [`super::open_url`].  Scheme validation
     /// happens in the caller, which matters more here than
-    /// elsewhere: `ShellExecuteW` resolves whatever it is handed
+    /// elsewhere: `ShellExecuteW` resolves whatever it's handed
     /// through the shell association table, so a `file:` URL would
-    /// launch a local program.
+    /// launch a local program
     ///
     /// `Win32_UI_Shell` is already enabled for this crate, so this
     /// costs no new feature and no new dependency.  The return value
-    /// is an `HINSTANCE`-shaped error code by legacy convention:
-    /// anything `> 32` is success
+    /// is an `HINSTANCE`-shaped error code by legacy convention: anything
+    /// `> 32` is success
     pub(super) fn open_url_impl(url: &str) {
         use windows_sys::Win32::UI::{
             Shell::ShellExecuteW,

--- a/rust/crates/exhale-app/src/settings_window.rs
+++ b/rust/crates/exhale-app/src/settings_window.rs
@@ -47,7 +47,7 @@ pub struct SettingsWindow {
     /// minted from `GpuContext::new_render_device` so settings
     /// rendering doesn't serialize behind the overlay's GPU work
     /// on a single shared queue.  This is what removes the
-    /// hover-storm-induces-overlay-lag bottleneck on Windows.
+    /// hover-storm-induces-overlay-lag bottleneck on Windows
     device:                Arc<wgpu::Device>,
     queue:                 Arc<wgpu::Queue>,
     pending_reset:         bool,
@@ -63,41 +63,41 @@ pub struct SettingsWindow {
     /// can dispatch directly without `main.rs` having to poll a
     /// flag after every render.  The closure is `Send + Sync` so
     /// the settings window could be moved off the main thread
-    /// later — though right now it stays on main for egui_winit.
+    /// later, though right now it stays on main for egui_winit
     on_quit:               Box<dyn Fn() + Send + Sync + 'static>,
     /// Fired right after the user captures a new keyboard shortcut
-    /// (or resets one to its default) — the main loop receives an
+    /// (or resets one to its default); the main loop receives an
     /// `AppEvent::RebindHotkeys` and reconciles the global-hotkey
     /// registrations with the updated `settings.keyboard_shortcuts`
     on_rebind_hotkeys:     Box<dyn Fn() + Send + Sync + 'static>,
     /// Tracks the OS appearance so egui visuals + the wgpu clear color stay
     /// in sync with Light/Dark mode.  `None` means the platform doesn't
-    /// report a theme (some Linux desktops); we default to Dark there.
+    /// report a theme (some Linux desktops); we default to Dark there
     theme: Theme,
     /// Raw pointer to the NSVisualEffectView installed on macOS.  0 when
     /// not applicable (non-macOS, or EXHALE_DISABLE_VIBRANCY set).  When
     /// the theme changes we call `platform::update_settings_vibrancy`
     /// with this pointer so the blur material/appearance follows the
-    /// system's Light/Dark toggle.
+    /// system's Light/Dark toggle
     vev_ptr: usize,
     /// Lazy-loaded SF Symbol textures for the Start / Stop / Reset
     /// buttons in dark and light themes.  None on non-macOS or when the
-    /// rasteriser fails — callers fall back to Unicode glyphs.
+    /// rasteriser fails: callers fall back to Unicode glyphs
     icon_cache: IconCache,
     /// Last value passed to `set_max_inner_size` so we can no-op when
     /// the natural content height hasn't changed.  Calling
     /// `set_max_inner_size` every frame translates on macOS to
     /// `NSWindow.setContentMaxSize:`, and AppKit re-enforces the
-    /// constraint on every call — at egui's natural ~500 Hz event-
+    /// constraint on every call; at egui's natural ~500 Hz event-
     /// driven repaint rate during a live bottom-edge drag, this
     /// fights the user's pointer and the window feels stuck.
     /// Caching the last value reduces the call count to "once per
-    /// content-tree change" (≈ when settings actually change).
+    /// content-tree change" (≈ when settings actually change)
     last_max_height: Option<u32>,
 }
 
 /// Which control-button icon a lookup is for.  `usize` index into
-/// [`IconCache::handles`] — keep the variants in the same order as
+/// [`IconCache::handles`]: keep the variants in the same order as
 /// the array, accessors index by `kind as usize`
 #[derive(Clone, Copy)]
 enum IconKind {
@@ -111,16 +111,16 @@ const ICON_KIND_COUNT: usize = 4;
 
 /// Holds the texture handles for each control-button icon × theme.
 /// Loads both themes up-front (cheap: 8 × ~32×32 RGBA = ~32 KB) so
-/// the theme toggle doesn't have to re-rasterise on first paint.
+/// the theme toggle doesn't have to re-rasterise on first paint
 ///
 /// Storage is a flat 2-D array `[IconKind; 2]` (dark first, then
 /// light) with a single indexed lookup.  The SF Symbol name table
 /// lives in [`IconCache::load`] so adding a new icon is a one-line
 /// enum variant plus one row in the table
 struct IconCache {
-    /// `handles[kind as usize][dark as usize]` — `dark=true` is
+    /// `handles[kind as usize][dark as usize]`: `dark=true` is
     /// index 1.  `None` slot for either non-macOS (where
-    /// `render_sf_symbol` returns `None`) or rasterisation failure.
+    /// `render_sf_symbol` returns `None`) or rasterisation failure
     handles: [[Option<egui::TextureHandle>; 2]; ICON_KIND_COUNT],
 }
 
@@ -130,11 +130,11 @@ impl IconCache {
         // the `.circle.fill` variants (whole-icon designs with the
         // ring AND inner glyph baked in by Apple) so the macOS
         // rendering matches Swift's `Image(systemName:)` output
-        // pixel-for-pixel — Apple has already done the optical
+        // pixel-for-pixel: Apple has already done the optical
         // centring of the inner glyph against the surrounding ring,
         // so we don't have to fiddle with sub-pixel offsets.
         // Non-mac platforms paint their own ring + Unicode glyph
-        // (U+25B6, U+25A0, U+21BA, U+00D7) at the call site.
+        // (U+25B6, U+25A0, U+21BA, U+00D7) at the call site
         const NAMES: [&str; ICON_KIND_COUNT] = [
             "play.circle.fill",
             "stop.circle.fill",
@@ -161,16 +161,16 @@ impl IconCache {
 }
 
 // Window-placement helpers (clamp, apply, capture) live in
-// `crate::placement` — shared between the settings window here and
+// `crate::placement`: shared between the settings window here and
 // the windowed-mode animation window (`overlay::create_windowed_app`)
 // so both use the exact same persisted-position logic and survive
-// the same monitor-rearrangement edge cases.
+// the same monitor-rearrangement edge cases
 
 /// Rasterise an SF Symbol via AppKit, upload as an egui texture.
 /// 16 pt matches Swift's `Image(systemName:).imageScale(.medium)`
 /// next to a 12 pt label, the slot size [`widgets::control_button`]
 /// allocates for the whole `.circle.fill` icon.  Returns `None`
-/// off-macOS or if the symbol isn't found.
+/// off-macOS or if the symbol isn't found
 fn load_sf_icon(ctx: &egui::Context, name: &str, dark_mode: bool) -> Option<egui::TextureHandle> {
     // Rasterise at 13 pt to match the reduced ring diameter set in
     // `widgets::control_button` (`icon_w = 13.0`).  Pre-fix this
@@ -191,14 +191,14 @@ fn load_sf_icon(ctx: &egui::Context, name: &str, dark_mode: bool) -> Option<egui
 // reference so the segmented-picker column (right-aligned, uniform width
 // across every row) has room for "Rectangle" / "Sinusoidal" without
 // truncation while still leaving a visible gap between the left-aligned
-// label column and the right-aligned picker column.
+// label column and the right-aligned picker column
 pub(super) const SETTINGS_WIDTH: u32 = 360;
 /// Lower bound when dragging the bottom edge.  100 pt lets the user
 /// collapse the settings window down to just the titlebar + a sliver
 /// of the Controls row (Start / Stop / Reset / Quit buttons) for a
-/// "compact" mode — the ScrollArea handles everything below the
+/// "compact" mode: the ScrollArea handles everything below the
 /// drag.  Matches Swift's "resize this far if you want" behaviour
-/// while leaving a tighter floor than the previous 428 pt cap.
+/// while leaving a tighter floor than the previous 428 pt cap
 const SETTINGS_MIN_HEIGHT: u32 = 100;
 
 impl SettingsWindow {
@@ -211,14 +211,14 @@ impl SettingsWindow {
     ) -> Result<Self> {
         // Width is fixed; only height is user-resizable.  Max height is set
         // later (once egui has measured the natural content size) so the
-        // window can never extend past the last visible setting.
+        // window can never extend past the last visible setting
         //
         // Default height shows Controls + Appearance + Timing whole, with
-        // the top of Randomization visible so it is obvious there is more
-        // below.  Saved height (when present) wins over the default — the
-        // user's own resize is always respected on relaunch.
+        // the top of Randomization visible so it's obvious there's more
+        // below.  Saved height (when present) wins over the default; the
+        // user's own resize is always respected on relaunch
         //
-        // The number is unchanged, but what it frames is not.  Measured at
+        // The number is unchanged, but what it frames isn't.  Measured at
         // the shipped 308 pt card width, the Timing card went 160 pt ->
         // 202 pt with the pacing readout -> 324 pt with the preset chips.
         // Preserving the old fold, which sat below Randomization, would
@@ -226,15 +226,15 @@ impl SettingsWindow {
         // so the window would open with its own bottom edge off-screen.
         // Between "Randomization stays above the fold" and "the window
         // fits on the machine it opens on", the second wins, and Timing is
-        // now the card worth keeping whole anyway — it is where the
-        // presets, the steppers and the coverage line all live.
+        // now the card worth keeping whole anyway; it's where the
+        // presets, the steppers and the coverage line all live
         const INITIAL_PREFERRED_H: u32 = 796;
         // Sanity ceiling on the saved height: no real monitor is taller
         // than this in logical points, so anything above is corrupt
         // (typically from older builds that mistakenly persisted
         // PHYSICAL pixels and then re-multiplied them by the scale
         // factor every launch).  Falling back to the default lets a
-        // corrupted settings file self-heal on the next save.
+        // corrupted settings file self-heal on the next save
         const SETTINGS_MAX_LOGICAL_H: u32 = 4096;
         let saved_h = settings.settings_window_height
             .filter(|&h| h <= SETTINGS_MAX_LOGICAL_H);
@@ -243,7 +243,7 @@ impl SettingsWindow {
             .unwrap_or(false)
         {
             log::warn!(
-                "settings_window_height = {:?} pt is larger than {} — \
+                "settings_window_height = {:?} pt is larger than {}; \
                  ignoring (likely corrupted by physical-vs-logical bug \
                  in older builds); using default",
                 settings.settings_window_height,
@@ -253,12 +253,12 @@ impl SettingsWindow {
         let initial_h = saved_h
             .unwrap_or(INITIAL_PREFERRED_H)
             .max(SETTINGS_MIN_HEIGHT);
-        // Transparent settings window is macOS-only.
+        // Transparent settings window is macOS-only
         //
         // On macOS we install an NSVisualEffectView child window behind
         // the settings NSWindow to get the AppKit vibrancy / blur
         // backdrop; the wgpu surface clears at alpha 0 and the egui
-        // panel fill is `TRANSPARENT`, so the VEV shows through.
+        // panel fill is `TRANSPARENT`, so the VEV shows through
         //
         // On Windows + Linux we deliberately render the settings
         // window OPAQUE.  Previous attempts to wire up DWM acrylic on
@@ -268,17 +268,17 @@ impl SettingsWindow {
         //      window's translucent client area in the z-stack,
         //      making the breath animation render in FRONT of the
         //      settings window (so opacity=1.0 trivially hid the
-        //      controls — no way to edit them back).
+        //      controls: no way to edit them back).
         //   2. Mouse hover over the (DWM-composed alpha) settings
         //      window forced DWM to recomposite the whole acrylic
         //      stack per cursor move, producing very visible animation
         //      lag on Windows.
         // Both go away when the settings window is a plain opaque
-        // surface — `clear_color_for_theme` paints the themed panel
+        // surface: `clear_color_for_theme` paints the themed panel
         // colour directly and `panel_fill` is opaque too, so the
         // window is just a normal Windows / Linux app window.
         // macOS retains its vibrancy because Cocoa composes the VEV
-        // child window outside the wgpu pipeline entirely.
+        // child window outside the wgpu pipeline entirely
         let want_transparent = cfg!(target_os = "macos");
         let attrs = Window::default_attributes()
             .with_title("exhale")
@@ -296,7 +296,7 @@ impl SettingsWindow {
         // `with_inner_size(LogicalSize::new(SETTINGS_WIDTH, initial_h))`
         // using the persisted logical-points value, so this only
         // needs to deal with the cross-platform position restore
-        // (monitor-name lookup + clamp).
+        // (monitor-name lookup + clamp)
         crate::placement::apply_placement(
             event_loop,
             &window,
@@ -323,8 +323,8 @@ impl SettingsWindow {
         // output (mid-tone blends render brighter than intended under
         // sRGB).  Driver-bug guard: wgpu specifies `formats` as
         // non-empty, but a misbehaving driver could return an empty
-        // list — fall back to a hard-coded `Bgra8Unorm` rather than
-        // panic on `formats[0]`.
+        // list: fall back to a hard-coded `Bgra8Unorm` rather than
+        // panic on `formats[0]`
         let format = caps.formats.iter()
             .copied()
             .find(|f| !f.is_srgb())
@@ -337,8 +337,8 @@ impl SettingsWindow {
         // `PreMultiplied` is the next-best alpha-respecting mode (some
         // Linux/Wayland adapters expose it instead of PostMultiplied).
         // Fall back to `Auto` (typically Opaque) if neither is available
-        // — `clear_color_for_theme` handles that case by rendering the
-        // window opaquely.
+        // ; `clear_color_for_theme` handles that case by rendering the
+        // window opaquely
         let alpha_mode =
             if caps.alpha_modes.contains(&wgpu::CompositeAlphaMode::PostMultiplied) {
                 wgpu::CompositeAlphaMode::PostMultiplied
@@ -363,7 +363,7 @@ impl SettingsWindow {
         // Install the NSVisualEffectView with a theme-appropriate material
         // so the Dark-mode vibrancy uses a neutral blend (underWindowBackground)
         // that doesn't lighten dark backdrops, while Light mode uses hudWindow
-        // for a visibly translucent blur over bright desktops.
+        // for a visibly translucent blur over bright desktops
         let initial_theme = window.theme().unwrap_or(Theme::Dark);
         // RAII guard so the backdrop NSWindow is released even if some
         // future code between here and `Self { … }` adds a fallible
@@ -372,7 +372,7 @@ impl SettingsWindow {
         // `Self.vev_ptr`, the guard's `Drop` calls `uninstall_…` and
         // balances the retain.  Without this guard, a future `?` after
         // the vibrancy install would silently leak one NSWindow per
-        // SettingsWindow creation failure.
+        // SettingsWindow creation failure
         let vev_guard = BackdropGuard(platform::install_settings_vibrancy(
             &window, matches!(initial_theme, Theme::Dark),
         ));
@@ -383,22 +383,22 @@ impl SettingsWindow {
         // Ubuntu/Cantarell/Noto on Linux) so text in our settings window
         // matches the rest of the OS's system preferences.  Silently falls
         // back to egui's default Ubuntu font if the platform's system font
-        // isn't locatable — nothing critical breaks.
+        // isn't locatable: nothing critical breaks
         install_system_ui_font(&egui_ctx);
 
         // Pre-populate both style buckets with our custom visuals.  egui owns
         // separate dark_style / light_style slots and picks one per-frame
         // based on `ThemePreference` + `system_theme`.  Populating both up
         // front means whichever bucket egui selects already contains the
-        // correct visuals — no rewrite-on-switch, no risk of writing to the
-        // wrong bucket under a rapid toggle race.
+        // correct visuals: no rewrite-on-switch, no risk of writing to the
+        // wrong bucket under a rapid toggle race
         egui_ctx.set_visuals_of(egui::Theme::Dark,  visuals_for_theme(Theme::Dark));
         egui_ctx.set_visuals_of(egui::Theme::Light, visuals_for_theme(Theme::Light));
 
         // Pin the theme preference explicitly (not `System`) so egui never
-        // flips styles on our behalf based on a stale egui_winit `system_theme`
-        // — we remain the single authoritative source, driven by the
-        // render-time `window.theme()` poll below.
+        // flips styles on our behalf based on a stale egui_winit `system_theme`;
+        // we remain the single authoritative source, driven by the
+        // render-time `window.theme()` poll below
         let theme = initial_theme;
         egui_ctx.set_theme(theme_preference(theme));
 
@@ -413,15 +413,15 @@ impl SettingsWindow {
 
         let egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, false);
 
-        // Pre-rasterise SF Symbol icons for both themes — cheap one-shot
+        // Pre-rasterise SF Symbol icons for both themes: cheap one-shot
         // cost (~6 small RGBA blobs uploaded as textures) so the theme
-        // toggle doesn't have to lock-focus into AppKit on the hot path.
+        // toggle doesn't have to lock-focus into AppKit on the hot path
         let icon_cache = IconCache::load(&egui_ctx);
 
         // Take ownership of the backdrop pointer from the RAII guard.
         // If we reach this line, `Self` is being constructed and the
-        // guard's drop will be skipped — `vev_ptr` lives on with the
-        // window and is balanced by `Drop for SettingsWindow`.
+        // guard's drop will be skipped; `vev_ptr` lives on with the
+        // window and is balanced by `Drop for SettingsWindow`
         let vev_ptr = vev_guard.take();
 
         Ok(Self {
@@ -439,8 +439,8 @@ impl SettingsWindow {
     }
 
     /// Forward a window event to egui.
-    /// Returns (consumed, wants_repaint) — the caller uses `wants_repaint`
-    /// to drive redraws instead of polling every idle tick.
+    /// Returns (consumed, wants_repaint): the caller uses `wants_repaint`
+    /// to drive redraws instead of polling every idle tick
     pub fn on_window_event(&mut self, event: &WindowEvent) -> (bool, bool) {
         let response = self.egui_state.on_window_event(&self.window, event);
         match event {
@@ -449,8 +449,8 @@ impl SettingsWindow {
             // rapid System Settings toggles the queue can hold an in-flight
             // event whose value is already stale by the time we dequeue it,
             // leaving the window inverted for one frame.  Instead, just
-            // schedule a redraw — the render-time poll of `window.theme()`
-            // is the single authoritative source.
+            // schedule a redraw: the render-time poll of `window.theme()`
+            // is the single authoritative source
             WindowEvent::ThemeChanged(_) => self.window.request_redraw(),
             _ => {}
         }
@@ -463,9 +463,9 @@ impl SettingsWindow {
         self.config.height = size.height;
         self.surface.configure(&self.device, &self.config);
         // Keep the vibrancy backdrop NSWindow the same size as the
-        // settings window — AppKit auto-tracks child-window position but
+        // settings window: AppKit auto-tracks child-window position but
         // NOT size, so we copy the parent's frame onto the backdrop here.
-        // No-op on non-macOS or when `EXHALE_DISABLE_BLUR` is set.
+        // No-op on non-macOS or when `EXHALE_DISABLE_BLUR` is set
         platform::sync_settings_backdrop_frame(self.vev_ptr);
     }
 
@@ -473,7 +473,7 @@ impl SettingsWindow {
         self.window.request_redraw();
     }
 
-    /// Whether the right-click → Change Shortcut overlay is currently
+    /// Whether the right-click -> Change Shortcut overlay is currently
     /// open and waiting for the user's next key combination.  The
     /// main-loop dispatcher checks this before forwarding any
     /// `GlobalHotKeyEvent`s so a previously-bound hotkey doesn't
@@ -488,8 +488,8 @@ impl SettingsWindow {
 
     /// Externally arm shortcut-capture mode for `action`.  Used by
     /// the tray menu's "Keyboard Shortcuts ▶" submenu so the
-    /// capture overlay shows the next time we render — same flow as
-    /// the right-click → Change Shortcut path inside the settings
+    /// capture overlay shows the next time we render; same flow as
+    /// the right-click -> Change Shortcut path inside the settings
     /// window, just initiated from outside
     pub fn begin_capturing(&mut self, action: ShortcutAction) {
         self.capturing_shortcut_for = Some(action);
@@ -497,7 +497,7 @@ impl SettingsWindow {
 
     /// Raise the in-window Reset confirmation card on the next frame.
     /// Used by the Reset global hotkey (default Ctrl+Shift+D) on
-    /// every OS — macOS originally routed this through a native
+    /// every OS: macOS originally routed this through a native
     /// `NSAlert.runModal()` for the system look, but consolidated to
     /// the inline egui card so the confirmation chrome matches the
     /// button-click path the user already sees in the settings panel
@@ -507,9 +507,9 @@ impl SettingsWindow {
     }
 
     /// Render one egui frame onto the settings surface.
-    /// Returns the `repaint_delay` egui requests for its next frame — used by
+    /// Returns the `repaint_delay` egui requests for its next frame, used by
     /// the caller to schedule the next repaint via a deadline instead of
-    /// polling every idle tick.  `Duration::MAX` means no scheduled repaint.
+    /// polling every idle tick.  `Duration::MAX` means no scheduled repaint
     pub fn render(
         &mut self,
         settings:         &mut Settings,
@@ -520,14 +520,14 @@ impl SettingsWindow {
         // System Settings toggles on macOS/Windows, which leaves the egui
         // visuals inverted from the real appearance.  Re-querying here
         // guarantees the window can never stay out of sync for more than
-        // one frame regardless of how events were delivered.
+        // one frame regardless of how events were delivered
         //
         // We flip egui's `ThemePreference` (not `set_visuals`) because both
         // style buckets were pre-populated in `new()`.  `set_visuals` would
-        // write into whichever bucket `ctx.theme()` currently resolves to —
+        // write into whichever bucket `ctx.theme()` currently resolves to;
         // and under a rapid toggle that can be the wrong bucket (egui_winit
         // may not have fed the latest `system_theme` yet), leaving the
-        // wrong-colour visuals stuck in the bucket egui later selects.
+        // wrong-colour visuals stuck in the bucket egui later selects
         if let Some(current) = self.window.theme() {
             if current != self.theme {
                 self.theme = current;
@@ -536,8 +536,8 @@ impl SettingsWindow {
                 // the vibrancy blur tint follows the Light/Dark toggle.
                 // We do this ourselves because `install_settings_vibrancy`
                 // pinned the VEV's appearance explicitly (to avoid the
-                // AppKit auto-propagation crash) — without this call the
-                // blur would stay frozen at its install-time theme.
+                // AppKit auto-propagation crash): without this call the
+                // blur would stay frozen at its install-time theme
                 platform::update_settings_vibrancy(
                     self.vev_ptr,
                     matches!(current, Theme::Dark),
@@ -560,7 +560,7 @@ impl SettingsWindow {
         let mut content_height: f32 = 0.0;
         // `full_output.platform_output.copied_text` is taken on
         // macOS only (clipboard hand-off); on other platforms the
-        // binding is read-only, hence the cross-cfg `unused_mut`.
+        // binding is read-only, hence the cross-cfg `unused_mut`
         #[allow(unused_mut)]
         let mut full_output = self.egui_ctx.run(raw_input, |ctx| {
             content_height = settings_ui(
@@ -573,11 +573,11 @@ impl SettingsWindow {
             );
         });
 
-        // egui populates a repaint_delay per viewport — respect it so we can
+        // egui populates a repaint_delay per viewport; respect it so we can
         // stop blindly repainting every idle tick.  Short delays keep tooltip
         // fade-ins and button-press animations working; `Duration::MAX` means
         // nothing is animating and the window can sit idle until the next
-        // user/external event.
+        // user/external event
         let repaint_delay = full_output
             .viewport_output
             .get(&ViewportId::ROOT)
@@ -593,17 +593,17 @@ impl SettingsWindow {
         // Anything less than `2 * OUTER_PAD = 28.0` total leaves the
         // ScrollArea thinking it's under-tall and showing a scrollbar
         // even when every control fits, AND clamps the bottom-edge
-        // resize handle short of fitting the content.
+        // resize handle short of fitting the content
         //
         // Only forward the value to `set_max_inner_size` when the
-        // computed max differs from what we last sent — calling
+        // computed max differs from what we last sent, calling
         // `setContentMaxSize:` on macOS is NOT a no-op on equal
         // input; AppKit re-enforces the constraint on every call,
         // and at egui's event-driven ~500 Hz repaint rate during a
         // bottom-edge live drag, the constant re-enforcement fights
         // the user's pointer and the window feels stuck.  Caching
         // reduces the call rate to "once per layout change" (≈ when
-        // a setting changes or a section folds open/closed).
+        // a setting changes or a section folds open/closed)
         if content_height > 0.0 {
             let natural_h = (content_height + 2.0 * OUTER_PAD)
                 .ceil()
@@ -628,19 +628,19 @@ impl SettingsWindow {
         // `objc_retain` segfaults mid-session when the ivar backing the
         // NSCursor reference becomes stale (likely a consequence of our
         // vibrancy install reparenting winit's NSView under a sibling
-        // container, which winit's cursor tracking doesn't expect).
+        // container, which winit's cursor tracking doesn't expect)
         //
         // Neither hazard is reachable if we never let egui_winit hand the
         // platform output back to winit.  We do still need clipboard copy
         // (egui TextEdits write `copied_text` when the user presses ⌘C),
         // and `set_clipboard_text` is a pure arboard call that never
-        // touches winit state — safe to invoke from here.
+        // touches winit state: safe to invoke from here
         //
         // Cost on macOS: no cursor-icon changes (buttons / TextEdits keep
         // the default arrow), no IME cursor positioning (acceptable for a
         // Latin-text settings window), and no open_url handling (we don't
         // generate URL output anywhere).  All other platforms follow the
-        // normal path.
+        // normal path
         #[cfg(target_os = "macos")]
         {
             let copied = std::mem::take(&mut full_output.platform_output.copied_text);
@@ -707,10 +707,10 @@ impl Drop for SettingsWindow {
     /// Release the macOS NSVisualEffectView backdrop NSWindow we
     /// installed via `platform::install_settings_vibrancy`.  Without
     /// this we leaked one retained NSWindow per settings-window
-    /// lifecycle — visible in `leaks` reports and accumulating over
+    /// lifecycle: visible in `leaks` reports and accumulating over
     /// open/close cycles.  No-op on Windows / Linux (those platforms'
     /// `install_settings_vibrancy` returns 0 and the `uninstall`
-    /// matches with an early return).
+    /// matches with an early return)
     fn drop(&mut self) {
         platform::uninstall_settings_vibrancy(self.vev_ptr);
     }
@@ -720,14 +720,14 @@ impl Drop for SettingsWindow {
 /// [`platform::install_settings_vibrancy`].  Releases the +1 retain
 /// count via `uninstall_settings_vibrancy` if dropped without being
 /// `take()`-en.  Used inside [`SettingsWindow::new`] to make
-/// construction failure exception-safe — once `Self` is assembled,
+/// construction failure exception-safe: once `Self` is assembled,
 /// the long-lived `Drop for SettingsWindow` impl takes over and this
-/// guard is consumed.
+/// guard is consumed
 struct BackdropGuard(usize);
 
 impl BackdropGuard {
     /// Surrender ownership.  Caller is responsible for the eventual
-    /// `uninstall_settings_vibrancy` call.
+    /// `uninstall_settings_vibrancy` call
     fn take(mut self) -> usize {
         let ptr = self.0;
         self.0 = 0;       // Defuse so `Drop` no-ops.
@@ -747,18 +747,18 @@ impl Drop for BackdropGuard {
 // ─── Settings UI ─────────────────────────────────────────────────────────────
 //
 // Layout mirrors the Swift SettingsView exactly:
-//   • Controls  — Start / Stop / Reset
-//   • Appearance — colors, opacity, shape, gradient, animation, ripple, visibility
-//   • Timing    — 4 phase durations
-//   • Randomization — 4 jitter sliders + drift
-//   • Timers    — reminder + auto-stop
+//   • Controls: Start / Stop / Reset
+//   • Appearance: colors, opacity, shape, gradient, animation, ripple, visibility
+//   • Timing: 4 phase durations
+//   • Randomization: 4 jitter sliders + drift
+//   • Timers: reminder + auto-stop
 
 /// Returns the natural (fully-expanded) content height in logical points so
 /// the caller can clamp the window's max size.
 /// Attach the right-click "Change Shortcut…" / "Reset to Default"
 /// menu to a control-button `Response`.  Lives next to the buttons
 /// rather than inside [`control_button`] because tooltip help text is
-/// already passed in — the context-menu hook is independent of the
+/// already passed in: the context-menu hook is independent of the
 /// glyph rendering and easier to reason about as a separate concern
 fn shortcut_context_menu(
     resp:                   &egui::Response,
@@ -795,7 +795,7 @@ fn shortcut_context_menu(
     });
 }
 
-/// Shared one-line helper for the button tooltip text — embeds the
+/// Shared one-line helper for the button tooltip text, embeds the
 /// current binding when present, or "Right-click to set." when the
 /// slot is unbound (the default for Start / Stop / Reset / Quit
 /// after the "no opt-in defaults" simplification)
@@ -822,7 +822,7 @@ fn settings_ui(
 ) -> f32 {
     let mut dirty = false;
     let mut content_height = 0.0f32;
-    // Set on any action that updates `settings.keyboard_shortcuts` — both
+    // Set on any action that updates `settings.keyboard_shortcuts`, both
     // direct rebinds via the capture overlay and the per-action "Reset to
     // Default" context-menu entry need to fire `on_rebind_hotkeys` so
     // `main.rs` re-registers with the global-hotkey manager.  Set inside
@@ -847,13 +847,13 @@ fn settings_ui(
     //     overlay would composite right back into "solid white" and
     //     hide the vibrancy entirely, so we leave the panel fully
     //     transparent and let vibrancy be the sole gutter material.
-    // Fully-transparent panel fill matches Swift's look exactly.
+    // Fully-transparent panel fill matches Swift's look exactly
     //
     // The NSVisualEffectView's `.hudWindow` blur masks backdrop content
     // (terminal text, etc.) enough that nothing legible leaks through
-    // the 14-px gutters.
+    // the 14-px gutters
     //
-    // Other platforms: opaque fallback (they have no vibrancy backend).
+    // Other platforms: opaque fallback (they have no vibrancy backend)
     let panel_fill = if platform::is_blur_active() {
         egui::Color32::TRANSPARENT
     } else if ctx.style().visuals.dark_mode {
@@ -870,25 +870,25 @@ fn settings_ui(
         // sections it contains can never be wider than the window's 14-px
         // horizontal gutters.  Using `max_width` here (rather than
         // `ui.set_width` on each card) propagates down through the nested
-        // `available_width` chain — so rows inside the cards also know the
+        // `available_width` chain: so rows inside the cards also know the
         // true right edge and right-aligned widgets (color swatches,
         // stepper fields, segmented pickers) end up flush with the card
-        // boundary instead of extending past it.
+        // boundary instead of extending past it
         let scroll_max_w = SETTINGS_WIDTH as f32 - 2.0 * OUTER_PAD;
         let scroll_out = egui::ScrollArea::vertical()
             .auto_shrink([false; 2])
             .max_width(scroll_max_w)
             .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::VisibleWhenNeeded)
             .show(ui, |ui| {
-            // `sectionSpacing: 10` — vertical gap between SectionCard instances.
+            // `sectionSpacing: 10`: vertical gap between SectionCard instances
             ui.spacing_mut().item_spacing.y = SECTION_GAP;
 
             // Measure every segmented picker in the Appearance section once,
             // pick the widest natural width, and use it as the uniform column
             // width for all of them.  This guarantees the leftmost option of
             // every picker lands on the same X, regardless of option count
-            // or text length — and the column only extends as far left as
-            // the widest picker requires.
+            // or text length, and the column only extends as far left as
+            // the widest picker requires
             let picker_column_w = uniform_picker_column_width(ui, &[
                 &["Rectangle", "Circle", "Full"],
                 &["Inner", "Off", "On"],
@@ -897,13 +897,13 @@ fn settings_ui(
                 &["Top Bar", "Dock", "Both"],
             ]);
 
-            // ── Controls (no header — matches Swift's top SectionCard) ───────
+            // ── Controls (no header; matches Swift's top SectionCard) ───────
             // Swift has only THREE buttons: Start, Stop, Reset.  Pause is
             // implemented in `SettingsModel` but isn't exposed in the
             // SwiftUI `SettingsView`, so we omit it here too for 1:1
             // parity.  `Ctrl+Shift+S` (stop) handles "I want it to halt"
             // and the breathing controller treats `is_animating=false`
-            // the same as paused for the purposes of stopping renders.
+            // the same as paused for the purposes of stopping renders
             section(ui, "", |ui| {
                 ui.horizontal(|ui| {
                     const BUTTON_SPACING: f32 = 8.0;
@@ -921,7 +921,7 @@ fn settings_ui(
                     // (possibly user-customised) shortcut binding.  Re-read
                     // from `settings.keyboard_shortcuts` every frame so the
                     // tooltip stays in sync with whatever the user just
-                    // captured in the right-click → Change Shortcut overlay.
+                    // captured in the right-click -> Change Shortcut overlay
                     let start_help = format!(
                         "Start the app and re-initialize animation.\n{}",
                         shortcut_tooltip_line(settings, ShortcutAction::Start),
@@ -949,7 +949,7 @@ fn settings_ui(
                         // Segoe UI's low-left U+25B6 placement.
                         // macOS keeps using Apple's `play.circle.fill`
                         // because the triangle flag yields to the
-                        // texture path when one is available.
+                        // texture path when one is available
                         "\u{25B6}", icons.play(dark),
                         None, 0.0, false, true,
                         "Start",
@@ -968,9 +968,9 @@ fn settings_ui(
                     let stop_resp = control_button(
                         ui, btn_w,
                         // `icon` and `icon_texture` are both ignored
-                        // when `draw_inner_square: true` — we paint a
+                        // when `draw_inner_square: true`: we paint a
                         // primitive square instead.  Pass placeholders
-                        // for documentation continuity.
+                        // for documentation continuity
                         "\u{25A0}", icons.stop(dark),
                         None, 0.0, true, false,
                         "Stop",
@@ -992,7 +992,7 @@ fn settings_ui(
                         // U+21BA ANTICLOCKWISE OPEN CIRCLE ARROW lives
                         // in the Arrows block, and Segoe UI draws it
                         // taller than the Geometric Shapes glyphs
-                        // (`▶ ■`) — arrows traditionally reach into
+                        // (`▶ ■`): arrows traditionally reach into
                         // the ascender region.  At the 8 pt default
                         // the arrow is already pixel-tight; nudge to
                         // 9 pt for visual parity with the other
@@ -1001,7 +1001,7 @@ fn settings_ui(
                         // uses the SF Symbol texture which is sized
                         // uniformly.
                         // Scaled with the 13 pt ring (was 9.0 alongside
-                        // the 16 pt ring; 7.3 ≈ 9.0 × 13 / 16 → 7.5
+                        // the 16 pt ring; 7.3 ≈ 9.0 × 13 / 16 -> 7.5
                         // rounded keeps the arrow visually centred
                         // without poking past the ring's rim on the
                         // Unicode-fallback path)
@@ -1015,7 +1015,7 @@ fn settings_ui(
                     );
                     if reset_resp.clicked() {
                         // Defer the actual reset to an inline
-                        // confirmation card below the button row —
+                        // confirmation card below the button row;
                         // an unconfirmed Reset wipes every setting
                         // including custom keyboard shortcuts, and
                         // a single misclick (or focused-Reset + Space
@@ -1023,32 +1023,32 @@ fn settings_ui(
                         // be unrecoverable.  Setting `pending_reset`
                         // makes the confirmation card render this
                         // frame; the user picks Cancel or Reset to
-                        // resolve it.  Idempotent — clicking Reset
+                        // resolve it.  Idempotent: clicking Reset
                         // again while already pending is a no-op
                         *pending_reset = true;
                     }
-                    // Quit — full shutdown.  Dispatches directly via the
+                    // Quit: full shutdown.  Dispatches directly via the
                     // injected `on_quit` callback (set up at
                     // `SettingsWindow::new`) so we don't need `main.rs`
                     // to poll a `pending_quit` flag after every render.
                     // Matches the tray-menu Quit path so all teardown
                     // (settings flush, controller stop, tray destroy)
-                    // runs in the canonical order.
+                    // runs in the canonical order
                     let quit_resp = control_button(
                         ui, btn_w,
-                        // U+00D7 MULTIPLICATION SIGN — Latin-1 Supplement
+                        // U+00D7 MULTIPLICATION SIGN: Latin-1 Supplement
                         // block, part of basic Western font coverage so
                         // every TTF / OTF system UI font carries it by
                         // default.  Previous attempts (U+23FB POWER
                         // SYMBOL, U+2715 HEAVY MULTIPLICATION X) lived
                         // in Misc Technical / Dingbats blocks, and
                         // Segoe UI's regular face on Windows skips
-                        // those — egui's font-fallback chain then
+                        // those: egui's font-fallback chain then
                         // rendered the tofu / missing-glyph box.
                         // `×` reads unambiguously as "close / quit" at
                         // glyph-icon scale and stays monochrome so it
                         // pairs with the other Geometric-Shapes icons
-                        // (▶ / ■ / ↺) in the row.
+                        // (▶ / ■ / ↺) in the row
                         //
                         // `×` is intrinsically sized to lowercase
                         // x-height (Latin-1 lives alongside `é` `ñ`
@@ -1056,7 +1056,7 @@ fn settings_ui(
                         // visibly shorter than the full-em-box
                         // Geometric Shapes glyphs.  Bump it ~50% so
                         // `×` lands at the same visible height as the
-                        // other three icons inside the 16 pt circle.
+                        // other three icons inside the 16 pt circle
                         "\u{00D7}", icons.quit(dark),
                         // `×` lives at the math-axis (below the
                         // em-centre) instead of the em-centre where
@@ -1071,7 +1071,7 @@ fn settings_ui(
                         // offset is small enough at 1 px that the
                         // texture path is still acceptably aligned
                         // Scaled with the 13 pt ring (was 12.0 alongside
-                        // the 16 pt ring; 9.75 ≈ 12.0 × 13 / 16 → 10.0
+                        // the 16 pt ring; 9.75 ≈ 12.0 × 13 / 16 -> 10.0
                         // rounded so the `×` keeps its visible weight
                         // against the smaller ring on the Unicode-
                         // fallback path)
@@ -1095,7 +1095,7 @@ fn settings_ui(
                 // Ctrl+Shift+D global hotkey on non-macOS).  Lives
                 // inside the same `section` as the buttons so the
                 // prompt sits in the document flow rather than as a
-                // floating `egui::Window` popup — the user asked
+                // floating `egui::Window` popup: the user asked
                 // for it integrated into the settings UI directly.
                 // Reset is destructive (wipes every setting AND the
                 // user's custom keyboard shortcuts), so the
@@ -1109,7 +1109,7 @@ fn settings_ui(
                     ui.add_space(ROW_GAP);
                     let dark_mode = ui.visuals().dark_mode;
                     let warning_color = if dark_mode {
-                        // Pastel red on dark — enough contrast to
+                        // Pastel red on dark: enough contrast to
                         // read as "warning" without screaming
                         egui::Color32::from_rgb(255, 130, 130)
                     } else {
@@ -1129,7 +1129,7 @@ fn settings_ui(
                     );
                     ui.add_space(4.0);
                     // Cancel + Reset are paired, equal-weight
-                    // actions — easier to read when they share the
+                    // actions: easier to read when they share the
                     // exact same footprint and sit symmetrically
                     // under the warning text rather than left-
                     // aligned and unevenly sized (Cancel's longer
@@ -1156,7 +1156,7 @@ fn settings_ui(
                         if left_pad > 0.0 {
                             ui.add_space(left_pad);
                         }
-                        // Cancel — muted default styling.  Esc also
+                        // Cancel: muted default styling.  Esc also
                         // dismisses via the input handling below so
                         // a user who hit Reset by accident can fall
                         // back to the keyboard
@@ -1166,7 +1166,7 @@ fn settings_ui(
                         ).clicked() {
                             *pending_reset = false;
                         }
-                        // Reset — destructive, red label.  Same
+                        // Reset: destructive, red label.  Same
                         // dimensions as Cancel so the visual weight
                         // of the choice is equal; the colour is the
                         // only thing that flags it as the dangerous
@@ -1195,7 +1195,7 @@ fn settings_ui(
                         }
                     });
                     // Esc dismisses the confirmation without
-                    // resetting — matches the platform convention
+                    // resetting: matches the platform convention
                     // for any prompt with a Cancel button.  Only
                     // consume the key while the prompt is open so
                     // it stays available to text fields / other
@@ -1210,14 +1210,14 @@ fn settings_ui(
 
             // ── Appearance ───────────────────────────────────────────────────
             section(ui, "Appearance", |ui| {
-                // Inhale color — no alpha (Swift: supportsOpacity: false)
+                // Inhale color: no alpha (Swift: supportsOpacity: false)
                 labeled_row(ui, "Inhale Color", |ui| {
                     let mut c = to_color32(settings.inhale_color);
                     let resp = egui::color_picker::color_edit_button_srgba(
                         ui, &mut c, egui::color_picker::Alpha::Opaque,
                     );
                     // Scroll the picker into view when Tab moves
-                    // focus to it from above/below the viewport —
+                    // focus to it from above/below the viewport;
                     // egui's stock color button doesn't auto-scroll
                     // on its own, so an off-screen color row would
                     // silently swallow a Tab press otherwise
@@ -1230,7 +1230,7 @@ fn settings_ui(
                     }
                 }).on_hover_text("Choose the color for the inhale phase.");
 
-                // Exhale color — no alpha (Swift: supportsOpacity: false)
+                // Exhale color: no alpha (Swift: supportsOpacity: false)
                 labeled_row(ui, "Exhale Color", |ui| {
                     let mut c = to_color32(settings.exhale_color);
                     let resp = egui::color_picker::color_edit_button_srgba(
@@ -1245,14 +1245,14 @@ fn settings_ui(
                     }
                 }).on_hover_text("Choose the color for the exhale phase.");
 
-                // Background color (with alpha) — disabled for Fullscreen (matches Swift)
+                // Background color (with alpha); disabled for Fullscreen (matches Swift)
                 labeled_row(ui, "Background Color", |ui| {
                     // Background color is only visually meaningful when
                     // `shape != Fullscreen`, but we deliberately render
                     // the picker enabled regardless.  Wrapping it in
                     // `add_enabled_ui(false, ...)` made egui call
                     // `surrender_focus` on the disabled widget every
-                    // time Tab landed there — focus was lost mid-cycle
+                    // time Tab landed there; focus was lost mid-cycle
                     // and the next Tab wrapped back to the first
                     // focusable widget (Start button), so users with
                     // `shape = Fullscreen` saw Tab go button-button-
@@ -1273,9 +1273,9 @@ fn settings_ui(
                     }
                 }).on_hover_text("Choose the background color. No effect when Shape is Fullscreen.");
 
-                // Overlay opacity — Swift stores 0.0..1.0, displays 0..100 %.
+                // Overlay opacity: Swift stores 0.0..1.0, displays 0..100 %.
                 // Wrap with an f64 shim because ValueScale::Percent operates
-                // on `*value / 100.0` and settings.overlay_opacity is f32.
+                // on `*value / 100.0` and settings.overlay_opacity is f32
                 let mut opacity_pct = settings.overlay_opacity as f64;
                 if stepper_row(
                     ui, "Overlay Opacity (%)",
@@ -1300,9 +1300,9 @@ fn settings_ui(
                     ],
                 ) { dirty = true; }
 
-                // Gradient — order matches Swift's enum declaration (Inner, Off, On)
+                // Gradient: order matches Swift's enum declaration (Inner, Off, On)
                 // so segmented-picker placement is identical to the macOS app.
-                // Gradient picker stays focusable regardless of shape —
+                // Gradient picker stays focusable regardless of shape;
                 // passing `enabled = false` to `segmented_row` triggers
                 // egui's disabled-widget `surrender_focus` path, which
                 // broke Tab navigation downstream (see Background Color
@@ -1320,7 +1320,7 @@ fn settings_ui(
                     ],
                 ) { dirty = true; }
 
-                // Animation mode — labels use Swift's enum raw values.
+                // Animation mode: labels use Swift's enum raw values
                 if segmented_row(
                     ui, "Animation",
                     "Sinusoidal eases in/out naturally. Linear is constant speed.",
@@ -1332,8 +1332,8 @@ fn settings_ui(
                     ],
                 ) { dirty = true; }
 
-                // Hold ripple — order matches Swift's enum declaration
-                // (Gradient, Stark, Off) so the default (Gradient) sits first.
+                // Hold ripple: order matches Swift's enum declaration
+                // (Gradient, Stark, Off) so the default (Gradient) sits first
                 if segmented_row(
                     ui, "Hold Ripple",
                     "Hold phase ripple: Gradient (smooth glow), Stark (solid edge), or Off.",
@@ -1362,9 +1362,9 @@ fn settings_ui(
 
             // ── Timing ───────────────────────────────────────────────────────
             section(ui, "Timing", |ui| {
-                // Above the steppers, not below: the whole point of a
+                // Above the steppers: the whole point of a
                 // chip is that clicking it visibly moves all four rows
-                // under it, which is not something the user has to be
+                // under it, which isn't something the user has to be
                 // told if they can watch it happen
                 if preset_chips(ui, settings) { dirty = true; }
                 if duration_row(ui, "Inhale Duration (s)",  "Duration of the inhale phase, in seconds.",             &mut settings.inhale_duration) { dirty = true; }
@@ -1388,12 +1388,12 @@ fn settings_ui(
                 if pct_row(ui, "Exhale (%)",           "Randomize exhale duration by this percentage.",            &mut settings.randomized_timing_exhale) { dirty = true; }
                 if pct_row(ui, "Post-Exhale Hold (%)", "Randomize post-exhale hold duration by this percentage.",  &mut settings.randomized_timing_post_exhale_hold) { dirty = true; }
 
-                // Drift — stored as a per-cycle multiplier (1.01 = +1 %), displayed
+                // Drift: stored as a per-cycle multiplier (1.01 = +1 %), displayed
                 // as a percentage above 1.0 so "1" reads as "+1 % per cycle".
                 // Swift's stepper has no upper limit (`max: nil`).  Minimum
-                // stays at 0 % (drift = 1.0) per the `defaultMin` clamp.
+                // stays at 0 % (drift = 1.0) per the `defaultMin` clamp
                 //
-                // Step is 0.1 percentage points, not 1: compounding makes whole
+                // Step is 0.1 percentage points: compounding makes whole
                 // percents enormous. 1 % doubles the breath in 70 breaths, which
                 // runs away inside one sitting; 0.1 % takes 693, which is a
                 // working day. Counted in breaths rather than minutes because
@@ -1402,11 +1402,11 @@ fn settings_ui(
                 // sat entirely below the old minimum step, so whole percents
                 // offered no gentle setting at all. Finer values can still be
                 // typed: `format_num` caps display at three decimals, so 0.001 %
-                // is the finest value the field round-trips.
+                // is the finest value the field round-trips
                 //
                 // Display is `(stored - 1) * 100`, so the user reads 0 for "off"
                 // and never sees the multiplier. One step up from off is 0.1 %,
-                // stored as 1.001. See `ValueScale::DriftPercent`.
+                // stored as 1.001. See `ValueScale::DriftPercent`
                 if stepper_row(
                     ui, "Drift (%)",
                     "Lengthens every cycle by this much, compounding, for pranayama-style graded extension. Off by default. Type a value for finer control than the arrows give.",
@@ -1447,7 +1447,7 @@ fn settings_ui(
     // widget that registers interest on the NEXT frame (via
     // `give_to_next`).  Tab itself is a keyboard event that
     // egui-winit reports with `repaint: true`, so a follow-up frame
-    // normally runs and the wrap completes — but if anything in the
+    // normally runs and the wrap completes; but if anything in the
     // caller skips that second frame, the user sees focus
     // disappear instead of wrapping to the top.  Explicit
     // `request_repaint` guarantees the second frame runs no matter
@@ -1497,12 +1497,12 @@ fn settings_ui(
 
         // egui::Window's `.open()` flips `still_capturing` to false when
         // the user clicks the title-bar close button.  Either signal
-        // cancels capture and leaves the binding unchanged.
+        // cancels capture and leaves the binding unchanged
         if !still_capturing || closed_via_button {
             *capturing_shortcut_for = None;
         } else {
             // Inspect this frame's input events for a key press matching
-            // the "valid combo" criteria (at least one modifier).
+            // the "valid combo" criteria (at least one modifier)
             let captured = ctx.input(|i| {
                 for event in &i.events {
                     if let egui::Event::Key { key, modifiers, pressed: true, repeat: false, .. } = event {
@@ -1511,7 +1511,7 @@ fn settings_ui(
                         }
                         // Reject plain printable keys with no modifier so
                         // the user doesn't accidentally bind `A` to Start
-                        // and then lose access to every text field.
+                        // and then lose access to every text field
                         let has_modifier = modifiers.ctrl
                             || modifiers.shift
                             || modifiers.alt
@@ -1547,7 +1547,7 @@ fn settings_ui(
 
     // Reset confirmation is now rendered inline inside the
     // Controls section above (see the `if *pending_reset` block)
-    // rather than as a floating `egui::Window` popup — matches
+    // rather than as a floating `egui::Window` popup, matches
     // the user request to integrate the confirmation into the
     // settings UI rather than spawn a separate window
 
@@ -1558,7 +1558,7 @@ fn settings_ui(
 
 // Swift's SectionCard: 10 px rounded rect, 1 px stroke at `Color.primary.opacity(0.06)`,
 // fill at `Color(NSColor.controlBackgroundColor).opacity(0.55)`, 12 px internal padding.
-// Header (when present) is 10 pt uppercase `.secondary` with 0.8 pt letter-spacing.
+// Header (when present) is 10 pt uppercase `.secondary` with 0.8 pt letter-spacing
 
 // ─── Tests ───────────────────────────────────────────────────────────────
 //
@@ -1566,7 +1566,7 @@ fn settings_ui(
 // feeding synthetic pointer events to verify the stepper_row widgets
 // respond to clicks without panicking.  That exercises the exact code
 // path the user complained about: "click the up and down stepper buttons
-// they do nothing".
+// they do nothing"
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1574,11 +1574,11 @@ mod tests {
 
     // Clamp-helper tests for the position-restore path live in
     // `crate::placement::tests` now that the helpers are shared
-    // between this window and the windowed-mode animation window.
+    // between this window and the windowed-mode animation window
 
     /// Build a single RawInput frame with a pointer move to `pos` followed
     /// by a down+up primary click at that position.  egui requires BOTH
-    /// the down and up within the same frame to register as a `clicked()`.
+    /// the down and up within the same frame to register as a `clicked()`
     fn click_input(pos: Pos2) -> RawInput {
         RawInput {
             screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(400.0, 800.0))),
@@ -1593,7 +1593,7 @@ mod tests {
 
     /// Run a single frame of the stepper_row helper, returning the
     /// TextEdit's rect so tests can target the stepper rect relative to
-    /// it.  `click` is fed as the RawInput for this frame.
+    /// it.  `click` is fed as the RawInput for this frame
     fn run_stepper_frame(
         ctx:     &Context,
         raw_in:  RawInput,
@@ -1603,11 +1603,11 @@ mod tests {
         let mut changed = false;
         // egui::Context::run returns `FullOutput`; we don't need it
         // here because the test only inspects the side effect on
-        // `changed`.
+        // `changed`
         let _ = ctx.run(raw_in, |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 // Force the ui wide enough that stepper_row's layout is
-                // the same as in the real app.
+                // the same as in the real app
                 ui.set_width(332.0);
                 changed = stepper_row(
                     ui,
@@ -1628,10 +1628,10 @@ mod tests {
     /// Warm-up frame registers the stepper's interact rects in egui's
     /// memory AND records the exact top/bot rects via the `test_hooks`
     /// side channel.  Then the click frame targets the center of the
-    /// recorded up/down half.
+    /// recorded up/down half
     fn simulate_click_on_stepper(ctx: &Context, value: &mut f64, click_up: bool) -> bool {
         // Frame A (warmup): no input, just run stepper_row to register
-        // widgets and capture sub-rects.
+        // widgets and capture sub-rects
         let mut value_probe = *value;
         let _ = ctx.run(RawInput {
             screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(400.0, 800.0))),
@@ -1650,7 +1650,7 @@ mod tests {
         let (top_rect, bot_rect) = super::widgets::test_hooks::take_stepper_rects()
             .expect("stepper_buttons should have recorded its rects during warmup frame");
 
-        // Frame B: click the center of the desired half.
+        // Frame B: click the center of the desired half
         let target = if click_up { top_rect } else { bot_rect };
         let click_pos = target.center();
         run_stepper_frame(ctx, click_input(click_pos), value, "Test")
@@ -1658,12 +1658,12 @@ mod tests {
 
     /// Content width inside a section card: `SETTINGS_WIDTH` minus the
     /// outer gutters and the card padding. The chips have to wrap
-    /// against the real number, not a convenient one
+    /// against the real number rather than a convenient one
     const CARD_CONTENT_W: f32 = SETTINGS_WIDTH as f32 - 2.0 * OUTER_PAD - 2.0 * CARD_PAD;
 
-    /// Run one frame of `preset_chips` inside a real `section` card.
+    /// Run one frame of `preset_chips` inside a real `section` card
     ///
-    /// The card, not a bare `ui.set_width`, because `set_width` on a
+    /// The card rather than a bare `ui.set_width`, because `set_width` on a
     /// `CentralPanel`'s own `Ui` is silently undone: `Placer::set_max_width`
     /// unions the result back with `min_rect`, which for a panel is already
     /// the full panel. The first version of this harness therefore laid the
@@ -1705,7 +1705,7 @@ mod tests {
         }
     }
 
-    /// Warm-up frame to register the chip rects, then hand them back.
+    /// Warm-up frame to register the chip rects, then hand them back
     fn chip_rects(ctx: &Context, settings: &mut exhale_core::settings::Settings) -> Vec<Rect> {
         let mut probe = settings.clone();
         let _ = run_chips_frame(ctx, blank_input(), &mut probe);
@@ -1717,7 +1717,7 @@ mod tests {
     fn clicking_a_chip_moves_all_four_durations() {
         let ctx = Context::default();
         let mut settings = exhale_core::settings::Settings::default();
-        // Deliberately NOT chip 0: that is the shipped default, so
+        // Deliberately NOT chip 0: that's the shipped default, so
         // clicking it would leave every field at the value it already
         // had and the test would pass without proving anything moved.
         // Chip 3 is box breathing, which differs in all four
@@ -1741,7 +1741,7 @@ mod tests {
 
     #[test]
     fn space_activates_a_focused_chip() {
-        // The handoff flagged this as unverified: it was not known
+        // The handoff flagged this as unverified: it wasn't known
         // whether egui 0.29 synthesises a click from Space on a focused
         // `ui.interact` response the way it does for `Button`. It does
         // (`Context::create_widget` sets `fake_primary_click`), and
@@ -1803,7 +1803,7 @@ mod tests {
 
         let left = rects[0].min.x;
         for (i, r) in rects.iter().enumerate() {
-            // Wrapping, not clipping. A chip wider than the card would
+            // Wrapping rather than clipping. A chip wider than the card would
             // be a label that no longer describes its own pattern
             assert!(
                 r.width() <= CARD_CONTENT_W + 0.5,
@@ -1826,7 +1826,7 @@ mod tests {
         // is the property worth keeping rather than the exact result: a
         // sixth preset, or a label long enough to need three rows, turns
         // the block back into the four-line stack this was tightened to
-        // avoid. Wrapping to a second row is fine; wrapping past it is a
+        // avoid. Wrapping to a second row is fine; wrapping past it's a
         // design decision that should be made on purpose
         let rows = rects.iter().map(|r| r.min.y as i32).collect::<std::collections::BTreeSet<_>>();
         assert!(
@@ -1838,7 +1838,7 @@ mod tests {
 
     #[test]
     fn nudging_one_stepper_unselects_every_chip() {
-        // Derived selection, stated as a behaviour. There is no
+        // Derived selection, stated as a behaviour. There's no
         // "Custom" chip to light up instead: custom is the absence of
         // a lit pill
         let ctx = Context::default();
@@ -1880,10 +1880,10 @@ mod tests {
         let mut value = 5.0_f64;
         // simulate_click_on_stepper runs a warmup frame (registers the
         // stepper's interact rects in egui memory) followed by a click
-        // frame.  Exactly one click per invocation.
+        // frame.  Exactly one click per invocation
         let changed = simulate_click_on_stepper(&ctx, &mut value, true);
         assert!(changed, "UP click should change the value");
-        assert_eq!(value, 6.0, "UP click should increment by step=1.0 (5 → 6)");
+        assert_eq!(value, 6.0, "UP click should increment by step=1.0 (5 -> 6)");
     }
 
     #[test]
@@ -1892,7 +1892,7 @@ mod tests {
         let mut value = 5.0_f64;
         let changed = simulate_click_on_stepper(&ctx, &mut value, false);
         assert!(changed, "DOWN click should change the value");
-        assert_eq!(value, 4.0, "DOWN click should decrement by step=1.0 (5 → 4)");
+        assert_eq!(value, 4.0, "DOWN click should decrement by step=1.0 (5 -> 4)");
     }
 
     #[test]
@@ -1907,7 +1907,7 @@ mod tests {
     fn stepper_many_clicks_no_crash() {
         // Regression test for the user-reported "after a few clicks it
         // crashes": drive ~50 alternating UP/DOWN clicks and make sure
-        // nothing panics and the value stays finite.
+        // nothing panics and the value stays finite
         let ctx = Context::default();
         let mut value = 10.0_f64;
         for i in 0..50 {
@@ -1919,7 +1919,7 @@ mod tests {
     #[test]
     fn stepper_repeated_ups_accumulate() {
         // Each call to simulate_click_on_stepper performs ONE click,
-        // so N invocations should give N increments (5 + 3 = 8).
+        // so N invocations should give N increments (5 + 3 = 8)
         let ctx = Context::default();
         let mut value = 5.0_f64;
         for _ in 0..3 {

--- a/rust/crates/exhale-app/src/settings_window/theme.rs
+++ b/rust/crates/exhale-app/src/settings_window/theme.rs
@@ -1,13 +1,13 @@
-//! Theme + visuals helpers for the settings window.
+//! Theme + visuals helpers for the settings window
 //!
 //! Three responsibilities:
 //!   - Install an OS-native UI font on the egui context so settings
 //!     text reads as SF Pro on macOS, Segoe UI on Windows, Ubuntu/
-//!     Cantarell on Linux.
+//!     Cantarell on Linux
 //!   - Build the per-theme [`egui::Visuals`] used by the settings
-//!     window (text colour, widget rounding, stepper chrome, etc.).
+//!     window (text colour, widget rounding, stepper chrome, etc.)
 //!   - Pick the wgpu surface clear colour for the current theme +
-//!     OS-blur availability.
+//!     OS-blur availability
 use egui::ThemePreference;
 use winit::window::Theme;
 
@@ -16,7 +16,7 @@ use crate::platform;
 /// Corner radius used for egui widget chrome (TextEdit, comboboxes,
 /// etc.) inside the settings window.  Hand-painted widgets (stepper,
 /// segmented picker, control button) draw their own rounding via
-/// `painter.rect_*` and pass their own constants — they aren't
+/// `painter.rect_*` and pass their own constants; they aren't
 /// affected by this value.  Kept here (not in the parent module's
 /// layout constants) so [`visuals_for_theme`] can be tested in
 /// isolation
@@ -26,15 +26,15 @@ const TEXT_EDIT_RADIUS: f32 = 5.0;
 /// font on the egui context.  Each platform's system-preferences app uses a
 /// specific typeface (SF Pro on macOS, Segoe UI on Windows, Ubuntu/Cantarell
 /// on common Linux desktops); matching that here makes our settings window
-/// read as a native part of the OS instead of egui's default Ubuntu fallback.
+/// read as a native part of the OS instead of egui's default Ubuntu fallback
 ///
-/// System fonts are NOT redistributed — we read the font file the OS ships
+/// System fonts are NOT redistributed: we read the font file the OS ships
 /// with, exactly like every native app does (NSFont on macOS, GDI on
-/// Windows, fontconfig on Linux).  No licensing concern.
+/// Windows, fontconfig on Linux).  No licensing concern
 ///
 /// If no candidate path exists on the current machine, we silently keep
-/// egui's default font — the window still works, it just doesn't blend in
-/// quite as well.
+/// egui's default font: the window still works, it just doesn't blend in
+/// quite as well
 pub(crate) fn install_system_ui_font(ctx: &egui::Context) {
     #[cfg(target_os = "macos")]
     let candidates: &[&str] = &[
@@ -86,7 +86,7 @@ pub(crate) fn install_system_ui_font(ctx: &egui::Context) {
     ctx.set_fonts(fonts);
 }
 
-/// Resolve the OS-appearance-aware egui visuals used by the settings window.
+/// Resolve the OS-appearance-aware egui visuals used by the settings window
 pub(crate) fn visuals_for_theme(theme: Theme) -> egui::Visuals {
     let mut v = match theme {
         Theme::Dark  => egui::Visuals::dark(),
@@ -96,10 +96,10 @@ pub(crate) fn visuals_for_theme(theme: Theme) -> egui::Visuals {
 
     // Force full-contrast text that reads over the vibrancy-tinted cards in
     // both modes.  egui's defaults (from_gray(140) dark / from_gray(60) light)
-    // look washed-out against the translucent SectionCards — especially light
+    // look washed-out against the translucent SectionCards, especially light
     // mode over hudWindow vibrancy, which is already near-white, so a dark
-    // gray label reads as if someone turned the opacity down on the text.
-    // Match SwiftUI `.primary` (#FFFFFF on dark, #000000 on light).
+    // gray label reads as if someone turned the opacity down on the text;
+    // match SwiftUI `.primary` (#FFFFFF on dark, #000000 on light)
     let (fg_text, fg_subtle) = if matches!(theme, Theme::Dark) {
         (egui::Color32::from_rgb(235, 235, 240), egui::Color32::from_rgb(235, 235, 240))
     } else {
@@ -114,14 +114,14 @@ pub(crate) fn visuals_for_theme(theme: Theme) -> egui::Visuals {
     // Light mode's default inactive widget stroke is near-invisible, so
     // segmented-picker segments bleed into the panel background.  Bump the
     // inactive stroke to a faint mid-gray so each segment's edge reads at
-    // rest — matching the legibility we already get in dark mode and the
-    // Swift `NSSegmentedControl` look.
+    // rest, matching the legibility we already get in dark mode and the
+    // Swift `NSSegmentedControl` look
     if matches!(theme, Theme::Light) {
         v.widgets.inactive.bg_stroke = egui::Stroke::new(1.0, egui::Color32::from_gray(180));
     }
 
     // Round egui widget chrome (TextEdit, checkboxes, comboboxes) to match
-    // the macOS-native ~5-6 px corner.
+    // the macOS-native ~5-6 px corner
     let r = egui::Rounding::same(TEXT_EDIT_RADIUS);
     v.widgets.noninteractive.rounding = r;
     v.widgets.inactive.rounding       = r;
@@ -135,9 +135,9 @@ pub(crate) fn visuals_for_theme(theme: Theme) -> egui::Visuals {
     // ≈ rgb(60,60,60)) which sits darker than the card behind and
     // disappears against it.  AppKit's `NSTextField` and `NSStepper`
     // are noticeably LIGHTER than the surrounding controlBackground in
-    // dark mode — they read as raised input affordances.  Match that
+    // dark mode: they read as raised input affordances.  Match that
     // by lifting both fills several steps in dark mode; light mode's
-    // defaults are already correct.
+    // defaults are already correct
     if matches!(theme, Theme::Dark) {
         v.extreme_bg_color = egui::Color32::from_rgb(58, 58, 60);
 
@@ -158,7 +158,7 @@ pub(crate) fn visuals_for_theme(theme: Theme) -> egui::Visuals {
 
 /// Map winit's `Theme` onto egui's `ThemePreference` so the context can be
 /// pinned to the exact OS appearance we just polled (bypassing egui's own
-/// `System` auto-detect, which runs one frame behind).
+/// `System` auto-detect, which runs one frame behind)
 pub(crate) fn theme_preference(theme: Theme) -> ThemePreference {
     match theme {
         Theme::Dark  => ThemePreference::Dark,
@@ -166,17 +166,17 @@ pub(crate) fn theme_preference(theme: Theme) -> ThemePreference {
     }
 }
 
-/// wgpu clear colour for the settings surface.
+/// wgpu clear colour for the settings surface
 ///
 /// When `platform::is_blur_active()` is true, the OS is providing a blur
 /// behind the window (macOS VEV child-window, Windows DWM acrylic, KDE
-/// blur-behind region) — we clear at alpha 0 so wgpu doesn't paint
-/// anything where egui hasn't drawn, letting the OS blur show through.
+/// blur-behind region); we clear at alpha 0 so wgpu doesn't paint
+/// anything where egui hasn't drawn, letting the OS blur show through
 ///
 /// When blur isn't active (older Windows, GNOME, opt-out via
-/// `EXHALE_DISABLE_BLUR=1`), the window is rendered opaquely — clear to
+/// `EXHALE_DISABLE_BLUR=1`), the window is rendered opaquely: clear to
 /// egui's panel fill so there's no flash between surface reconfiguration
-/// and the first paint.
+/// and the first paint
 pub(crate) fn clear_color_for_theme(theme: Theme) -> wgpu::Color {
     if platform::is_blur_active() {
         wgpu::Color { r: 0.0, g: 0.0, b: 0.0, a: 0.0 }
@@ -202,7 +202,7 @@ mod tests {
     fn visuals_dark_uses_high_contrast_text() {
         let v = visuals_for_theme(Theme::Dark);
         let c = v.override_text_color.expect("text color override set in dark mode");
-        // RGB > 200 = near-white; we use rgb(235,235,240).
+        // RGB > 200 = near-white; we use rgb(235,235,240)
         assert!(c.r() >= 200 && c.g() >= 200 && c.b() >= 200,
             "dark-mode text should be near-white, got {c:?}");
     }

--- a/rust/crates/exhale-app/src/settings_window/widgets.rs
+++ b/rust/crates/exhale-app/src/settings_window/widgets.rs
@@ -1,6 +1,6 @@
 //! Reusable egui widget primitives for the settings window: custom
 //! stepper, segmented picker, control button, section card, color
-//! helpers, formatting.
+//! helpers, formatting
 //!
 //! Everything here is `pub(super)` because it's only consumed by
 //! the parent `settings_window` module
@@ -10,35 +10,35 @@ pub(super) fn section(ui: &mut egui::Ui, header: &str, add_contents: impl FnOnce
     let dark_mode = ui.visuals().dark_mode;
 
     // Swift's SectionCard fill is `Color(NSColor.controlBackgroundColor)
-    // .opacity(0.55)` — over an NSVisualEffectView .hudWindow backdrop that
+    // .opacity(0.55)`: over an NSVisualEffectView .hudWindow backdrop that
     // renders at ~80% (dark) or ~85% (light) luminance, this produces cards
     // that are *barely* distinguishable from the vibrancy.  Matching that
     // with a hand-tuned premul-unaware fill:
-    //   dark  — controlBackgroundColor ≈ #1E1E1E, .55 alpha ≈ 86 out of 255
+    //   dark: controlBackgroundColor ≈ #1E1E1E, .55 alpha ≈ 86 out of 255
     //           but vibrancy already tints toward dark, so the visible delta
     // EXACT match for Swift's `SectionCard.fill`:
     //   Color(NSColor.controlBackgroundColor).opacity(0.55)
     // `controlBackgroundColor`:
-    //   dark  → (0.118, 0.118, 0.118, 1.0) ≈ #1E1E1E (RGB 30, 30, 30)
-    //   light → #FFFFFF (RGB 255, 255, 255)
-    // `.opacity(0.55)` → alpha = 140 / 255.  Composited over the
+    //   dark -> (0.118, 0.118, 0.118, 1.0) ≈ #1E1E1E (RGB 30, 30, 30)
+    //   light -> #FFFFFF (RGB 255, 255, 255)
+    // `.opacity(0.55)` -> alpha = 140 / 255.  Composited over the
     // NSVisualEffectView's popover/hudWindow material, this gives
     // Swift's "dark dark gray" card in dark mode and a translucent
-    // white card in light mode.
+    // white card in light mode
     let fill = card_fill(dark_mode);
     // Constrain the card to exactly the scroll area's viewport width so every
     // section (Controls, Appearance, Timing, Randomization, Timers) aligns at
-    // the same left and right gutters.
+    // the same left and right gutters
     let target_w = (super::SETTINGS_WIDTH as f32 - 2.0 * OUTER_PAD).min(ui.available_width());
     ui.allocate_ui_with_layout(
         egui::vec2(target_w, 0.0),
         egui::Layout::top_down(egui::Align::LEFT),
         |ui| {
             ui.set_max_width(target_w);
-            // No stroke on the section Frame — the translucent `fill` alone
+            // No stroke on the section Frame: the translucent `fill` alone
             // separates the card from the vibrancy gutters.  The outlined
             // look is reserved for the control buttons inside the top card,
-            // matching Swift's `ControlButton.strokeBorder` treatment.
+            // matching Swift's `ControlButton.strokeBorder` treatment
             egui::Frame::none()
                 .inner_margin(CARD_PAD)
                 .rounding(CARD_RADIUS)
@@ -58,13 +58,13 @@ pub(super) fn section(ui: &mut egui::Ui, header: &str, add_contents: impl FnOnce
 }
 
 /// Uppercase, letter-spaced, `.secondary` header mimicking SwiftUI's
-/// `.font(.system(size: 10, weight: .semibold)).foregroundColor(.secondary).tracking(0.8)`.
+/// `.font(.system(size: 10, weight: .semibold)).foregroundColor(.secondary).tracking(0.8)`
 pub(super) fn section_header(ui: &mut egui::Ui, text: &str) {
     use egui::text::{LayoutJob, TextFormat};
 
     let dark_mode = ui.visuals().dark_mode;
     // `.secondary` ≈ 60% of primary.  Picked by eye to match SwiftUI's
-    // secondaryLabelColor (#EBEBF599 on dark, #3C3C4399 on light).
+    // secondaryLabelColor (#EBEBF599 on dark, #3C3C4399 on light)
     let color = if dark_mode {
         egui::Color32::from_rgb(160, 160, 166)
     } else {
@@ -78,7 +78,7 @@ pub(super) fn section_header(ui: &mut egui::Ui, text: &str) {
         TextFormat {
             font_id: egui::FontId::proportional(10.0),
             color,
-            // SwiftUI tracking(0.8) → 0.8 pt extra between glyphs.
+            // SwiftUI tracking(0.8) -> 0.8 pt extra between glyphs
             extra_letter_spacing: 0.8,
             ..Default::default()
         },
@@ -90,52 +90,52 @@ pub(super) fn section_header(ui: &mut egui::Ui, text: &str) {
 /// SwiftUI `ControlButton`: an icon + 12 pt medium label on a 7 px rounded rect
 /// with theme-aware translucent fill + stroke, and a hover/press tint that
 /// brightens by ~5% / 8% respectively.  Buttons expand equally across the row
-/// (`.frame(maxWidth: .infinity)` in Swift) — we achieve that by dividing the
+/// (`.frame(maxWidth: .infinity)` in Swift): we achieve that by dividing the
 /// ui's available width by the number of siblings, which egui's horizontal
-/// layout with equal allocations gives us for free via `allocate_exact_size`.
+/// layout with equal allocations gives us for free via `allocate_exact_size`
 ///
 /// Two rendering paths depending on what icon material is available:
 ///   - **macOS (SF Symbol texture present)**: paint the whole
 ///     `.circle.fill` symbol directly.  Apple has done the optical
 ///     centring of the inner glyph against the surrounding ring, so
 ///     the rendering matches Swift's `Image(systemName:)` output
-///     pixel-for-pixel and no per-icon offset is needed.
+///     pixel-for-pixel and no per-icon offset is needed
 ///   - **Windows / Linux (no texture)**: paint a filled circle in
 ///     the foreground colour then composite the Unicode glyph
 ///     (`▶ ■ ↺ ×`) on top in a muted contrasting colour, mimicking
 ///     SF Symbol's transparent cutout look.  Per-glyph
 ///     `unicode_y_offset` tunes positioning against system fonts'
-///     varied glyph metrics.
+///     varied glyph metrics
 ///
 /// `icon_font_size_override` lets a caller bump the font size used for
-/// the Unicode fallback glyph specifically — useful when the chosen
+/// the Unicode fallback glyph specifically, useful when the chosen
 /// glyph lives in a Unicode block (e.g. Latin-1 Supplement, where `×`
 /// is sized to lowercase x-height) that renders visually smaller than
 /// the Geometric Shapes glyphs the other buttons use (`▶ ■ ↺`, all
 /// full-em).  `None` keeps the default 8 pt sizing.  Has no effect
-/// when an SF Symbol texture is in use.
+/// when an SF Symbol texture is in use
 ///
 /// `unicode_y_offset` shifts the Unicode fallback glyph vertically
 /// inside the painted ring (px, negative = up).  Has no effect on
 /// the SF Symbol texture path because Apple's symbol design is the
-/// source of truth for inner-glyph positioning there.
+/// source of truth for inner-glyph positioning there
 ///
 /// `draw_inner_square` and `draw_inner_triangle` paint the inner
-/// shape as an egui primitive instead of using the texture / glyph.
-/// The two have **different precedence** to reflect different
+/// shape as an egui primitive instead of using the texture / glyph;
+/// the two have **different precedence** to reflect different
 /// rendering issues:
 ///
 ///   - `draw_inner_square` overrides BOTH the texture and Unicode
 ///     paths.  Used by Stop because Apple's `stop.circle.fill`
 ///     rasterises the inner square slightly high in our pipeline
 ///     (visible side-by-side with Swift) AND the Unicode U+25A0
-///     glyph isn't reliably centred across system fonts.
+///     glyph isn't reliably centred across system fonts
 ///   - `draw_inner_triangle` overrides only the Unicode path,
-///     yielding to the SF Symbol texture when one is available.
-///     Used by Play because Apple's `play.circle.fill` renders
-///     correctly on macOS — the issue is only Segoe UI / Linux
+///     yielding to the SF Symbol texture when one is available;
+///     used by Play because Apple's `play.circle.fill` renders
+///     correctly on macOS: the issue is only Segoe UI / Linux
 ///     fonts positioning U+25B6 low-left in its em-box (the glyph
-///     was designed as a dropdown indicator, not a play button)
+///     reads as a dropdown indicator rather than a play button)
 #[allow(clippy::too_many_arguments)]
 pub(super) fn control_button(
     ui:                      &mut egui::Ui,
@@ -149,8 +149,8 @@ pub(super) fn control_button(
     text:                    &str,
     help:                    &str,
 ) -> egui::Response {
-    // Stock `egui::Button` chrome — themed fill / stroke / hover /
-    // pressed states / focus indicator — same widget the inline
+    // Stock `egui::Button` chrome: themed fill / stroke / hover /
+    // pressed states / focus indicator, same widget the inline
     // reset-confirmation Cancel and Reset buttons render with, so
     // all six buttons in the Controls section land in a single
     // visually-consistent style.  The button is laid out with an
@@ -171,8 +171,8 @@ pub(super) fn control_button(
     // When Tab moves focus to a control button that's currently
     // scrolled out of the settings ScrollArea's viewport, the focus
     // halo would render off-screen and the user would think Tab
-    // skipped past — `scroll_to_me(None)` nudges the ScrollArea just
-    // enough to bring the focused widget into view, no further.
+    // skipped past: `scroll_to_me(None)` nudges the ScrollArea just
+    // enough to bring the focused widget into view, no further;
     // `gained_focus()` is true only on the FRAME focus arrived, so
     // we don't re-scroll every subsequent frame the button is
     // focused
@@ -185,7 +185,7 @@ pub(super) fn control_button(
     let dark_mode = ui.visuals().dark_mode;
 
     // `primary` and `with_alpha` are still used by the icon
-    // painting paths below — white-in-dark / black-in-light is the
+    // painting paths below: white-in-dark / black-in-light is the
     // colour we paint the `.circle.fill` ring + the label, matching
     // the unchanged-from-before icon rendering the user explicitly
     // asked us to preserve.  The egui Button chrome above paints
@@ -199,8 +199,8 @@ pub(super) fn control_button(
 
     // Keyboard-focus indicator.  When the button is reached via Tab
     // (response.has_focus()), draw a subtle outer ring in the
-    // theme-inverse colour so the user can see where focus landed.
-    // The fill alone doesn't change visibly when focused — without
+    // theme-inverse colour so the user can see where focus landed;
+    // the fill alone doesn't change visibly when focused; without
     // this ring the user has to remember which button they just
     // tabbed onto, especially in the top-row controls where every
     // button shares the same chrome.  Multi-layer soft halo (3 px
@@ -223,8 +223,8 @@ pub(super) fn control_button(
     }
 
     // Pressed state: Swift uses `.opacity(0.7)` + `.scaleEffect(0.97)`.  Scale
-    // is awkward in immediate-mode; drop opacity instead — the user still gets
-    // a clear "pressed" read.
+    // is awkward in immediate-mode; drop opacity instead: the user still gets
+    // a clear "pressed" read
     let content_alpha: u8 = if pressed { 178 } else if enabled { 255 } else { 110 };
     let content_color = with_alpha(primary, content_alpha);
 
@@ -237,11 +237,11 @@ pub(super) fn control_button(
     // (`▶ ■ ↺`)
     let icon_font_size = icon_font_size_override.unwrap_or(8.0);
     let font_icon = egui::FontId::proportional(icon_font_size);
-    // Ring diameter — dropped from 16 pt to 13 pt because at 16 pt
+    // Ring diameter: dropped from 16 pt to 13 pt because at 16 pt
     // the filled circle visibly dominated the 22 pt button height
     // next to the 12 pt label text (icon read as larger than the
     // word it sat beside).  13 pt leaves the ring just a touch
-    // taller than the label cap-height — same family of weights
+    // taller than the label cap-height, same family of weights
     // egui's segmented-picker glyphs use elsewhere in the panel
     let icon_w     = 13.0_f32;
     let label_size = ui.fonts(|f| f.layout_no_wrap(text.to_string(), font_label.clone(), content_color).size());
@@ -272,7 +272,7 @@ pub(super) fn control_button(
         // instead of using `stop.circle.fill` (macOS) or the
         // Unicode U+25A0 glyph (Win/Linux) because both of those
         // rasterise the square slightly above the ring's centre in
-        // our rendering pipeline — visible side-by-side with Swift
+        // our rendering pipeline, visible side-by-side with Swift
         // even though both apps load the same SF Symbol.  Drawing
         // the rectangle ourselves trades a tiny anti-aliasing
         // difference vs Apple's hand-tuned symbol for guaranteed
@@ -299,7 +299,7 @@ pub(super) fn control_button(
         // `Image(systemName:)` rendering pixel-for-pixel without any
         // per-icon offset on our side.  `content_color` tint
         // modulates pressed / disabled states the same way the label
-        // dims — the texture itself is a white silhouette in dark
+        // dims; the texture itself is a white silhouette in dark
         // mode and black in light mode (see `render_sf_symbol`'s
         // template + SourceAtop pass)
         // Match the icon_w ring-painting paths so the SF Symbol
@@ -322,9 +322,9 @@ pub(super) fn control_button(
         // override the SF Symbol texture path (Apple's
         // `play.circle.fill` renders correctly), but the Unicode
         // U+25B6 BLACK RIGHT-POINTING TRIANGLE glyph is positioned
-        // low-left in Segoe UI's em-box (the glyph was designed as
-        // a dropdown indicator, not a play button), so painting our
-        // own triangle is the only reliable cross-font centring.
+        // low-left in Segoe UI's em-box (the glyph reads as a
+        // dropdown indicator rather than a play button), so painting our
+        // own triangle is the only reliable cross-font centring
         let icon_center = egui::pos2(start_x + icon_w * 0.5, baseline_y);
         painter.circle_filled(icon_center, icon_w * 0.5, content_color);
         // Triangle bounding box ~5.5×5.5 pt, matching the stop
@@ -332,8 +332,8 @@ pub(super) fn control_button(
         // centroid (true centre of mass) lands on the ring's centre
         // rather than the bounding box.  An isoceles right-pointing
         // triangle's centroid sits at 1/3 of its width from the
-        // base, i.e. left of bounding-box centre by `width / 6` —
-        // for a 5.5 pt triangle that's ~0.9 px.  Adding the shift
+        // base, i.e. left of bounding-box centre by `width / 6`: for
+        // a 5.5 pt triangle that's ~0.9 px.  Adding the shift
         // moves the centroid to the ring's centre, where the eye
         // expects "centred" to mean
         // Triangle scaled proportionally with the smaller ring
@@ -377,22 +377,22 @@ pub(super) fn control_button(
 }
 
 // Layout constants mirror SwiftUI SettingsView.swift:
-//   label column width (115) → SettingsView.settingLabelWidth
-//   outer padding    (14)    → .padding(.horizontal, 14) + .padding(.top/.bottom, 14)
-//   card padding     (12)    → SectionCard.padding(12)
-//   section gap      (10)    → sectionSpacing
-//   row gap          (8)     → rowSpacing
-//   card radius      (10)    → RoundedRectangle(cornerRadius: 10, style: .continuous)
-//   button radius    (7)     → ControlButton's RoundedRectangle(cornerRadius: 7)
-//   stepper field    (56)    → CombinedStepperTextField TextField .frame(width: 56)
+//   label column width (115) -> SettingsView.settingLabelWidth
+//   outer padding    (14) -> .padding(.horizontal, 14) + .padding(.top/.bottom, 14)
+//   card padding     (12) -> SectionCard.padding(12)
+//   section gap      (10) -> sectionSpacing
+//   row gap          (8) -> rowSpacing
+//   card radius      (10) -> RoundedRectangle(cornerRadius: 10, style: .continuous)
+//   button radius    (7) -> ControlButton's RoundedRectangle(cornerRadius: 7)
+//   stepper field    (56) -> CombinedStepperTextField TextField .frame(width: 56)
 // Label column width.  Trade-off: shorter keeps the segmented pickers
 // (Rectangle/Circle/Full, Gradient/Stark/Off, etc.) from wrapping their
 // widest option text, at the cost of ellipsising a few long labels like
 // "Overlay Opacity (%)" and "Background Color".  Swift's SettingsView
-// uses 115 pt with `.lineLimit(1)` — same behaviour.  The pickers at this
+// uses 115 pt with `.lineLimit(1)`, same behaviour.  The pickers at this
 // width get ~191 px to share across 3 segments (≈63 px each), which fits
 // "Rectangle" (≈55 px natural) with room to spare when we render buttons
-// with `button_padding = 0` inside the segmented row.
+// with `button_padding = 0` inside the segmented row
 pub(super) const LABEL_W:          f32 = 115.0;
 pub(super) const ROW_H:            f32 = 22.0;
 pub(super) const OUTER_PAD:        f32 = 14.0;
@@ -401,18 +401,18 @@ pub(super) const SECTION_GAP:      f32 = 10.0;
 pub(super) const ROW_GAP:          f32 = 8.0;
 pub(super) const CARD_RADIUS:      f32 = 10.0;
 pub(super) const BUTTON_RADIUS:    f32 = 7.0;
-// (`TEXT_EDIT_RADIUS` lives in the `theme` submodule — it's used by
+// (`TEXT_EDIT_RADIUS` lives in the `theme` submodule: it's used by
 // `visuals_for_theme` and nothing else, no reason to expose it here)
 pub(super) const STEPPER_FIELD_W:  f32 = 56.0;
 
 /// macOS-native selection pill: a slightly inset rounded rect filled in
 /// gray (lighter than the container in dark mode, near-white in light
 /// mode), matching AppKit's `NSSegmentedControl`
-/// `.selectedContentBackground`.
+/// `.selectedContentBackground`
 ///
-/// Shared by the segmented pickers and the preset chips so there is one
+/// Shared by the segmented pickers and the preset chips so there's one
 /// selected colour in the window rather than two that drift apart, and
-/// so the contrast test in this file covers both. It is measured rather
+/// so the contrast test in this file covers both. It's measured rather
 /// than eyeballed: see `selected_pill_text_meets_wcag_aa`
 /// Translucent `SectionCard` fill, composited over the platform
 /// vibrancy backdrop. Hoisted out of [`section`] so the contrast test
@@ -427,11 +427,11 @@ pub(super) fn card_fill(dark_mode: bool) -> egui::Color32 {
 
 pub(super) fn selected_pill_fill(dark_mode: bool) -> egui::Color32 {
     if dark_mode {
-        // ~rgb(110,110,110) at 90% — reads as a clear lighter gray over
-        // the dark vibrancy without going washed-out.
+        // ~rgb(110,110,110) at 90%, reads as a clear lighter gray over
+        // the dark vibrancy without going washed-out
         egui::Color32::from_rgba_unmultiplied(110, 110, 110, 230)
     } else {
-        // Near-white selection on a light translucent backdrop.
+        // Near-white selection on a light translucent backdrop
         egui::Color32::from_rgba_unmultiplied(255, 255, 255, 235)
     }
 }
@@ -446,14 +446,14 @@ pub(super) fn selected_pill_text(dark_mode: bool) -> egui::Color32 {
 /// natural column width across them.  Buttons within a single picker get
 /// equal width (so all options in that picker fit their widest text); the
 /// column width is then max-of-natural-widths so that every picker in the
-/// settings window shares the same left AND right bounds.
+/// settings window shares the same left AND right bounds
 ///
 /// `SEGMENT_SLACK_PX` adds a small per-segment breathing room so the
-/// measurement is always wide enough for the actual rendered text — the
+/// measurement is always wide enough for the actual rendered text: the
 /// `layout_no_wrap` measure and the on-render glyph layout can disagree by
 /// a couple of pixels due to font hinting and sub-pixel positioning, which
 /// was enough to let "Rectangle" wrap onto a second line inside a segment
-/// that measured as "just big enough".
+/// that measured as "just big enough"
 pub(super) fn uniform_picker_column_width(ui: &egui::Ui, pickers: &[&[&str]]) -> f32 {
     const SEGMENT_SLACK_PX: f32 = 10.0;
     let pad_x   = ui.spacing().button_padding.x * 2.0;
@@ -478,15 +478,15 @@ pub(super) fn uniform_picker_column_width(ui: &egui::Ui, pickers: &[&[&str]]) ->
 /// edge.  Everything to the right of the label cell sits in a `right_to_left`
 /// layout so the widget hugs the right edge exactly like Swift's Form.
 /// Two-column row: a fixed-width label painted directly via the painter on
-/// the left, and a `right_to_left` widget area on the right.
+/// the left, and a `right_to_left` widget area on the right
 ///
 /// The painter-direct approach exists because `allocate_ui_with_layout` with
 /// a fixed min_size collapses to the label's natural width inside a
-/// horizontal layout — which left the remaining widget area wider than it
+/// horizontal layout, which left the remaining widget area wider than it
 /// should be, and caused stepper TextEdits to draw over labels that were
 /// still in their natural rect.  Reserving an exact-size rect and drawing
 /// into it with the painter API guarantees the widget area to the right
-/// starts at `LABEL_W + item_spacing`.
+/// starts at `LABEL_W + item_spacing`
 pub(super) fn labeled_row(ui: &mut egui::Ui, label: &str, add_widget: impl FnOnce(&mut egui::Ui)) -> egui::Response {
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 0.0;
@@ -498,15 +498,15 @@ pub(super) fn labeled_row(ui: &mut egui::Ui, label: &str, add_widget: impl FnOnc
 /// Reserve a LABEL_W × ROW_H rect and paint `label` into it flush against the
 /// rect's left edge with the current theme's text colour.  Using the painter
 /// directly (rather than `ui.put(rect, Label::truncate())`) pins the text
-/// exactly at `rect.left()` — `Label` was adding implicit horizontal padding
-/// that read as "the labels aren't left-aligned" against Swift's reference.
+/// exactly at `rect.left()`: `Label` was adding implicit horizontal padding
+/// that read as "the labels aren't left-aligned" against Swift's reference
 pub(super) fn paint_label(ui: &mut egui::Ui, label: &str) -> egui::Response {
     paint_label_with_width(ui, label, LABEL_W)
 }
 
 /// Like `paint_label` but with a caller-specified column width.  Used by
 /// `segmented_row` so the picker can extend leftward into the label column
-/// when its natural width would otherwise overflow the card on the right.
+/// when its natural width would otherwise overflow the card on the right
 ///
 /// Returns the label's hover-Response so callers can scope tooltips
 /// to the label region only (not the entire row).  Important for the
@@ -548,7 +548,7 @@ pub(super) fn paint_label_with_width(
 /// (see `uniform_picker_column_width`) and passed identically to every
 /// picker in the Appearance section, so the leftmost option button lands
 /// on the same X coordinate regardless of the picker's option count or
-/// text length.
+/// text length
 pub(super) fn segmented_row<T: Copy + PartialEq>(
     ui:       &mut egui::Ui,
     label:    &str,
@@ -563,25 +563,25 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
         ui.spacing_mut().item_spacing.x = 0.0;
         // If the picker's natural column_w wouldn't fit at the standard
         // LABEL_W, shrink the label column so the picker can claim its
-        // natural width — making every segmented picker share the same
+        // natural width, making every segmented picker share the same
         // left and right edges regardless of the widest option's text.
         // `MIN_LABEL_W` is the lower bound at which even short labels
-        // ("Shape", "Gradient") stay readable after truncation.
+        // ("Shape", "Gradient") stay readable after truncation
         const MIN_LABEL_W: f32 = 70.0;
         const SAFETY_PX:   f32 = 2.0;
         let row_avail = ui.available_width();
         let label_w   = (row_avail - column_w - SAFETY_PX)
                          .clamp(MIN_LABEL_W, LABEL_W);
-        // Scope the help-text tooltip to the label region only — see
+        // Scope the help-text tooltip to the label region only: see
         // `paint_label_with_width` docstring for why the row-wide
         // hover tooltip was producing the "duplicate label" artifact
-        // when hovering individual options.
+        // when hovering individual options
         paint_label_with_width(ui, label, label_w).on_hover_text(help);
-        // `SAFETY_PX` slack on the right — the outer rect stroke I paint
+        // `SAFETY_PX` slack on the right: the outer rect stroke I paint
         // under the picker is 1 px centered-on-edge (so 0.5 px bleed outside),
         // and sub-pixel rounding of `per_w = (picker_w / n).floor()` plus the
         // last_w remainder can occasionally push the child min_rect by
-        // another fraction of a pixel.
+        // another fraction of a pixel
         let remaining = (ui.available_width() - SAFETY_PX).max(0.0);
         let picker_w  = column_w.min(remaining).max(1.0);
         let gap       = (remaining - picker_w).max(0.0);
@@ -590,18 +590,18 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
         ui.add_enabled_ui(enabled, |ui| {
             let n = options.len();
             // Sub-pixel remainder is absorbed by the last segment so the
-            // rightmost edge lands exactly on picker_w.
+            // rightmost edge lands exactly on picker_w
             let per_w  = (picker_w / n as f32).floor().max(1.0);
             let last_w = per_w + (picker_w - per_w * n as f32).max(0.0);
 
             // Pre-compute the outer rect ourselves and use `ui.put(rect, btn)`
             // for each segment.  `ui.add_sized(size, btn)` does NOT actually
-            // constrain the Button to `size` — Button's `allocate_at_least`
+            // constrain the Button to `size`: Button's `allocate_at_least`
             // grows the frame to the natural text+padding width, which was
             // the real source of the Appearance-section right-overflow (debug
             // showed picker_w=156 requested but actual=167 delivered).
             // `ui.put` positions the widget into a fixed rect without
-            // letting it grow the parent's min_rect.
+            // letting it grow the parent's min_rect
             let outer_rect = egui::Rect::from_min_size(
                 ui.cursor().min,
                 egui::vec2(picker_w, ROW_H),
@@ -609,9 +609,9 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 
             let dark_mode = ui.visuals().dark_mode;
 
-            // Disable egui's default Button hover/press fills — we'll paint
+            // Disable egui's default Button hover/press fills; we'll paint
             // a rounded inset pill ourselves for hover/press/selected so all
-            // three states share the same macOS-native pill look.
+            // three states share the same macOS-native pill look
             {
                 let widgets = &mut ui.visuals_mut().widgets;
                 widgets.inactive.bg_stroke    = egui::Stroke::NONE;
@@ -631,7 +631,7 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 
             // Pre-compute every segment's rect so we can interact + paint
             // pill chrome BEFORE rendering each label (the pill must sit
-            // under the text, not over it).
+            // under the text rather than over it)
             let mut seg_rects: Vec<egui::Rect> = Vec::with_capacity(n);
             let mut seg_x = outer_rect.min.x;
             for i in 0..n {
@@ -649,17 +649,17 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
                 let is_selected = *current == *variant;
                 let seg_rect    = seg_rects[i];
 
-                // Interact first — gives us hover/press/click without drawing.
+                // Interact first: gives us hover/press/click without drawing
                 let seg_id = ui.id().with("seg").with(i).with(*text);
                 let resp = ui.interact(seg_rect, seg_id, egui::Sense::click());
-                // Same scroll-into-view nudge as `control_button` —
-                // see comment there.  Tab landing on an off-screen
+                // Same scroll-into-view nudge as `control_button`: see
+                // comment there.  Tab landing on an off-screen
                 // segment would otherwise appear to do nothing
                 if resp.gained_focus() {
                     resp.scroll_to_me(None);
                 }
 
-                // Pill chrome (selected > pressed > hovered) drawn under text.
+                // Pill chrome (selected > pressed > hovered) drawn under text
                 let pill_fill: Option<egui::Color32> = if is_selected {
                     Some(selected_fill)
                 } else if resp.is_pointer_button_down_on() {
@@ -709,7 +709,7 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
                     }
                 }
 
-                // Selected text flips to primary; unselected uses default text color.
+                // Selected text flips to primary; unselected uses default text color
                 let label_color = if is_selected {
                     selected_pill_text(dark_mode)
                 } else {
@@ -718,8 +718,8 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 
                 // Paint the label centered in the segment via the painter,
                 // matching the segment width we measured for the picker
-                // column — `ui.put(rect, Button)` would re-allocate and
-                // grow `min_rect`, which we deliberately avoid in this row.
+                // column: `ui.put(rect, Button)` would re-allocate and
+                // grow `min_rect`, which we deliberately avoid in this row
                 let galley = ui.painter().layout_no_wrap(
                     text.to_string(),
                     font_id.clone(),
@@ -738,9 +738,9 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
             }
 
             // Explicitly allocate the outer rect so the parent's cursor
-            // advances past picker_w exactly — otherwise nothing has
+            // advances past picker_w exactly; otherwise nothing has
             // reserved the horizontal space and the scope's min_rect
-            // wouldn't include the pickers (ui.put doesn't advance cursor).
+            // wouldn't include the pickers (ui.put doesn't advance cursor)
             let _ = ui.allocate_rect(outer_rect, egui::Sense::hover());
 
             // Rounded outline around the picker's outer bounds.  The
@@ -749,7 +749,7 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
             // the rounded outer border (`pill = outer.shrink(INSET)`
             // means pill's corner-radius needs to be outer's minus
             // INSET to stay visually concentric).  AppKit's native
-            // `NSSegmentedControl` uses the same look.
+            // `NSSegmentedControl` uses the same look
             let stroke_color = ui.visuals().widgets.noninteractive.bg_stroke.color;
             ui.painter().rect_stroke(
                 outer_rect,
@@ -762,23 +762,23 @@ pub(super) fn segmented_row<T: Copy + PartialEq>(
 }
 
 /// Duration row (seconds). Swift's CombinedStepperTextField with `limits: (0, nil)`
-/// and step 1.0 — so the ±-button step matches the Stepper control on macOS.
-/// Preset chips: one click that moves all four Timing steppers at once.
+/// and step 1.0, so the ±-button step matches the Stepper control on macOS.
+/// Preset chips: one click that moves all four Timing steppers at once
 ///
 /// Lives inside the Timing card, directly above the steppers it writes,
 /// so the effect of a click is visible in the same glance rather than
-/// having to be believed.
+/// having to be believed
 ///
 /// **Selection is derived, never stored.** Which chip is lit comes from
 /// comparing the four durations in `Settings` against each preset, with
 /// the epsilon `SettingsDiff::from` uses on those same fields. There is
-/// no sixth "selected preset" field, so there is nothing to migrate,
+/// no sixth "selected preset" field, so there's nothing to migrate,
 /// nothing to desync, and nothing that can be stale after the user
-/// nudges a stepper by hand: the chip simply goes out.
+/// nudges a stepper by hand: the chip simply goes out
 ///
-/// **There is no "Custom" chip.** Custom is the absence of a lit pill.
+/// **There's no "Custom" chip.** Custom is the absence of a lit pill.
 /// A chip that does nothing when clicked is still a Tab stop, and this
-/// file already documents that hazard twice.
+/// file already documents that hazard twice
 ///
 /// Laid out by hand rather than with `ui.horizontal_wrapped` because
 /// the pill chrome has to be painted UNDER the label, which means every
@@ -796,7 +796,7 @@ pub(super) fn preset_chips(
     let current     = selected(settings);
     let font_id     = egui::TextStyle::Button.resolve(ui.style());
 
-    // 7 and 5, which look arbitrary and are not. Measured at the shipped
+    // 7 and 5, which look arbitrary and aren't. Measured at the shipped
     // 308 pt card width with the four-number labels, the five chips come
     // to 297 pt at these values and 331 pt at a roomier 10 and 6, so the
     // difference between them is whether the last chip sits in the row or
@@ -899,7 +899,7 @@ pub(super) fn preset_chips(
             // Unselected chips need a visible edge. The pickers get one
             // from the container outline around the whole control; a
             // wrapped chip row has no container, so without this an
-            // unselected chip is bare text and does not read as
+            // unselected chip is bare text and doesn't read as
             // clickable at all
             ui.painter().rect_stroke(
                 pill,
@@ -960,20 +960,20 @@ pub(super) fn preset_chips(
 
 /// The pacing readout: what the current timing settings actually work
 /// out to, and how that sits against the range with direct
-/// experimental support.
+/// experimental support
 ///
 /// Every string comes from [`exhale_core::pacing::readout_lines`],
-/// which is where the copy is tested. This function only paints.
+/// which is where the copy is tested. This function only paints
 ///
 /// Rendered unprompted, never behind a hover or a disclosure triangle.
 /// The reason is specific rather than stylistic. A disclosure reaches
 /// only the people who go looking, and the settings most in need of a
 /// coverage note are the ones a user picks *without* reading anything:
 /// box breathing works out to 3.8 a minute, below the tested range, and
-/// looks gentler than it is because the holds hide the arithmetic.
+/// looks gentler than it's because the holds hide the arithmetic.
 /// A line that appears only when the news is bad is a line nobody
 /// trusts, so it appears always, including for the default, which it
-/// reports as inside the range.
+/// reports as inside the range
 ///
 /// A tooltip could not carry this either. `egui`'s tooltip width
 /// clamps to `ctx.screen_rect()`, which here is a 360 pt window, so
@@ -984,7 +984,7 @@ pub(super) fn pacing_readout(ui: &mut egui::Ui, settings: &exhale_core::settings
         return;
     }
     ui.add_space(2.0);
-    // Scoped so the tighter spacing does not leak into the rest of the
+    // Scoped so the tighter spacing doesn't leak into the rest of the
     // card. `section` sets `item_spacing.y = ROW_GAP` for control rows,
     // which is right between a slider and the next slider and wrong
     // between two sentences: at 8 pt these read as three unrelated
@@ -992,7 +992,7 @@ pub(super) fn pacing_readout(ui: &mut egui::Ui, settings: &exhale_core::settings
     ui.scope(|ui| {
         ui.spacing_mut().item_spacing.y = 2.0;
         for line in lines {
-            // Wrapping, not truncating. `paint_label_with_width` sets
+            // Wrapping rather than truncating. `paint_label_with_width` sets
             // `max_rows: 1` with an ellipsis, which is right for a
             // control label in a fixed column and wrong for a sentence
             // whose second half is the qualification
@@ -1012,25 +1012,25 @@ pub(super) fn duration_row(ui: &mut egui::Ui, label: &str, help: &str, value: &m
 /// Randomised-timing percentage row.  Stored in Settings as 0.0–1.0; Swift
 /// displays it multiplied by 100 with a stepper step of 1 % (== 0.01 in
 /// storage).  `ValueScale::Percent` handles the ×100 / ÷100 conversion on
-/// both read and write so the displayed/entered value is always a percent.
+/// both read and write so the displayed/entered value is always a percent
 pub(super) fn pct_row(ui: &mut egui::Ui, label: &str, help: &str, value: &mut f64) -> bool {
     stepper_row(ui, label, help, None, value, 1.0, 0.0, None, ValueScale::Percent)
 }
 
-/// How a stored value is mapped to the displayed/entered number.
+/// How a stored value is mapped to the displayed/entered number
 ///
 /// Swift's CombinedStepperTextField is parameterised by a Binding that
 /// transforms the stored value before it reaches the TextField.  We
 /// accomplish the same thing with a scale enum so callers don't have to
 /// open-code `*100` / `÷100` / `(x-1)*100` conversions everywhere, and the
-/// stepper's `step` field still describes the *displayed* step (e.g. 1 %).
+/// stepper's `step` field still describes the *displayed* step (e.g. 1 %)
 #[derive(Clone, Copy)]
 pub(super) enum ValueScale {
     /// `display = stored`
     Identity,
-    /// `display = stored * 100` — randomised-timing sliders stored as fractions.
+    /// `display = stored * 100`: randomised-timing sliders stored as fractions
     Percent,
-    /// `display = (stored - 1) * 100` — drift multiplier stored as e.g. 1.01.
+    /// `display = (stored - 1) * 100`: drift multiplier stored as e.g. 1.01
     DriftPercent,
 }
 
@@ -1055,13 +1055,13 @@ impl ValueScale {
 /// SwiftUI's `CombinedStepperTextField`: a fixed-width numeric TextField with
 /// a two-button vertical Stepper to its right and an optional left-hand hint
 /// ("0 = off").  `step`, `min`, and `max` are in the *displayed* unit; the
-/// `scale` enum maps that display value to/from the stored `value`.
+/// `scale` enum maps that display value to/from the stored `value`
 ///
 /// The buffer is persisted in egui's temp data keyed by `label` so typing a
 /// partial number ("1." on the way to "1.25") doesn't get clobbered by a
 /// redraw.  When the field loses focus (or the stepper nudges the value) we
 /// canonicalise the buffer via `format_num` so extraneous zeros/decimals get
-/// cleaned up — matching Swift's NumberFormatter with `maximumFractionDigits: 3`.
+/// cleaned up, matching Swift's NumberFormatter with `maximumFractionDigits: 3`
 #[allow(clippy::too_many_arguments)]
 pub(super) fn stepper_row(
     ui:     &mut egui::Ui,
@@ -1081,7 +1081,7 @@ pub(super) fn stepper_row(
         // is exact and `widgets_w` accounts for every gap placed
         ui.spacing_mut().item_spacing.x = 0.0;
 
-        // Label column — painter-direct, fixed LABEL_W wide.
+        // Label column: painter-direct, fixed LABEL_W wide
         paint_label(ui, label);
 
         let stepper_btn_w = 14.0_f32;
@@ -1093,7 +1093,7 @@ pub(super) fn stepper_row(
         } else { 0.0 };
         // Exact total width of the trailing column: hint + hint_gap + field
         // + field_gap + stepper buttons.  Every component lines up with an
-        // explicit add_space so this equals the actual placed width.
+        // explicit add_space so this equals the actual placed width
         let trailing_gap = if hint.is_some() { hint_gap } else { 0.0 };
         let widgets_w = hint_w + trailing_gap + STEPPER_FIELD_W + field_gap + stepper_btn_w;
 
@@ -1123,7 +1123,7 @@ pub(super) fn stepper_row(
                 .margin(egui::vec2(4.0, 2.0)),
         );
         // Scroll into view when Tab moves focus to this field while
-        // it's off-screen — same pattern as `control_button` /
+        // it's off-screen: same pattern as `control_button` /
         // segmented-picker segment focus handling
         if field_resp.gained_focus() {
             field_resp.scroll_to_me(None);
@@ -1144,7 +1144,7 @@ pub(super) fn stepper_row(
         // up / down arrows nudge the value by one `step` per press.
         // `consume_key` drains EVERY matching event in the queue
         // this frame (including key-repeat fires from a held key)
-        // so hold-to-step works naturally — one tick per system
+        // so hold-to-step works naturally: one tick per system
         // repeat interval.  Singleline `TextEdit` doesn't do
         // anything useful with vertical arrows, so consuming them
         // here doesn't break editing
@@ -1173,18 +1173,18 @@ pub(super) fn stepper_row(
             }
         }
 
-        // Gap between field and ± buttons (now explicit since item_spacing = 0).
+        // Gap between field and ± buttons (now explicit since item_spacing = 0)
         ui.add_space(field_gap);
 
-        // Stepper buttons (right of field) — pass the TextEdit's actual
+        // Stepper buttons (right of field): pass the TextEdit's actual
         // rendered rect so the stepper's vertical bounds match the field's
         // visible bounds exactly (otherwise `ROW_H`-sized stepper overhangs
-        // the TextEdit's slightly-shorter visible rectangle).
+        // the TextEdit's slightly-shorter visible rectangle)
         let field_rect = field_resp.rect;
         let stepper_changed = stepper_buttons(
             ui,
             field_rect,
-            label,  // row_salt — makes interact IDs unique per stepper row
+            label,  // row_salt: makes interact IDs unique per stepper row
             &scale.to_display(*value),
             step, min, max_disp,
         );
@@ -1197,7 +1197,7 @@ pub(super) fn stepper_row(
         }
 
         // Canonicalise the buffer when the field isn't focused, or when the
-        // stepper just nudged the value (button click OR arrow-key step) —
+        // stepper just nudged the value (button click OR arrow-key step): this
         // prevents stale text hanging around after external state changes
         // (reset, cross-row effects) and keeps the on-screen text in
         // sync after an arrow nudge while focus remains on the field
@@ -1212,14 +1212,14 @@ pub(super) fn stepper_row(
 
 /// Vertically stacked ▲/▼ Stepper buttons sized to match the adjacent
 /// TextEdit's physical rect exactly.  `field_rect` is the TextEdit's
-/// response rect — we use its `top()` and `bottom()` directly rather than
+/// response rect: we use its `top()` and `bottom()` directly rather than
 /// the parent UI's `ROW_H` so the stepper's top and bottom edges align with
-/// the field's visible frame, never overhanging top or bottom.
+/// the field's visible frame, never overhanging top or bottom
 ///
 /// Button widgets handle clicks and draw the chrome (fill + stroke +
 /// hover/press states); triangles are drawn geometrically with the painter
 /// because egui's default font (Ubuntu) doesn't include the ▲ U+25B2 /
-/// ▼ U+25BC glyphs — they rendered as missing-glyph tofu boxes.
+/// ▼ U+25BC glyphs; they rendered as missing-glyph tofu boxes
 pub(super) fn stepper_buttons(
     ui:         &mut egui::Ui,
     field_rect: egui::Rect,
@@ -1234,12 +1234,12 @@ pub(super) fn stepper_buttons(
     let total_h = field_rect.height();
 
     // Reserve horizontal space WITHOUT creating a widget response at the
-    // full rect — `allocate_exact_size(Sense::hover())` was registering an
+    // full rect: `allocate_exact_size(Sense::hover())` was registering an
     // interaction zone at the whole column that could absorb pointer
     // events ahead of the per-half `ui.interact` calls below, resulting
     // in clicks never registering for the stepper halves.  `allocate_space`
     // only advances the cursor; the actual hit-testing is done exclusively
-    // by the two `ui.interact` calls, whose IDs are unique to each half.
+    // by the two `ui.interact` calls, whose IDs are unique to each half
     let (_, alloc_rect) = ui.allocate_space(egui::vec2(btn_w, total_h));
     let rect = egui::Rect::from_min_size(
         egui::pos2(alloc_rect.left(), field_rect.top()),
@@ -1255,11 +1255,11 @@ pub(super) fn stepper_buttons(
         egui::vec2(btn_w, total_h - half_h),
     );
 
-    // Hit-testing via `ui.interact` — this is the ONLY way to get pixel-
+    // Hit-testing via `ui.interact`: this is the ONLY way to get pixel-
     // perfect sub_rects.  Debug logs proved `egui::Button` ignores
     // ui.put's max_rect and draws at its own desired_size (empty-text
     // galley line-height ≈ 15 px), overhanging the 9 px sub_rect by 6 px
-    // below — exactly the "gray below the input" artifact.  With raw
+    // below: exactly the "gray below the input" artifact.  With raw
     // interact + painter chrome, the rect we pass IS the rect drawn.
     // Scope the interact IDs by `row_salt` (the stepper_row's label) so
     // every stepper in the window has a unique ID pair.  Using `ui.id()`
@@ -1267,7 +1267,7 @@ pub(super) fn stepper_buttons(
     // UiBuilder has no id_salt, so sibling `ui.horizontal()` children of
     // a given parent all share the parent's id.  That caused egui's
     // click-tracking to silently drop every click because it couldn't
-    // disambiguate which stepper was hit.
+    // disambiguate which stepper was hit
     let row_id  = ui.id().with(row_salt);
     let up_resp = ui.interact(top_rect, row_id.with("stepper_up"), egui::Sense::click());
     let dn_resp = ui.interact(bot_rect, row_id.with("stepper_dn"), egui::Sense::click());
@@ -1276,28 +1276,28 @@ pub(super) fn stepper_buttons(
 
     // When Tab moves focus to a stepper half that's currently
     // scrolled out of the settings ScrollArea's viewport, nudge
-    // the viewport just enough to bring it into view — same
+    // the viewport just enough to bring it into view, same
     // pattern as `control_button` / segmented-picker segment.
     // `gained_focus()` is true only on the FRAME focus arrived
-    // so we don't re-scroll every subsequent frame.
+    // so we don't re-scroll every subsequent frame
     if up_resp.gained_focus() { up_resp.scroll_to_me(None); }
     if dn_resp.gained_focus() { dn_resp.scroll_to_me(None); }
 
     paint_stepper_chrome(ui, top_rect, StepperDir::Up,   up_resp.hovered(), up_resp.is_pointer_button_down_on());
     paint_stepper_chrome(ui, bot_rect, StepperDir::Down, dn_resp.hovered(), dn_resp.is_pointer_button_down_on());
 
-    // Triangles as small filled polygons (font-independent).
+    // Triangles as small filled polygons (font-independent)
     let tri_color = ui.visuals().text_color();
     paint_triangle(ui, top_rect, StepperDir::Up,   tri_color);
     paint_triangle(ui, bot_rect, StepperDir::Down, tri_color);
 
     // Keyboard-focus halo for the stepper halves.  The button rects
     // here are tiny (~13×9 px) so the layered glow that works on
-    // the top-row control buttons reads too soft — bump the inner
+    // the top-row control buttons reads too soft; bump the inner
     // ring alpha to fully-opaque so even at glance distance the
     // user can see which half of the stepper Tab landed on (and
     // why pressing Tab three more times before hitting the next
-    // control is the expected behaviour: TextEdit → ▲ → ▼ → next
+    // control is the expected behaviour: TextEdit -> ▲ -> ▼ -> next
     // row).  Two stacked stroked rects with a brighter inner
     // edge + a soft outer falloff
     let dark_mode = ui.visuals().dark_mode;
@@ -1323,7 +1323,7 @@ pub(super) fn stepper_buttons(
     if up_resp.has_focus() { paint_halo(top_rect); }
     if dn_resp.has_focus() { paint_halo(bot_rect); }
 
-    // Press-and-hold auto-repeat — matches macOS NSStepper / SwiftUI
+    // Press-and-hold auto-repeat: matches macOS NSStepper / SwiftUI
     // Stepper.  A click fires once on press-down; holding the button past
     // `INITIAL_DELAY` starts a repeat that fires every `REPEAT_INTERVAL`
     // until release.  Values match AppKit's NSStepper defaults
@@ -1353,7 +1353,7 @@ pub(super) struct StepperHoldState {
     last_tick:   Instant,
 }
 
-/// Decide whether one stepper half should fire a step this frame.
+/// Decide whether one stepper half should fire a step this frame
 ///
 /// Returns `Some(delta)` (the signed step amount) when the button
 /// should step the value:
@@ -1362,7 +1362,7 @@ pub(super) struct StepperHoldState {
 ///     held for at least `initial_delay`,
 ///   * on a same-frame press-and-release (catches the synthetic
 ///     down+up-in-one-frame events used in unit tests, and real
-///     trackpad taps that egui collapses to a single frame).
+///     trackpad taps that egui collapses to a single frame)
 ///
 /// Returns `None` while the button is idle or in the initial-delay
 /// dead-zone of a hold.  Requests a repaint deadline while the
@@ -1380,13 +1380,13 @@ pub(super) fn stepper_hold_tick(
     let prev = ui.data(|d| d.get_temp::<StepperHoldState>(id));
     // The stepper-button hit rect is small (13 × 11 pt per half).
     // `Response::is_pointer_button_down_on` returns false the moment
-    // the cursor drifts off that rect — which during a slow-and-shaky
+    // the cursor drifts off that rect, which during a slow-and-shaky
     // hold flickers between true/false at the boundary.  Each flicker
     // would clear our hold state and re-treat the next frame as a
     // fresh press, dropping the user back into the initial-delay
-    // dead-zone and producing the "stops after 3-4 increments" bug.
+    // dead-zone and producing the "stops after 3-4 increments" bug
     //
-    // Robust signal: combine "the primary pointer button is currently
+    // `held` combines two signals: "the primary pointer button is currently
     // down somewhere" (a global state independent of widget hit-test)
     // with our own memo "the press started on this widget" (set
     // either by an in-rect press-down THIS frame or by an existing
@@ -1400,10 +1400,10 @@ pub(super) fn stepper_hold_tick(
 
     if held {
         if let Some(state) = prev {
-            // Already holding — check whether enough time has passed
+            // Already holding: check whether enough time has passed
             // since press for auto-repeat to engage, and whether we're
             // past the next `repeat_interval` boundary since the last
-            // tick we fired.
+            // tick we fired
             ui.ctx().request_repaint_after(repeat_interval);
             if now.duration_since(state.press_start) >= initial_delay
                 && now.duration_since(state.last_tick) >= repeat_interval
@@ -1416,9 +1416,9 @@ pub(super) fn stepper_hold_tick(
             }
             None
         } else {
-            // Fresh press-down — fire one immediate step and start
+            // Fresh press-down: fire one immediate step and start
             // tracking the hold.  This matches NSStepper, which sends
-            // its `action` on press-down, not on release.
+            // its `action` on press-down rather than waiting for release
             ui.data_mut(|d| d.insert_temp(id, StepperHoldState {
                 press_start: now,
                 last_tick:   now,
@@ -1428,16 +1428,16 @@ pub(super) fn stepper_hold_tick(
         }
     } else {
         if prev.is_some() {
-            // Released — we already fired on the press-down edge and
+            // Released: we already fired on the press-down edge and
             // any auto-repeat ticks during the hold, so just clear the
-            // hold state.  Don't re-fire on release.
+            // hold state.  Don't re-fire on release
             ui.data_mut(|d| d.remove::<StepperHoldState>(id));
             None
         } else if resp.clicked() {
             // Same-frame press+release (`is_pointer_button_down_on()` is
             // false at end-of-frame, but `clicked()` registered a full
             // down+up cycle).  Trackpad taps and synthetic test inputs
-            // land here — fire a single step
+            // land here: fire a single step
             Some(step)
         } else {
             None
@@ -1462,7 +1462,7 @@ pub(super) fn paint_stepper_chrome(
     };
     // Round only the outer corners so the up + down halves merge into a
     // single rounded-rect column with a flush mid-edge.  A 3-px radius
-    // matches the subtle macOS-native NSStepper look.
+    // matches the subtle macOS-native NSStepper look
     const STEPPER_RADIUS: f32 = 3.0;
     let rounding = match dir {
         StepperDir::Up   => egui::Rounding { nw: STEPPER_RADIUS, ne: STEPPER_RADIUS, sw: 0.0, se: 0.0 },
@@ -1504,11 +1504,11 @@ pub(super) fn paint_triangle(ui: &egui::Ui, rect: egui::Rect, dir: StepperDir, c
 
 /// Swift NumberFormatter equivalent: decimal with `maximumFractionDigits: 3`,
 /// `usesGroupingSeparator = false`, trailing zeros stripped so `5.0` shows as
-/// "5" and `25.50` shows as "25.5".
+/// "5" and `25.50` shows as "25.5"
 pub(super) fn format_num(v: f64) -> String {
     if v.fract().abs() < 1e-9 {
-        // Whole number path — avoid the "5.000" → "5" string thrash for the
-        // common case where every setting starts as an integer default.
+        // Whole number path: avoid the "5.000" -> "5" string thrash for the
+        // common case where every setting starts as an integer default
         format!("{}", v.round() as i64)
     } else {
         let s = format!("{:.3}", v);
@@ -1520,10 +1520,10 @@ pub(super) fn format_num(v: f64) -> String {
 // Settings stores sRGB [f32;4] in 0..1 (not linear), matching SwiftUI's Color
 // values (NSColor/CGColor in the deviceRGB space). The shader treats channel
 // values as sRGB and writes them to an 8-bit UNORM framebuffer as-is, which
-// the OS compositor displays as sRGB — identical to Swift's MTKView
+// the OS compositor displays as sRGB, identical to Swift's MTKView
 // (`colorPixelFormat = .bgra8Unorm`) pipeline. Storing sRGB also makes
 // gradient lerps interpolate in gamma space, matching SwiftUI's
-// LinearGradient/RadialGradient default behaviour.
+// LinearGradient/RadialGradient default behaviour
 
 pub(super) fn to_color32(c: [f32; 4]) -> egui::Color32 {
     egui::Color32::from_rgba_unmultiplied(
@@ -1543,7 +1543,7 @@ pub(super) fn from_color32(c: egui::Color32) -> [f32; 4] {
     ]
 }
 
-/// Like from_color32 but forces alpha=1.0 (for inhale/exhale colors).
+/// Like from_color32 but forces alpha=1.0 (for inhale/exhale colors)
 pub(super) fn from_color32_opaque(c: egui::Color32) -> [f32; 4] {
     [
         c.r() as f32 / 255.0,
@@ -1557,7 +1557,7 @@ pub(super) fn from_color32_opaque(c: egui::Color32) -> [f32; 4] {
 //
 // A handful of test-only atomics and helpers so unit tests can observe
 // where stepper_buttons actually placed its interact rects during the
-// previous frame.  Used only under `#[cfg(test)]`.
+// previous frame.  Used only under `#[cfg(test)]`
 #[cfg(test)]
 pub(super) mod test_hooks {
     use std::cell::RefCell;
@@ -1575,7 +1575,7 @@ pub(super) mod test_hooks {
 
     // Unlike the stepper hook above, the chip hook is `cfg(test)`: it is
     // written on every frame the chips are laid out, and a thread-local
-    // borrow plus a Vec clone per frame is not worth paying for in a
+    // borrow plus a Vec clone per frame isn't worth paying for in a
     // release build to support a test
     #[cfg(test)]
     thread_local! {
@@ -1601,7 +1601,7 @@ mod tests {
         let displayed = scale.to_display(stored);
         let back      = scale.from_display(displayed);
         assert!((back - stored).abs() < 1e-9,
-            "{:?}: {} → {} → {} (roundtrip drift {})",
+            "{:?}: {} -> {} -> {} (roundtrip drift {})",
             scale_name(scale), stored, displayed, back, back - stored);
     }
 
@@ -1613,7 +1613,7 @@ mod tests {
         }
     }
 
-    /// sRGB relative luminance, WCAG 2.1 definition.
+    /// sRGB relative luminance, WCAG 2.1 definition
     fn luminance(c: egui::Color32) -> f64 {
         let f = |v: u8| {
             let v = v as f64 / 255.0;
@@ -1628,7 +1628,7 @@ mod tests {
         (hi + 0.05) / (lo + 0.05)
     }
 
-    /// Source-over composite of `fg` (with alpha) onto opaque `bg`.
+    /// Source-over composite of `fg` (with alpha) onto opaque `bg`
     fn over(fg: egui::Color32, bg: egui::Color32) -> egui::Color32 {
         // `Color32::from_rgba_unmultiplied` stores premultiplied bytes, so
         // read the alpha back out and un-premultiply before compositing,
@@ -1647,7 +1647,7 @@ mod tests {
         // under the 4.5:1 AA threshold for body-size text, and asked for
         // a measurement. Measured, it clears: the pill is drawn at alpha
         // 230, so what shows through the card and the vibrancy behind it
-        // moves the result by less than a point of contrast.
+        // moves the result by less than a point of contrast
         //
         // Swept across every possible backdrop rather than one assumed
         // desktop grey, because the vibrancy material composites against
@@ -1709,20 +1709,20 @@ mod tests {
     fn unselected_chip_text_holds_up_wherever_the_vibrancy_can_land() {
         // Unselected chips paint `visuals().text_color()` directly on the
         // translucent card, so unlike the selected pill they inherit
-        // whatever the OS blur composites behind the window.
+        // whatever the OS blur composites behind the window
         //
-        // The bound swept here is that the material does not invert: a
+        // The bound swept here is that the material doesn't invert: a
         // dark material never renders lighter than mid-grey and a light
-        // one never renders darker. That is what "dark material" means,
-        // and it is the strongest honest assumption available from
+        // one never renders darker. That's what "dark material" means,
+        // and it's the strongest honest assumption available from
         // inside the process, since `NSVisualEffectView` gives back no
-        // sampled colour to test against.
+        // sampled colour to test against
         //
         // Past that bound the guarantee does lapse: near-white behind a
-        // dark-mode window measures about 3.0:1. That is a property of
+        // dark-mode window measures about 3.0:1. That's a property of
         // every `ui.label` in this window rather than anything the chips
-        // introduced, and it is the same accessibility debt as the
-        // missing AccessKit tree. Recorded here so it is a known number
+        // introduced, and it's the same accessibility debt as the
+        // missing AccessKit tree. Recorded here so it's a known number
         // instead of a surprise
         for (dark_mode, range) in [(true, 0..=128u8), (false, 128..=255u8)] {
             let text = if dark_mode {
@@ -1758,18 +1758,18 @@ mod tests {
 
     #[test]
     fn drift_percent_shifts_by_one() {
-        // 1.01 stored → 1.0 displayed (1 % drift).
+        // 1.01 stored -> 1.0 displayed (1 % drift)
         assert!((ValueScale::DriftPercent.to_display(1.01) - 1.0).abs() < 1e-9);
-        // 1 % displayed → 1.01 stored.
+        // 1 % displayed -> 1.01 stored
         assert!((ValueScale::DriftPercent.from_display(1.0) - 1.01).abs() < 1e-9);
-        // 0 % displayed → 1.0 stored (no drift).
+        // 0 % displayed -> 1.0 stored (no drift)
         assert!((ValueScale::DriftPercent.from_display(0.0) - 1.0).abs() < 1e-9);
     }
 
     /// The Drift row shows a percentage, never the multiplier it stores.
     /// Zero must mean "no drift" so that "off" is legible without the user
-    /// knowing anything about how it is stored, and one 0.1 step up from off
-    /// must land on 1.001 rather than anything coarser.
+    /// knowing anything about how it's stored, and one 0.1 step up from off
+    /// must land on 1.001 rather than anything coarser
     #[test]
     fn drift_zero_is_off_and_one_step_is_a_tenth_of_a_percent() {
         const STEP: f64 = 0.1; // matches the Drift stepper_row in settings_window.rs
@@ -1805,9 +1805,9 @@ mod tests {
 
     #[test]
     fn display_then_store_is_idempotent() {
-        // The settings UI does this: read stored → show → user edits →
-        // convert back → store.  If the user doesn't change anything,
-        // stored should equal its prior value to machine epsilon.
+        // The settings UI does this: read stored -> show -> user edits -> 
+        // convert back -> store.  If the user doesn't change anything,
+        // stored should equal its prior value to machine epsilon
         let cases = [
             (ValueScale::Identity,     5.0_f64),
             (ValueScale::Percent,      0.42_f64),
@@ -1815,7 +1815,7 @@ mod tests {
         ];
         for (scale, stored) in cases {
             let displayed = scale.to_display(stored);
-            // Simulate the user re-entering the same displayed value.
+            // Simulate the user re-entering the same displayed value
             let stored_again = scale.from_display(displayed);
             assert!((stored_again - stored).abs() < 1e-9,
                 "{:?}: round-trip drift on {stored}", scale_name(scale));

--- a/rust/crates/exhale-app/src/timers.rs
+++ b/rust/crates/exhale-app/src/timers.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use exhale_core::settings::Settings;
 use log::info;
 
-/// All timer state, checked each event-loop tick in `about_to_wait`.
+/// All timer state, checked each event-loop tick in `about_to_wait`
 pub struct Timers {
     pub auto_stop_deadline: Option<Instant>,
     pub last_reminder:      Option<Instant>,
@@ -14,7 +14,7 @@ impl Timers {
         Self { auto_stop_deadline: None, last_reminder: None }
     }
 
-    /// Call whenever `is_animating` or `auto_stop_minutes` changes.
+    /// Call whenever `is_animating` or `auto_stop_minutes` changes
     pub fn reschedule_auto_stop(&mut self, settings: &Settings) {
         self.auto_stop_deadline = if settings.auto_stop_minutes > 0.0 && settings.is_animating {
             let secs = settings.auto_stop_minutes * 60.0;
@@ -24,7 +24,7 @@ impl Timers {
         };
     }
 
-    /// Call whenever `reminder_interval_minutes` changes.
+    /// Call whenever `reminder_interval_minutes` changes
     pub fn reschedule_reminder(&mut self, settings: &Settings) {
         self.last_reminder = if settings.reminder_interval_minutes > 0.0 {
             Some(Instant::now())
@@ -33,11 +33,11 @@ impl Timers {
         };
     }
 
-    /// Earliest time the event loop must wake to service a pending timer.
-    /// Returned to `about_to_wait` so it can configure `ControlFlow::WaitUntil`
-    /// — without this the loop would sleep forever on idle and miss auto-stop
-    /// / reminder firings now that the old per-tick redraw loop no longer
-    /// wakes it every frame.
+    /// Earliest time the event loop must wake to service a pending
+    /// timer; returned to `about_to_wait` so it can configure
+    /// `ControlFlow::WaitUntil`: without this the loop would sleep
+    /// forever on idle and miss auto-stop / reminder firings now that
+    /// the old per-tick redraw loop no longer wakes it every frame
     pub fn next_deadline(&self, settings: &Settings) -> Option<Instant> {
         let mut next: Option<Instant> = self.auto_stop_deadline;
         if settings.reminder_interval_minutes > 0.0 {
@@ -54,9 +54,9 @@ impl Timers {
         next
     }
 
-    /// Returns `true` if the animation should be stopped (auto-stop deadline hit).
-    /// Returns `true` if a reminder notification should fire.
-    /// Caller is responsible for applying the stop and sending the notification.
+    /// Returns `true` if the animation should be stopped (auto-stop deadline hit)
+    /// Returns `true` if a reminder notification should fire
+    /// Caller is responsible for applying the stop and sending the notification
     pub fn tick(&mut self, settings: &Settings) -> TimerEvents {
         let now = Instant::now();
         let mut events = TimerEvents::default();
@@ -90,12 +90,12 @@ pub struct TimerEvents {
     pub reminder:  bool,
 }
 
-/// Cross-platform desktop notification ("Remember to breathe").
+/// Cross-platform desktop notification ("Remember to breathe")
 ///
 /// macOS uses the native `UNUserNotifications` framework (required for Mac
-/// App Store distribution — `NSUserNotification` is deprecated and
+/// App Store distribution: `NSUserNotification` is deprecated and
 /// `notify-rust`'s macOS backend relies on it).  Other platforms continue
-/// to use `notify-rust` (D-Bus on Linux, WinRT toasts on Windows).
+/// to use `notify-rust` (D-Bus on Linux, WinRT toasts on Windows)
 pub fn send_reminder() {
     info!("reminder: Remember to breathe");
     #[cfg(target_os = "macos")]
@@ -113,26 +113,27 @@ fn send_reminder_other() {
     }
 }
 
-/// Deliver a local notification via `UNUserNotificationCenter`.
+/// Deliver a local notification via `UNUserNotificationCenter`
 ///
 /// Mirrors the Swift AppDelegate's `sendReminderNotification()`: builds a
 /// `UNMutableNotificationContent` with title, body, and default sound, wraps
 /// it in a `UNNotificationRequest` with a fresh UUID identifier and a `nil`
-/// trigger (deliver immediately), then hands it to the shared center.
+/// trigger (deliver immediately), then hands it to the shared center
 ///
 /// Requires the bundle to be code-signed and to have been granted
-/// `.alert | .sound` authorization (see `platform::request_notification_permission`).
-/// In an unsigned `cargo run` build the center silently drops the request
-/// — that's fine for development.
+/// `.alert | .sound` authorization (see
+/// `platform::request_notification_permission`); in an unsigned
+/// `cargo run` build the center silently drops the request, which
+/// doesn't affect development
 #[cfg(target_os = "macos")]
 fn send_reminder_macos() {
     use block2::StackBlock;
     use objc2::msg_send;
     use objc2::runtime::{AnyClass, AnyObject};
 
-    // SAFETY: framework class lookups are fallible — skip silently
+    // SAFETY: framework class lookups are fallible; skip silently
     // when `UserNotifications.framework` isn't linked (e.g. in a
-    // bare `cargo test` binary).  Production app bundle has it.
+    // bare `cargo test` binary).  Production app bundle has it
     let (Some(unc_cls), Some(content_cls), Some(sound_cls), Some(req_cls)) = (
         AnyClass::get(c"UNUserNotificationCenter"),
         AnyClass::get(c"UNMutableNotificationContent"),
@@ -147,8 +148,8 @@ fn send_reminder_macos() {
 
         let ns_string = objc2::class!(NSString);
         // C-string literals via `c"…"` are guaranteed nul-terminated
-        // at compile time — no runtime `CString::new(...).unwrap()`,
-        // no allocation per reminder fire.
+        // at compile time, no runtime `CString::new(...).unwrap()`,
+        // no allocation per reminder fire
         let title:  *mut AnyObject = msg_send![ns_string, stringWithUTF8String: c"exhale".as_ptr()];
         let body:   *mut AnyObject = msg_send![ns_string, stringWithUTF8String: c"Remember to breathe".as_ptr()];
         let _: () = msg_send![content, setTitle: title];
@@ -183,10 +184,10 @@ fn send_reminder_macos() {
             ];
         }
 
-        // Balance the +1 retain from `[UNMutableNotificationContent alloc] init]`.
+        // Balance the +1 retain from `[UNMutableNotificationContent alloc] init]`;
         // `requestWithIdentifier:…` retains `content` internally, and the
         // request / sound / strings / uuid are autoreleased convenience
-        // returns that we don't own.
+        // returns that we don't own
         let _: () = msg_send![content, release];
     }
 }
@@ -230,7 +231,7 @@ mod tests {
         t.reschedule_auto_stop(&settings_with(2.0, 0.0, true));
         let deadline = t.auto_stop_deadline.expect("deadline set");
         let dt = deadline.duration_since(before);
-        // 2 minutes = 120s; allow ±100ms for clock noise.
+        // 2 minutes = 120s; allow ±100ms for clock noise
         assert!(dt >= Duration::from_secs_f64(119.9));
         assert!(dt <= Duration::from_secs_f64(120.1));
     }
@@ -266,7 +267,7 @@ mod tests {
         t.reschedule_reminder(&s);
         let d = t.next_deadline(&s).expect("some deadline");
         let now = Instant::now();
-        // Reminder fires in ~1 min, auto-stop in ~10 min → next should be ~1 min.
+        // Reminder fires in ~1 min, auto-stop in ~10 min -> next should be ~1 min
         let dt = d.duration_since(now);
         assert!(dt < Duration::from_secs(90),
             "earliest should be the 1-minute reminder, got {dt:?}");
@@ -276,7 +277,7 @@ mod tests {
     fn tick_fires_auto_stop_when_deadline_passes() {
         let mut t = Timers::new();
         // Use a tiny duration we can wait past.  We can't sleep in
-        // tests reliably, so backdate the deadline directly.
+        // tests reliably, so backdate the deadline directly
         t.auto_stop_deadline = Some(Instant::now() - Duration::from_millis(1));
         let events = t.tick(&settings_with(5.0, 0.0, true));
         assert!(events.auto_stop, "auto-stop event must fire when deadline passed");
@@ -295,7 +296,7 @@ mod tests {
     #[test]
     fn tick_fires_reminder_at_interval_and_resets_clock() {
         let mut t = Timers::new();
-        // Backdate so the interval has just passed.
+        // Backdate so the interval has just passed
         t.last_reminder = Some(Instant::now() - Duration::from_secs(61));
         let s = settings_with(0.0, 1.0, true);
         let events = t.tick(&s);

--- a/rust/crates/exhale-app/src/tray.rs
+++ b/rust/crates/exhale-app/src/tray.rs
@@ -7,19 +7,20 @@ use tray_icon::{
 
 // ─── Research link ────────────────────────────────────────────────────────────
 
-/// Deep link into the gaps ledger, not the top of the citation list.
+/// Deep link into the gaps ledger; the top of the citation list would
+/// read as authority instead of naming what the research doesn't support
 ///
 /// Landing the reader on 48 references reads as a wall of authority;
-/// landing them on the fourteen things the literature does *not*
+/// landing them on the fourteen things the literature *doesn't*
 /// support is the same click with the opposite effect.  The anchor is
 /// as much the feature as the menu item is, so both are pinned here
 /// together and `scripts/generate-citations.py` validates that this
-/// heading still exists.
+/// heading still exists
 ///
 /// Pinned to `main` rather than a release tag on purpose.  A binary
 /// stays installed long after its tag stops being the current state
 /// of the evidence, and a retraction has to reach the people running
-/// old builds.  A moved anchor is a CI failure; a stale claim is not
+/// old builds.  A moved anchor is a CI failure; a stale claim isn't
 ///
 /// Points at `docs/citations.html` rather than the file itself.  That
 /// page fetches `docs/CITATIONS.md` from `main` at load, so it stays
@@ -32,7 +33,7 @@ pub const RESEARCH_URL: &str =
 /// Named next to the URL because the wording and the anchor are one
 /// decision.  The label is plain, so the anchor carries the whole
 /// intent: "Research" pointing at the gaps ledger lands the reader on
-/// the fourteen things the literature does not support, where the same
+/// the fourteen things the literature doesn't support, where the same
 /// word pointing at the top of `CITATIONS.md` would land them in a wall
 /// of 48 references.  Shared with the macOS app menu, which shows the
 /// same item, so the two can never disagree
@@ -47,11 +48,11 @@ pub struct TrayMenuIds {
     pub stop:        tray_icon::menu::MenuId,
     pub reset:       tray_icon::menu::MenuId,
     pub quit:        tray_icon::menu::MenuId,
-    // Handles for dynamic enable/disable.
+    // Handles for dynamic enable/disable
     pub start_item:  MenuItem,
     pub stop_item:   MenuItem,
     // Top-level item handles whose labels include the current
-    // keybinding — kept here so the rebind path can `set_text` them
+    // keybinding: kept here so the rebind path can `set_text` them
     // when the user changes a shortcut, instead of rebuilding the
     // whole tray
     pub preferences_item: MenuItem,
@@ -65,8 +66,8 @@ pub struct TrayMenuIds {
     //
     // Each entry both displays the action's current binding (label
     // text via `set_text` on rebind) and acts as a click target that
-    // opens the settings window in capture mode for that action.
-    // Storing the handles here lets us update labels in place without
+    // opens the settings window in capture mode for that action;
+    // storing the handles here lets us update labels in place without
     // a tray rebuild. The handles themselves are only `set_text`'d by
     // `refresh_labels`, which only runs from the hotkey-rebind path
     // (feature-gated). MAS build keeps the fields populated so the
@@ -90,8 +91,8 @@ pub struct TrayMenuIds {
 
 impl TrayMenuIds {
     /// Match a clicked tray-menu item id back to the
-    /// [`ShortcutAction`] whose binding the user wants to change.
-    /// Returns `None` for items that aren't part of the
+    /// [`ShortcutAction`] whose binding the user wants to change;
+    /// returns `None` for items that aren't part of the
     /// "Keyboard Shortcuts ▶" submenu
     pub fn kb_action_for(&self, id: &tray_icon::menu::MenuId) -> Option<ShortcutAction> {
         if id == &self.kb_start       { Some(ShortcutAction::Start) }
@@ -143,9 +144,9 @@ fn submenu_label(action: ShortcutAction, shortcuts: &KeyboardShortcuts) -> Strin
     format!("{}: {binding}", action.label())
 }
 
-/// Build the system-tray icon + menu.
-/// Returns the `TrayIcon` handle (must stay alive) and the menu item IDs
-/// so the caller can match incoming `MenuEvent`s.
+/// Build the system-tray icon + menu, returning the `TrayIcon` handle
+/// (must stay alive) and the menu item IDs so the caller can match
+/// incoming `MenuEvent`s
 ///
 /// `shortcuts` is the current snapshot of user keybindings; labels
 /// embed each action's binding so the user can see at a glance what's
@@ -154,24 +155,24 @@ fn submenu_label(action: ShortcutAction, shortcuts: &KeyboardShortcuts) -> Strin
 /// the menu in sync
 pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuIds)> {
     // Propagate icon-construction failures via `?` rather than
-    // panicking — callers (`App::sync_tray_to_visibility`) already
+    // panicking: callers (`App::sync_tray_to_visibility`) already
     // log + continue when `build_tray` returns `Err`, so a bad
     // RGBA buffer or platform limitation degrades gracefully to
     // "no tray icon" instead of aborting the whole process at
     // launch.  In practice the buffer is hardcoded RGBA we
     // generate ourselves, so this branch is never expected to
-    // fire — but a `.expect()` here was the difference between
+    // fire, but a `.expect()` here was the difference between
     // "app didn't open" and "log line + app keeps running"
     let icon = make_icon()?;
 
     // No `Accelerator::new(...)` on any item.  Reasons:
     //   1. Bindings are user-customisable now; a static accelerator
-    //      label would lie when the user reassigns a shortcut.
+    //      label would lie when the user reassigns a shortcut
     //   2. On macOS, an `Accelerator` becomes the NSMenuItem's
     //      `keyEquivalent`, which fires WHILE the menu is open.  The
     //      same key press also queues in the global-hotkey channel,
-    //      so closing the menu plays the action a second time —
-    //      double-trigger bug.
+    //      so closing the menu plays the action a second time: a
+    //      double-trigger bug
     // Embed the binding in the label text instead so it stays correct
     // and avoids the dual-dispatch hazard
     let prefs_item = MenuItem::new(top_level_label("Preferences",       shortcuts.get(ShortcutAction::Preferences)), true, None);
@@ -238,7 +239,7 @@ pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuId
         // Treat the ring glyph as a template image on macOS: AppKit re-tints
         // template NSImages (white + alpha) based on menu-bar appearance, so
         // the icon reads correctly in both light and dark mode. No-op on
-        // Windows/Linux.
+        // Windows/Linux
         .with_icon_as_template(true)
         .with_menu(Box::new(menu))
         .with_tooltip("exhale")
@@ -249,8 +250,8 @@ pub fn build_tray(shortcuts: &KeyboardShortcuts) -> Result<(TrayIcon, TrayMenuId
 
 /// Outlined-ring tray icon generated at runtime, matching the Swift
 /// `StatusBarIcon` asset (15×17 ring shape).  Drawn with anti-aliased edges
-/// in near-black so it reads well on both light and dark menu bars.
-/// Returns `Result` so a failed `Icon::from_rgba` (corrupt buffer,
+/// in near-black so it reads well on both light and dark menu bars,
+/// returning `Result` so a failed `Icon::from_rgba` (corrupt buffer,
 /// platform limitation) bubbles up through `build_tray` and the
 /// caller can log + run without a tray instead of panicking at
 /// startup
@@ -267,12 +268,12 @@ fn make_icon() -> Result<tray_icon::Icon> {
             let dy = y as f32 + 0.5 - cy;
             let d  = (dx * dx + dy * dy).sqrt();
             // Smooth 1-pixel antialiasing at both the outer and inner edges
-            // of the ring.  Alpha peaks at the band between `inner` and `outer`.
+            // of the ring.  Alpha peaks at the band between `inner` and `outer`
             let aa_outer = (outer - d).clamp(0.0, 1.0);
             let aa_inner = (d - inner).clamp(0.0, 1.0);
             let alpha = (aa_outer.min(aa_inner) * 255.0) as u8;
             // White RGB so template-image tinting on macOS and plain display
-            // on Windows/Linux both come out legible; alpha carries the shape.
+            // on Windows/Linux both come out legible; alpha carries the shape
             [0xFF, 0xFF, 0xFF, alpha]
         }))
         .collect();

--- a/rust/crates/exhale-core/src/controller.rs
+++ b/rust/crates/exhale-core/src/controller.rs
@@ -15,14 +15,14 @@ use crate::{
 
 // ─── Public state snapshot ────────────────────────────────────────────────────
 
-/// Snapshot of the breathing animation at a point in time.
-/// Read by the renderer every time it draws a frame.
+/// Snapshot of the breathing animation at a point in time. Read by
+/// the renderer every time it draws a frame
 #[derive(Clone, Copy, Debug)]
 pub struct BreathingState {
     pub phase:     BreathingPhase,
-    /// 0.0 = fully collapsed, 1.0 = fully expanded.
+    /// 0.0 = fully collapsed, 1.0 = fully expanded
     pub progress:  f32,
-    /// 0.0–1.0 elapsed fraction within the current hold phase (for ripple).
+    /// 0.0–1.0 elapsed fraction within the current hold phase (for ripple)
     pub hold_time: f32,
 }
 
@@ -33,7 +33,7 @@ pub struct BreathingState {
 // cadence anymore: bench measurements showed the slow-cadence path
 // fired for <10 % of clock time and saved well under 0.1 % CPU, which
 // is below the noise floor of any user-facing measurement and not
-// worth the extra hysteresis state.
+// worth the extra hysteresis state
 const INTERVAL_FAST: Duration = Duration::from_nanos(41_666_667);  // 1/24 s
 
 const MIN_PROGRESS_DELTA: f32 = 0.003;
@@ -46,7 +46,7 @@ struct Inner {
     phase_duration: Duration,
 
     cycle_count:    u64,
-    /// Running drift multiplier: starts at 1.0, multiplied by `drift` each cycle.
+    /// Running drift multiplier: starts at 1.0, multiplied by `drift` each cycle
     current_drift:  f64,
 
     did_render_hold:    bool,
@@ -57,28 +57,28 @@ struct Inner {
 
 // ─── Controller ──────────────────────────────────────────────────────────────
 
-/// Drives the breathing animation timing on a dedicated background thread.
+/// Drives the breathing animation timing on a dedicated background thread
 ///
-/// Direct port of `MetalBreathingController.swift`.  The thread sleeps between
-/// ticks — it never spins — so CPU overhead between frames is near zero.
+/// Direct port of `MetalBreathingController.swift`.  The thread sleeps
+/// between ticks, never spins, so CPU overhead between frames is near zero
 pub struct BreathingController {
     state:        Arc<Mutex<Option<BreathingState>>>,
     thread:       Option<JoinHandle<()>>,
     stop_flag:    Arc<std::sync::atomic::AtomicBool>,
-    /// Set to restart the animation from inhale phase 0 on the next tick.
+    /// Set to restart the animation from inhale phase 0 on the next tick
     reset_flag:   Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl BreathingController {
-    /// Create and immediately start the controller.
+    /// Create and immediately start the controller
     ///
     /// `state` is the shared snapshot slot the controller writes to each
-    /// tick — pre-constructed so per-overlay render threads can hold the
+    /// tick, pre-constructed so per-overlay render threads can hold the
     /// same `Arc` and read directly without round-tripping through the
     /// main event loop.  `request_draw` is called from the background
     /// thread whenever a new frame should be rendered; wire it to the
     /// overlays' render-thread channels so frame signals bypass the
-    /// main thread's message pump entirely.
+    /// main thread's message pump entirely
     pub fn start(
         settings:     Arc<RwLock<Settings>>,
         state:        Arc<Mutex<Option<BreathingState>>>,
@@ -98,43 +98,43 @@ impl BreathingController {
                 run_controller(settings_clone, state_clone, request_draw, stop_clone, reset_clone);
             })
             .expect(
-                "exhale-controller: thread::spawn failed (system thread limit / OOM) — \
-                 cannot continue without the breathing controller; restart the process \
+                "exhale-controller: thread::spawn failed (system thread limit / OOM): \
+                 can't continue without the breathing controller; restart the process \
                  once memory is available",
             );
 
         Self { state, thread: Some(handle), stop_flag, reset_flag }
     }
 
-    /// Get a snapshot of the current breathing state for rendering.
-    /// Returns `None` only before the first tick.
+    /// Get a snapshot of the current breathing state for rendering. Returns
+    /// `None` only before the first tick
     pub fn get_state(&self) -> Option<BreathingState> {
         *self.state.lock_or_recover()
     }
 
     /// Shared handle to the controller's state slot.  Cheap to clone;
     /// the per-overlay render thread reads from this directly each
-    /// frame instead of round-tripping through the main event loop.
-    /// The controller writes to this BEFORE invoking `request_draw`,
+    /// frame instead of round-tripping through the main event loop. The
+    /// controller writes to this BEFORE invoking `request_draw`,
     /// so any thread woken by `request_draw` is guaranteed to observe
     /// the latest state via the Mutex barrier
     pub fn state_handle(&self) -> Arc<Mutex<Option<BreathingState>>> {
         Arc::clone(&self.state)
     }
 
-    /// Restart the animation from inhale phase 0 on the next tick.
-    /// Matches Swift `MetalBreathingController.start()` which always resets
-    /// `cycleCount = 0` and `currentPhase = .inhale`.
+    /// Restart the animation from inhale phase 0 on the next tick. Matches
+    /// Swift `MetalBreathingController.start()` which always resets
+    /// `cycleCount = 0` and `currentPhase = .inhale`
     ///
     /// `unpark` wakes the controller out of its current
     /// `park_timeout` sleep so the reset takes effect immediately,
     /// not on the controller's next natural wakeup.  This matters
-    /// most when `restart()` is called from the Stop → Start
+    /// most when `restart()` is called from the Stop -> Start
     /// sequence: while `is_animating == false`, the tick function
     /// returns a 10 s sleep interval (no work to do), and without
     /// the unpark the user would see the animation start mid-cycle
     /// in whatever state the renderer had cached and stay frozen
-    /// there for up to 10 s — a bug that read as "Start is
+    /// there for up to 10 s, a bug that read as "Start is
     /// broken / animation is paused"
     pub fn restart(&self) {
         self.reset_flag.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -144,7 +144,7 @@ impl BreathingController {
     }
 
     /// Signal the controller to stop and join the thread.  Same
-    /// `unpark` rationale as [`Self::restart`] — without it,
+    /// `unpark` rationale as [`Self::restart`]; without it,
     /// shutdown could wait up to 10 s for the controller's
     /// not-animating sleep to elapse before the join returns
     pub fn stop(&mut self) {
@@ -179,13 +179,13 @@ fn run_controller(
 
     // Deadline the next iteration should fire at.  We advance this by the
     // tick's requested `next_interval` after every iteration, then sleep
-    // until that deadline rather than sleeping `next_interval` from "now".
-    // Without this, every `thread::sleep` overshoot (typically 0-10 ms on
-    // macOS) accumulated into perceived choppiness even at the same fps —
-    // frames landed at irregular wall-clock times.  Deadline-based
-    // scheduling means a 5-ms-late wake-up is followed by a 5-ms-shorter
-    // sleep, so the long-run cadence stays exact and the eye reads the
-    // motion as smooth at the same render rate / CPU cost.
+    // until that deadline rather than sleeping `next_interval` from "now". Without
+    // this, every `thread::sleep` overshoot (typically 0-10 ms on macOS)
+    // accumulated into perceived choppiness even at the same fps: frames
+    // landed at irregular wall-clock times.  Deadline-based scheduling
+    // means a 5-ms-late wake-up is followed by a 5-ms-shorter sleep, so
+    // the long-run cadence stays exact and the eye reads the motion as
+    // smooth at the same render rate / CPU cost
     let mut next_wakeup = Instant::now();
 
     loop {
@@ -194,7 +194,7 @@ fn run_controller(
         }
 
         // restart() was called (e.g. user pressed Start): reset to inhale phase 0,
-        // matching Swift MetalBreathingController.start() which resets cycleCount=0.
+        // matching Swift MetalBreathingController.start() which resets cycleCount=0
         if reset_flag.swap(false, std::sync::atomic::Ordering::Relaxed) {
             let inhale_dur = settings.read_or_recover().inhale_duration;
             inner = fresh_inner(Instant::now(), inhale_dur);
@@ -208,7 +208,7 @@ fn run_controller(
         );
 
         if should_draw {
-            // Write state snapshot before requesting draw so renderer sees it.
+            // Write state snapshot before requesting draw so renderer sees it
             let snap = compute_state(&inner);
             *state_out.lock_or_recover() = Some(snap);
             (request_draw)();
@@ -217,7 +217,7 @@ fn run_controller(
         // Advance the target deadline by exactly `next_interval`.  Catch-up
         // clamp: if a long pause (laptop sleep, app backgrounded) put us
         // more than 1 second past the target, snap forward instead of
-        // burst-rendering frames to "make up" the missed time.
+        // burst-rendering frames to "make up" the missed time
         next_wakeup += next_interval;
         let now = Instant::now();
         if next_wakeup + Duration::from_secs(1) < now {
@@ -229,11 +229,11 @@ fn run_controller(
         // `park_timeout` instead of `thread::sleep` so `restart()` /
         // `stop()` can wake us via `unpark()` mid-sleep.  When
         // `is_animating == false` the tick function returns a 10 s
-        // sleep interval, and without interruptible sleep a Stop →
+        // sleep interval, and without interruptible sleep a Stop -> 
         // Start press would wait up to 10 s before the controller
         // noticed the reset_flag and started ticking again.  If
         // unpark was called BEFORE we reached the park, the token
-        // is already pending and park_timeout returns immediately —
+        // is already pending and park_timeout returns immediately,
         // which is exactly what we want (don't lose a wakeup
         // signal that arrived during the previous tick's work)
         thread::park_timeout(sleep_for);
@@ -265,7 +265,7 @@ fn tick(
 ) -> (bool, Duration) {
     let now = Instant::now();
 
-    // Snapshot the fields we need; avoid holding the lock across sleeps.
+    // Snapshot the fields we need; avoid holding the lock across sleeps
     let (
         is_animating, is_paused, hold_ripple_enabled,
         shape_is_fullscreen, colors_match,
@@ -302,14 +302,14 @@ fn tick(
     //
     // `cycle_is_static` catches the degenerate input where the user
     // has zeroed every duration field.  Without this short-circuit
-    // the controller would cycle through Inhale → Hold → Exhale →
+    // the controller would cycle through Inhale -> Hold -> Exhale -> 
     // Hold in 400 ms (each phase floored to 0.1 s by `.max(0.1)` in
     // `phase_duration_for`), strobing the breath animation at
     // ~2.5 Hz.  Treating it as static instead: the existing one-
     // frame-per-second cadence renders whatever the last
     // `BreathingState` was, the shader keeps drawing that state,
     // and CPU stays as low as the matching-colour fullscreen tint
-    // path.  Threshold is 0.05 s (50 ms) — comfortably below the
+    // path.  Threshold is 0.05 s (50 ms), comfortably below the
     // 0.1 s phase floor and below human flicker-fusion frequency,
     // so anything the user could meaningfully type as "a real
     // animation" stays above it
@@ -354,7 +354,7 @@ fn tick(
             }
             return (false, INTERVAL_FAST.min(remaining));
         } else {
-            // No ripple: render exactly once per hold, then sleep until it ends.
+            // No ripple: render exactly once per hold, then sleep until it ends
             if !inner.did_render_hold {
                 inner.did_render_hold = true;
                 inner.last_draw_time  = now;
@@ -395,7 +395,7 @@ fn tick(
             inner.last_drawn_progress   = current.progress;
             return (true, cadence.min(time_to_phase_end));
         }
-        // Not yet time; come back when cadence expires.
+        // Not yet time; come back when cadence expires
         let wait = cadence.saturating_sub(elapsed_since_last);
         return (false, wait.min(time_to_phase_end));
     }
@@ -429,10 +429,10 @@ fn compute_state_with_easing(
 
     let hold_time = raw_t as f32;
 
-    // hold_time carries the linear phase-progress for all phases (not only
-    // holds). The shader uses it to drive the cross-phase ripple fade during
-    // the first 10% of inhale/exhale, matching Swift's
-    // `withAnimation(.linear(duration: duration * 0.1)) { rippleOpacity = 0 }`.
+    // hold_time carries the linear phase-progress for all phases, inhale
+    // and exhale included. The shader uses it to drive the cross-phase
+    // ripple fade during the first 10% of inhale/exhale, matching Swift's
+    // `withAnimation(.linear(duration: duration * 0.1)) { rippleOpacity = 0 }`
     match inner.phase {
         BreathingPhase::Inhale => BreathingState {
             phase:    BreathingPhase::Inhale,
@@ -532,7 +532,7 @@ mod tests {
     use std::sync::RwLock;
     use crate::settings::Settings;
 
-    // Helper: advance N phases manually through the inner state machine.
+    // Helper: advance N phases manually through the inner state machine
     fn advance_n_phases(inner: &mut Inner, n: usize, settings: &Settings) {
         for _ in 0..n {
             let now = Instant::now();
@@ -581,8 +581,8 @@ mod tests {
 
     #[test]
     fn drift_accumulates_correctly() {
-        // Drift is off by default now, so set it explicitly: this test is
-        // about compounding, not about what ships
+        // Drift is off by default now, so set it explicitly: this test
+        // covers compounding, independent of what ships as the default
         let mut settings = Settings::default();
         settings.drift = 1.01;
         let now = Instant::now();
@@ -598,7 +598,7 @@ mod tests {
             last_drawn_progress: -1.0,
         };
 
-        // One full cycle advance (HoldAfterExhale → Inhale)
+        // One full cycle advance (HoldAfterExhale -> Inhale)
         advance_n_phases(&mut inner, 1, &settings);
         assert_eq!(inner.cycle_count, 1);
         let expected_drift = 1.01_f64;
@@ -622,7 +622,7 @@ mod tests {
     #[test]
     fn drift_matches_pow() {
         // current_drift should equal drift^cycle_count at every cycle boundary,
-        // for as long as the ceiling has not been reached.
+        // for as long as the ceiling has not been reached
         let mut settings = Settings::default();
         settings.drift = 1.01;
         let now = Instant::now();
@@ -642,13 +642,13 @@ mod tests {
         // unbounded by design, so this must hold arbitrarily far out. An
         // earlier revision capped the compounding; that cap was removed
         // because advanced pranayama practice legitimately reaches breaths
-        // far longer than the research literature happens to have studied.
-        // See docs/CITATIONS.md gaps ledger item 6
+        // far longer than the research literature happens to have studied. See
+        // docs/CITATIONS.md gaps ledger item 6
         for cycle in 0..2_000_u64 {
             // advance one full cycle (4 phases)
             advance_n_phases(&mut inner, 4, &settings);
             let expected = settings.drift.powi((cycle + 1) as i32);
-            // Relative, not absolute: repeated multiplication and `powi` agree
+            // A relative tolerance: repeated multiplication and `powi` agree
             // to ~13 significant figures, but drift is unbounded, so by cycle
             // ~1200 the values are in the hundreds of thousands and a fixed
             // 1e-9 epsilon compares the wrong thing entirely
@@ -734,7 +734,7 @@ mod tests {
 
     #[test]
     fn phase_duration_minimum_is_100ms() {
-        // Even with drift=0 or base=0, duration must be ≥ 0.1s.
+        // Even with drift=0 or base=0, duration must be ≥ 0.1s
         let dur = phase_duration_for(
             BreathingPhase::Inhale,
             0.0, // impossible drift, tests the clamp
@@ -747,8 +747,8 @@ mod tests {
     // ── tick() cadence / hysteresis tests ─────────────────────────────────
     //
     // These exercise the per-tick scheduler logic that decides whether
-    // to render *this* tick and how long to sleep before the next.
-    // Prior to these tests `tick()` had zero coverage despite being the
+    // to render *this* tick and how long to sleep before the next. Prior
+    // to these tests `tick()` had zero coverage despite being the
     // hottest function in the app
 
     fn fresh_inner_at(now: Instant, dur: Duration) -> Inner {
@@ -774,7 +774,7 @@ mod tests {
         let easing   = EasingTable::default_ease_in_out();
         let mut inner = fresh_inner_at(Instant::now(), Duration::from_secs(5));
         let (should_draw, next) = tick(&mut inner, &settings, &easing);
-        assert!(!should_draw, "stopped controller should not request a draw");
+        assert!(!should_draw, "a stopped controller shouldn't request a draw");
         assert!(next >= Duration::from_secs(1), "stopped controller should sleep >=1s, got {next:?}");
     }
 
@@ -787,11 +787,11 @@ mod tests {
         let mut inner = fresh_inner_at(Instant::now(), Duration::from_secs(5));
         // First call: last_draw_time was 1s ago, so this should draw
         // (the paused branch redraws once a second to keep the static
-        // frame current against settings changes).
+        // frame current against settings changes)
         let (should_draw_1, _) = tick(&mut inner, &settings, &easing);
         assert!(should_draw_1, "paused controller draws once per second");
         // Second call immediately after: not yet a second elapsed, so
-        // it should NOT draw and the sleep should be < 1s.
+        // it should NOT draw and the sleep should be < 1s
         let (should_draw_2, next_2) = tick(&mut inner, &settings, &easing);
         assert!(!should_draw_2, "paused controller doesn't draw twice in a row");
         assert!(next_2 < Duration::from_secs(1));
@@ -800,7 +800,7 @@ mod tests {
     #[test]
     fn tick_hold_with_ripple_redraws_periodically() {
         // Hold-with-ripple: should draw at `interval_fast` cadence
-        // throughout the hold, not just at the boundaries.
+        // continuously through the hold, boundaries included
         let mut s = Settings::default();
         s.hold_ripple_mode = crate::types::HoldRippleMode::Gradient;
         s.post_inhale_hold_duration = 2.0; // long hold for the test
@@ -812,7 +812,7 @@ mod tests {
         inner.last_draw_time = now - Duration::from_millis(200); // not yet due
 
         let (should_draw, _) = tick(&mut inner, &settings, &easing);
-        // First tick of a fresh hold draws (did_render_hold was false).
+        // First tick of a fresh hold draws (did_render_hold was false)
         assert!(should_draw);
     }
 
@@ -836,7 +836,7 @@ mod tests {
     #[test]
     fn cadence_matches_swift_reference() {
         // 24 fps = 1/24 s = ~41.67 ms.  Matches `MetalBreathingController.swift`'s
-        // `maximumDrawIntervalFast`.
+        // `maximumDrawIntervalFast`
         let ms = INTERVAL_FAST.as_nanos() as f64 / 1_000_000.0;
         assert!((ms - 1000.0 / 24.0).abs() < 0.01,
             "INTERVAL_FAST should be 1/24 s = 41.67 ms, got {ms}");

--- a/rust/crates/exhale-core/src/easing.rs
+++ b/rust/crates/exhale-core/src/easing.rs
@@ -1,17 +1,17 @@
-/// Pre-computed lookup table for a CSS cubic-bezier easing curve.
+/// Pre-computed lookup table for a CSS cubic-bezier easing curve
 ///
 /// Direct port of `MetalBreathingController.buildEasingTable` and
 /// `CubicBezierEaseInOut` from the Swift source.  The table is built once at
-/// startup (1024 samples) and queried with linear interpolation — identical to
-/// the Swift implementation.
+/// startup (1024 samples) and queried with linear interpolation, identical to
+/// the Swift implementation
 pub struct EasingTable {
     samples: Box<[f32]>,
 }
 
 impl EasingTable {
-    /// Build a table for the given cubic-bezier control points.
+    /// Build a table for the given cubic-bezier control points
     ///
-    /// For the default sinusoidal mode use `(0.42, 0.0, 0.58, 1.0)`.
+    /// For the default sinusoidal mode use `(0.42, 0.0, 0.58, 1.0)`
     pub fn new(x1: f64, y1: f64, x2: f64, y2: f64, sample_count: usize) -> Self {
         assert!(sample_count >= 2, "need at least 2 samples");
         let samples = (0..sample_count)
@@ -24,13 +24,13 @@ impl EasingTable {
         Self { samples }
     }
 
-    /// Build the default ease-in-out table used by the breathing animation.
+    /// Build the default ease-in-out table used by the breathing animation
     pub fn default_ease_in_out() -> Self {
         Self::new(0.42, 0.0, 0.58, 1.0, 1024)
     }
 
     /// Sample the table at `t ∈ [0, 1]` using linear interpolation between
-    /// adjacent entries, identical to `MetalBreathingController.getEasedT`.
+    /// adjacent entries, identical to `MetalBreathingController.getEasedT`
     pub fn sample(&self, t: f64) -> f64 {
         let n = self.samples.len();
         let index_f = t * (n - 1) as f64;
@@ -41,7 +41,7 @@ impl EasingTable {
         (a + (b - a) * frac) as f64
     }
 
-    /// Number of samples in the table.
+    /// Number of samples in the table
     pub fn len(&self) -> usize {
         self.samples.len()
     }
@@ -53,7 +53,7 @@ impl EasingTable {
 
 // ─── Newton-Raphson cubic-bezier solver ──────────────────────────────────────
 //
-// Exact port of `CubicBezierEaseInOut.getValue` from Swift.
+// Exact port of `CubicBezierEaseInOut.getValue` from Swift
 
 fn cubic(t: f64, a1: f64, a2: f64) -> f64 {
     let c = 3.0 * a1;
@@ -69,10 +69,10 @@ fn cubic_derivative(t: f64, a1: f64, a2: f64) -> f64 {
     (3.0 * a * t + 2.0 * b) * t + c
 }
 
-/// Solve for the y-value of a CSS cubic-bezier at input `t`.
+/// Solve for the y-value of a CSS cubic-bezier at input `t`
 ///
 /// Uses Newton-Raphson to find `t'` such that `cubic_x(t') ≈ t`, then
-/// evaluates `cubic_y(t')`.
+/// evaluates `cubic_y(t')`
 pub fn cubic_bezier_value(t: f64, x1: f64, y1: f64, x2: f64, y2: f64) -> f64 {
     const EPSILON: f64 = 1e-6;
     let mut t_prime = t;
@@ -99,7 +99,7 @@ mod tests {
 
     const TOL: f64 = 1e-4;
 
-    // Boundary values must be exact for all easing curves.
+    // Boundary values must be exact for all easing curves
     #[test]
     fn boundary_values() {
         let table = EasingTable::default_ease_in_out();
@@ -107,7 +107,7 @@ mod tests {
         assert!((table.sample(1.0) - 1.0).abs() < TOL, "t=1 should yield 1");
     }
 
-    // ease-in-out is symmetric around t=0.5 → value ≈ 0.5
+    // ease-in-out is symmetric around t=0.5 -> value ≈ 0.5
     #[test]
     fn midpoint_near_half() {
         let table = EasingTable::default_ease_in_out();
@@ -130,7 +130,7 @@ mod tests {
         assert!(late > 0.75 - TOL, "ease-in-out should be fast at t=0.75, got {late}");
     }
 
-    // Linear mode: the table should be a straight line (identity).
+    // Linear mode: the table should be a straight line (identity)
     #[test]
     fn linear_is_identity() {
         let table = EasingTable::new(0.0, 0.0, 1.0, 1.0, 1024);
@@ -148,7 +148,7 @@ mod tests {
     }
 
     // Known reference values for CSS cubic-bezier(0.42, 0, 0.58, 1) computed
-    // independently.  Tolerance is generous to allow for minor float differences.
+    // independently.  Tolerance is generous to allow for minor float differences
     #[test]
     fn known_values() {
         let table = EasingTable::default_ease_in_out();

--- a/rust/crates/exhale-core/src/pacing.rs
+++ b/rust/crates/exhale-core/src/pacing.rs
@@ -1,36 +1,36 @@
-//! The sentences the settings window is allowed to say about pacing.
+//! The sentences the settings window is allowed to say about pacing
 //!
 //! This module exists so that every user-visible statement about the
 //! research is derived, testable, and covered by CI. It lives in
 //! `exhale-core` rather than next to the widget that paints it for one
-//! blunt reason: CI runs `cargo test -p exhale-core` and does not
+//! blunt reason: CI runs `cargo test -p exhale-core` and doesn't
 //! compile `exhale-app`, which needs wgpu, winit and GTK. Copy that
 //! makes a coverage statement should not be the only text in the
-//! project with no test behind it.
+//! project with no test behind it
 //!
 //! **What the binary is permitted to assert.** Numbers it computed
 //! itself, one range, and nothing else. No effect, no benefit, no
 //! condition, no outcome measure. The corpus contains far stronger
 //! warrants than anything here, and they stay out of the binary on
 //! purpose: a store-reviewed app carries a retraction latency measured
-//! in weeks, so a claim compiled into it cannot be withdrawn at the
+//! in weeks, so a claim compiled into it can't be withdrawn at the
 //! speed the evidence can change. Arithmetic has no such problem,
-//! because arithmetic cannot be retracted. See `docs/CITATIONS.md`.
+//! because arithmetic can't be retracted. See `docs/CITATIONS.md`
 
 use crate::settings::Settings;
 
-/// Slowest rate with direct experimental support, in breaths per minute.
+/// Slowest rate with direct experimental support, in breaths per minute
 ///
 /// From `you2023-respiratory-frequency`, which tested 5, 5.5, 6, 6.5
-/// and 7 cycles per minute. The endpoints are the endpoints of what was
-/// actually run, not a recommendation and not a safe range: outside it
-/// means untested here, which is different from tested and found
-/// wanting. Gaps ledger item 2
+/// and 7 cycles per minute. The endpoints are the edges of what was
+/// actually run: a fact about the experiment, separate from a
+/// recommendation or a safe range. Outside it means untested here,
+/// which is different from tested and found wanting. Gaps ledger item 2
 pub const TESTED_MIN_BPM: f64 = 5.0;
 /// Fastest rate with direct experimental support. See [`TESTED_MIN_BPM`]
 pub const TESTED_MAX_BPM: f64 = 7.0;
 
-/// Where a rate sits relative to the directly tested range.
+/// Where a rate sits relative to the directly tested range
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Coverage {
     Slower,
@@ -39,7 +39,7 @@ pub enum Coverage {
 }
 
 impl Coverage {
-    /// Classify a rate that has ALREADY been rounded for display.
+    /// Classify a rate that has ALREADY been rounded for display
     ///
     /// Rounding first is deliberate. Classifying the raw value lets the
     /// panel print "5.0 breaths a minute" directly above "slower than
@@ -94,23 +94,24 @@ fn grouped(n: u64) -> String {
 }
 
 /// Breaths of continuous running before one cycle takes twice as long
-/// as it does now, or `None` when drift is off or shortening.
+/// as it does now, or `None` when drift is off or shortening
 ///
-/// **Counted in breaths, not minutes, and that is the whole point.**
-/// Cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at `k = ln2 / ln d`: the
-/// starting cycle length cancels out entirely. One per cent doubles the
-/// breath in 70 breaths whether the user started at 10 s or at 15 s.
+/// **Counted in breaths, because that unit stays constant across
+/// cycle lengths.** Cycle `k` lasts `c · dᵏ`, so `dᵏ = 2` at
+/// `k = ln2 / ln d`: the starting cycle length cancels out
+/// entirely. One per cent doubles the breath in 70 breaths
+/// whether the user started at 10 s or at 15 s
 ///
 /// Quoting a doubling *time* instead made the panel look broken. The
 /// same 1 % setting reads as 17 minutes from a 10 s cycle and 25
 /// minutes from a 15 s one, which invites the reader to conclude the
 /// arithmetic is unreliable when in fact both are correct and the
 /// question was ambiguous. A count of breaths is a property of the
-/// drift value alone, so it is stable, and it is also the thing the
-/// user is about to sit through.
+/// drift value alone, so it's stable, and it's also the thing the
+/// user is about to sit through
 ///
-/// It is a true repeat rate, not just a first milestone: the same `k`
-/// takes the cycle from `2c` to `4c`
+/// It's a repeat rate: the same `k` also takes the cycle from `2c`
+/// to `4c`
 pub fn breaths_to_double(settings: &Settings) -> Option<f64> {
     if settings.cycle_secs() <= 0.0 || settings.drift <= 1.0 {
         return None;
@@ -123,9 +124,9 @@ pub fn breaths_to_double(settings: &Settings) -> Option<f64> {
 /// somebody might actually sit through
 const PROJECTION_MINUTES: f64 = 60.0;
 
-/// Build the readout, one string per line, in display order.
+/// Build the readout, one string per line, in display order
 ///
-/// Returns empty when no phase has a duration, which is not a rate of
+/// Returns empty when no phase has a duration, which isn't a rate of
 /// anything and not a state worth narrating
 pub fn readout_lines(settings: &Settings) -> Vec<String> {
     let Some(bpm) = settings.breaths_per_min() else {
@@ -144,7 +145,7 @@ pub fn readout_lines(settings: &Settings) -> Vec<String> {
         .map(round_bpm);
 
     if projected.is_some() {
-        // Seconds, not breaths per minute. "About 1.3 a minute after an
+        // Seconds, rather than breaths per minute. "About 1.3 a minute after an
         // hour" is arithmetically correct and unreadable: nobody holds a
         // mental picture of 1.3 breaths a minute, whereas everybody can
         // picture a breath that has gone from 10 seconds to 46. Seconds
@@ -163,13 +164,13 @@ pub fn readout_lines(settings: &Settings) -> Vec<String> {
 
         let now  = settings.cycle_secs();
         let then = 60.0 / settings.breaths_per_min_after(PROJECTION_MINUTES).unwrap_or(f64::MAX);
-        // Suppress the second clause when an hour does not move the
+        // Suppress the second clause when an hour doesn't move the
         // number a person could read off the screen. At 0.001 % a 15 s
-        // cycle reaches 15.04 s, and "after an hour it is 15 s, not
-        // 15 s" reads as a bug rather than as a very gentle setting
+        // cycle reaches 15.04 s, and "after an hour the cycle is 15 s,
+        // up from 15 s" reads as a bug rather than as a gentle setting
         if (then - now).abs() >= 0.5 {
             drift_line.push_str(&format!(
-                " After an hour it is {}, not {}.",
+                " After an hour the cycle is {}, up from {}.",
                 format_secs(then),
                 format_secs(now),
             ));
@@ -182,11 +183,11 @@ pub fn readout_lines(settings: &Settings) -> Vec<String> {
 }
 
 /// The one range the binary is allowed to name, and where the current
-/// setting falls against it.
+/// setting falls against it
 ///
 /// Phrased about the literature throughout. It reports what was
-/// measured and whether this number was among it; it does not tell the
-/// user their breathing is wrong, because the corpus does not support
+/// measured and whether this number was among it; it doesn't tell the
+/// user their breathing is wrong, because the corpus doesn't support
 /// that and the app is in no position to say so
 fn coverage_line(now: f64, projected: Option<f64>) -> String {
     let base = format!(
@@ -210,9 +211,9 @@ fn coverage_line(now: f64, projected: Option<f64>) -> String {
     }
 }
 
-/// Whole seconds when the cycle is whole, one decimal when it is not.
-/// Timing steppers move in whole seconds, so "15 s" is the normal case
-/// and "15.5 s" only shows up for a typed value
+/// Whole seconds when the cycle is whole, one decimal when it isn't. Timing
+/// steppers move in whole seconds, so "15 s" is the normal case and "15.5 s"
+/// only shows up for a typed value
 fn format_secs(secs: f64) -> String {
     if (secs - secs.round()).abs() < 1e-9 {
         format!("{secs:.0} s")
@@ -229,7 +230,7 @@ mod tests {
     #[test]
     fn the_shipped_default_reports_itself_as_inside_the_tested_band() {
         // exhale defaults to 5 / 0 / 5 / 0, six a minute, and the panel
-        // says so on first open without being asked. The readout is not
+        // says so on first open without being asked. The readout isn't
         // here to flatter the default: `box_breathing_is_reported_as_
         // slower_than_it_looks` is the same code volunteering bad news
         let lines = readout_lines(&Settings::default());
@@ -273,7 +274,7 @@ mod tests {
         assert_eq!(lines.len(), 3, "{lines:#?}");
         assert_eq!(
             lines[1],
-            "Drift: the cycle doubles every 70 breaths. After an hour it is 46 s, not 10 s."
+            "Drift: the cycle doubles every 70 breaths. After an hour the cycle is 46 s, up from 10 s."
         );
         assert!(
             lines[2].ends_with("This one starts inside it and is slower than all of them within an hour."),
@@ -309,10 +310,10 @@ mod tests {
 
     #[test]
     fn the_doubling_count_does_not_depend_on_the_starting_cycle() {
-        // The bug this replaced. Quoted as a doubling *time*, one per
-        // cent read as 17 minutes from a 10 s cycle and 25 minutes from
-        // a 15 s one, and the panel looked like it could not do
-        // arithmetic. Both were right; the unit was wrong
+        // Guards against the bug where quoting a doubling *time* read as
+        // 17 minutes from a 10 s cycle and 25 minutes from a 15 s one,
+        // and the panel looked like it could not do arithmetic. Both
+        // were right; the unit was wrong
         let mut ten = Settings::default();
         ten.drift = 1.01;
         assert_eq!(ten.cycle_secs(), 10.0);
@@ -353,7 +354,7 @@ mod tests {
     #[test]
     fn a_drift_too_slow_to_see_within_an_hour_says_only_what_it_can() {
         // 0.001 % moves a 15 s cycle to 15.04 s in an hour. "After an
-        // hour it is 15 s, not 15 s" would read as a bug
+        // hour the cycle is 15 s, up from 15 s" would read as a bug
         let mut s = Settings::default();
         s.drift = 1.00001;
         let lines = readout_lines(&s);
@@ -386,12 +387,12 @@ mod tests {
 
     #[test]
     fn no_line_names_an_effect_a_benefit_or_a_condition() {
-        // A denylist, not a style rule. `scripts/generate-citations.py`
+        // A denylist, enforced rather than suggested. `scripts/generate-citations.py`
         // keeps retracted phrasing out of the store listings; this
         // keeps outcome vocabulary out of the binary, which is the
         // constraint that rules out quoting `custom.backsClaims`
-        // verbatim however well-sourced those strings are.
-        // `docs/CITATIONS.md` may say all of this; the app may not
+        // verbatim however well-sourced those strings are. `docs/CITATIONS.md`
+        // may say all of this; the app may not
         const BANNED: &[&str] = &[
             "anxiety", "depress", "stress", "calm", "relax", "vagal", "parasympathetic",
             "blood pressure", "heart rate variability", "hrv", "mood", "sleep",

--- a/rust/crates/exhale-core/src/poison.rs
+++ b/rust/crates/exhale-core/src/poison.rs
@@ -1,18 +1,18 @@
-//! Poison-tolerant lock helpers.
+//! Poison-tolerant lock helpers
 //!
 //! `RwLock`/`Mutex` in std return `PoisonError` whenever a thread panics
 //! while holding the lock.  The conventional `.unwrap()` then propagates
-//! the panic to every subsequent reader/writer — a single panic in one
-//! thread cascade-crashes every other thread that touches the lock.
+//! the panic to every subsequent reader/writer: a single panic in one
+//! thread cascade-crashes every other thread that touches the lock
 //!
-//! For exhale we want different semantics:
+//! For exhale we want different semantics
 //!   * The controller thread, the per-overlay render threads, the
 //!     settings-manager flusher, and the main thread *all* touch
-//!     `Arc<RwLock<Settings>>`.
+//!     `Arc<RwLock<Settings>>`
 //!   * A panic inside (say) egui's settings UI tree shouldn't take down
-//!     the breathing animation.
-//!   * The poisoned value is almost always still valid — `Settings` is
-//!     plain data, no in-flight invariants to worry about.
+//!     the breathing animation
+//!   * The poisoned value is almost always still valid: `Settings` is
+//!     plain data, no in-flight invariants to worry about
 //!
 //! These helpers take the inner value either way: on `Ok` the normal
 //! guard, on `Err` the wrapped guard via `PoisonError::into_inner`.  A
@@ -21,9 +21,9 @@
 use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub trait RwLockPoisonExt<T> {
-    /// Read-acquire; on poison, log once and continue with the wrapped guard.
+    /// Read-acquire; on poison, log once and continue with the wrapped guard
     fn read_or_recover(&self) -> RwLockReadGuard<'_, T>;
-    /// Write-acquire; on poison, log once and continue with the wrapped guard.
+    /// Write-acquire; on poison, log once and continue with the wrapped guard
     fn write_or_recover(&self) -> RwLockWriteGuard<'_, T>;
 }
 
@@ -32,7 +32,7 @@ impl<T> RwLockPoisonExt<T> for RwLock<T> {
         match self.read() {
             Ok(g)  => g,
             Err(p) => {
-                log::warn!("RwLock poisoned (read) — recovering with the wrapped value");
+                log::warn!("RwLock poisoned (read): recovering with the wrapped value");
                 p.into_inner()
             }
         }
@@ -41,7 +41,7 @@ impl<T> RwLockPoisonExt<T> for RwLock<T> {
         match self.write() {
             Ok(g)  => g,
             Err(p) => {
-                log::warn!("RwLock poisoned (write) — recovering with the wrapped value");
+                log::warn!("RwLock poisoned (write): recovering with the wrapped value");
                 p.into_inner()
             }
         }
@@ -49,7 +49,7 @@ impl<T> RwLockPoisonExt<T> for RwLock<T> {
 }
 
 pub trait MutexPoisonExt<T> {
-    /// Lock; on poison, log once and continue with the wrapped guard.
+    /// Lock; on poison, log once and continue with the wrapped guard
     fn lock_or_recover(&self) -> MutexGuard<'_, T>;
 }
 
@@ -58,7 +58,7 @@ impl<T> MutexPoisonExt<T> for Mutex<T> {
         match self.lock() {
             Ok(g)  => g,
             Err(p) => {
-                log::warn!("Mutex poisoned — recovering with the wrapped value");
+                log::warn!("Mutex poisoned: recovering with the wrapped value");
                 p.into_inner()
             }
         }
@@ -79,7 +79,7 @@ mod tests {
             let _g = l2.write().unwrap();
             panic!("intentional poison");
         }).join();
-        // Now the lock is poisoned.  `.unwrap()` would panic; ours recovers.
+        // Now the lock is poisoned.  `.unwrap()` would panic; ours recovers
         let v = *lock.read_or_recover();
         assert_eq!(v, 7);
         *lock.write_or_recover() = 9;

--- a/rust/crates/exhale-core/src/presets.rs
+++ b/rust/crates/exhale-core/src/presets.rs
@@ -1,42 +1,42 @@
-//! The breathing patterns the settings window offers as one click.
+//! The breathing patterns the settings window offers as one click
 //!
 //! Five entries, hand-written, in `exhale-core` rather than in the UI
 //! crate for the same reason [`crate::pacing`] is: CI compiles and
-//! tests this crate and does not compile `exhale-app`.
+//! tests this crate and doesn't compile `exhale-app`
 //!
-//! **A preset sets the four durations and nothing else.** Not drift,
-//! not the randomisation sliders. Clicking one can therefore never
-//! discard a value the user tuned by hand, which is the property that
-//! lets selection be *derived* by comparing four numbers instead of
-//! stored in a sixth settings field that could fall out of sync with
-//! the five it summarises. Drift and jitter keep whatever the user set,
-//! and the pacing readout underneath already reports what drift does
-//! to the rate, so nothing about the resulting pace goes unsaid.
+//! **A preset sets the four durations and nothing else,** leaving drift
+//! and the randomisation sliders untouched. Clicking one can therefore
+//! never discard a value the user tuned by hand, which is the property
+//! that lets selection be *derived* by comparing four numbers instead
+//! of stored in a sixth settings field that could fall out of sync
+//! with the five it summarises. Drift and jitter keep whatever the
+//! user set, and the pacing readout underneath already reports what
+//! drift does to the rate, so nothing about the resulting pace goes
+//! unsaid
 //!
 //! **Labels name the pattern, never the rate.** A chip reading "6 a
 //! minute" would be a claim about which rate is worth choosing; a chip
 //! reading "5/0/5/0" is a description of what the four steppers below
 //! it are about to say, in their own order: inhale, post-inhale hold,
-//! exhale, post-exhale hold. It is the notation the README already
-//! uses, and it is terse enough that all five chips fit a single row
+//! exhale, post-exhale hold. It's the notation the README already
+//! uses, and it's terse enough that all five chips fit a single row
 //! of a 308 pt card, where the spelled-out form took three. The rate,
-//! and how it sits
-//! against the range anyone has tested, is computed live by
-//! [`crate::pacing::readout_lines`] for whichever pattern is active.
-//! That is why no preset carries its own evidentiary caption: the
+//! and how it sits against the range anyone has tested, is computed
+//! live by [`crate::pacing::readout_lines`] for whichever pattern is
+//! active. That's why no preset carries its own evidentiary caption: the
 //! panel already volunteers "slower than any of them" the instant box
 //! breathing is selected, for every pattern rather than only the ones
-//! someone remembered to annotate.
+//! someone remembered to annotate
 //!
-//! `citekey` is provenance, not display. It never reaches the screen.
-//! It exists so `scripts/generate-citations.py` can refuse to build
-//! when a shipped preset points at a record that has been retracted,
-//! downgraded to tier E, or marked as one the binary may not lean on.
+//! `citekey` is provenance. It never reaches the screen. It exists so
+//! `scripts/generate-citations.py` can refuse to build when a shipped
+//! preset points at a record that has been retracted, downgraded to
+//! tier E, or marked as one the binary may not lean on
 
 use crate::settings::Settings;
 
 /// One offered pattern. Four durations, a label describing them, and a
-/// corpus record that has to still hold up for the preset to ship.
+/// corpus record that has to still hold up for the preset to ship
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Preset {
     /// Stable identifier. Not shown; used by tests and by any future
@@ -46,23 +46,24 @@ pub struct Preset {
     /// What the chip says. Describes the pattern, never the rate
     pub label: &'static str,
     /// A name or a fact about identity, never about effect. `None`
-    /// when the pattern has nothing to add that the readout below does
-    /// not already say better
+    /// when the pattern has nothing to add that the readout below
+    /// doesn't already say better
     pub note: Option<&'static str>,
     pub inhale: f64,
     pub post_inhale_hold: f64,
     pub exhale: f64,
     pub post_exhale_hold: f64,
     /// Corpus entry backing this pattern's presence in the list. See
-    /// the module comment: provenance, not display
+    /// the module comment on why the build needs it and the panel
+    /// never shows it
     pub citekey: &'static str,
 }
 
 impl Preset {
-    /// True when `settings` currently holds exactly this pattern.
+    /// True when `settings` currently holds exactly this pattern
     ///
     /// The epsilon is the one `SettingsDiff::from` uses on these same
-    /// four fields. Sharing it is deliberate: "this chip looks
+    /// four fields. Sharing it's deliberate: "this chip looks
     /// selected" and "changing this field marks settings dirty" must
     /// agree, or a chip can appear selected while a save is pending
     /// that will unselect it
@@ -85,13 +86,13 @@ impl Preset {
     }
 }
 
-/// The offered set, in display order.
+/// The offered set, in display order
 ///
 /// Ordered gentlest-first by the standard the corpus actually
 /// supports, which is the tested range rather than apparent
 /// simplicity. The two patterns that fall outside it come last and are
 /// still offered: `4 / 4 / 4 / 4` because people arrive looking for it
-/// by name, and `5 s in, 10 s out` because it is what exhale has
+/// by name, and `5 s in, 10 s out` because it's what exhale has
 /// shipped for years and removing it from the list would not remove it
 /// from anybody's installed configuration. A list that quietly omitted
 /// its own default would be the least honest version of this feature
@@ -156,12 +157,12 @@ pub const PRESETS: &[Preset] = &[
     },
 ];
 
-/// Index of the preset the current settings match, if any.
+/// Index of the preset the current settings match, if any
 ///
-/// `None` is a first-class answer and renders as no chip selected.
-/// There is deliberately no "Custom" chip to fall back on: a chip that
-/// cannot be clicked to any effect is still a Tab stop, and this
-/// window already documents that hazard twice
+/// `None` is a first-class answer and renders as no chip selected. There's
+/// deliberately no "Custom" chip to fall back on: a chip that can't be
+/// clicked to any effect is still a Tab stop, and this window already
+/// documents that hazard twice
 pub fn selected(settings: &Settings) -> Option<usize> {
     PRESETS.iter().position(|p| p.matches(settings))
 }
@@ -180,12 +181,12 @@ mod tests {
         let s = Settings::default();
         let i = selected(&s).expect("default settings match no preset");
         assert_eq!(PRESETS[i].id, "even-5");
-        assert_eq!(i, 0, "the default should be the first chip, not buried mid-row");
+        assert_eq!(i, 0, "the default should be the first chip");
     }
 
     #[test]
     fn the_previous_default_is_still_offered() {
-        // 5/0/10/0 shipped as the default for years, so it is what every
+        // 5/0/10/0 shipped as the default for years, so it's what every
         // existing settings.toml holds. It has to stay nameable
         let p = PRESETS.iter().find(|p| p.id == "long-exhale-5-10").unwrap();
         let mut s = Settings::default();
@@ -198,7 +199,7 @@ mod tests {
         for p in PRESETS {
             let mut s = Settings::default();
             p.apply(&mut s);
-            assert!(p.matches(&s), "{} does not match itself after apply", p.id);
+            assert!(p.matches(&s), "{} doesn't match itself after apply", p.id);
             assert_eq!(selected(&s), Some(PRESETS.iter().position(|q| q.id == p.id).unwrap()));
         }
     }
@@ -251,11 +252,11 @@ mod tests {
 
     #[test]
     fn no_label_or_note_states_a_rate_an_effect_or_a_recommendation() {
-        // Same denylist discipline as `pacing`, for the same reason.
-        // "a minute", "bpm" and "breaths per" are here because a rate
-        // baked into a label is a claim about which rate to choose,
-        // and because it would go stale against the live readout the
-        // moment either changed
+        // Same denylist discipline as `pacing`, for the same reason. "a
+        // minute", "bpm" and "breaths per" are here because a rate baked
+        // into a label is a claim about which rate to choose, and because
+        // it would go stale against the live readout the moment either
+        // changed
         const BANNED: &[&str] = &[
             "a minute", "per minute", "bpm", "breaths per",
             "anxiety", "stress", "calm", "relax", "vagal", "parasympathetic",
@@ -290,7 +291,7 @@ mod tests {
             assert!(!p.citekey.is_empty(), "{} has no citekey", p.id);
             assert!(
                 p.citekey.contains('-') && p.citekey.chars().any(|c| c.is_ascii_digit()),
-                "{}: {:?} is not shaped like a citekey", p.id, p.citekey
+                "{}: {:?} isn't shaped like a citekey", p.id, p.citekey
             );
         }
     }
@@ -323,7 +324,7 @@ mod tests {
             if !in_band {
                 assert!(
                     lines.last().unwrap().contains("slower than any of them"),
-                    "{id}: readout does not disclose it is outside the range: {lines:#?}"
+                    "{id}: readout doesn't disclose that it's outside the range: {lines:#?}"
                 );
             }
         }

--- a/rust/crates/exhale-core/src/settings.rs
+++ b/rust/crates/exhale-core/src/settings.rs
@@ -4,21 +4,21 @@ use crate::types::{
     AnimationMode, AnimationShape, AppVisibility, ColorFillGradient, HoldRippleMode,
 };
 
-/// All user-configurable settings for the exhale app.
+/// All user-configurable settings for the exhale app
 ///
-/// Matches the Swift `SettingsModel` exactly in field names and default values.
-/// Stored as TOML in the platform config directory.
+/// Matches the Swift `SettingsModel` exactly in field names and default
+/// values. Stored as TOML in the platform config directory
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Settings {
     // ── Appearance ────────────────────────────────────────────────────────────
-    /// Linear RGBA of the inhale color. Alpha is display alpha (not premultiplied).
+    /// Linear RGBA of the inhale color. Alpha is display alpha (not premultiplied)
     pub inhale_color: [f32; 4],
-    /// Linear RGBA of the exhale color.
+    /// Linear RGBA of the exhale color
     pub exhale_color: [f32; 4],
-    /// Linear RGBA of the background tint. Alpha controls background opacity.
+    /// Linear RGBA of the background tint. Alpha controls background opacity
     pub background_color: [f32; 4],
 
-    /// Master opacity of the overlay (0.0–1.0).
+    /// Master opacity of the overlay (0.0–1.0)
     pub overlay_opacity: f32,
 
     pub shape: AnimationShape,
@@ -33,15 +33,15 @@ pub struct Settings {
     pub exhale_duration: f64,
     pub post_exhale_hold_duration: f64,
 
-    /// Per-cycle duration multiplier. 1.01 = each cycle 1 % longer (drift).
+    /// Per-cycle duration multiplier. 1.01 = each cycle 1 % longer (drift)
     ///
     /// Defaults to 1.0 (off). Pranayama's graded extension is the reason this
-    /// exists and it is a reasonable thing to turn on, but it should not be
+    /// exists and it's a reasonable thing to turn on, but it should not be
     /// imposed: heart-rate-variability amplitude peaks at 4.5-6.5 breaths a
     /// minute rather than rising without limit, and exhale's default cadence
     /// already sits below that band, so drifting slower from cycle one moves
     /// every new user further from the studied range. When it IS on, the
-    /// compounding is bounded by [`crate::controller::DRIFT_MAX_CYCLE_SECS`].
+    /// compounding is bounded by [`crate::controller::DRIFT_MAX_CYCLE_SECS`]
     pub drift: f64,
 
     // ── Randomisation (±seconds of jitter per phase) ─────────────────────────
@@ -51,14 +51,14 @@ pub struct Settings {
     pub randomized_timing_post_exhale_hold: f64,
 
     // ── Timers ────────────────────────────────────────────────────────────────
-    /// Minutes between "Remember to breathe" notifications. 0 = off.
+    /// Minutes between "Remember to breathe" notifications. 0 = off
     pub reminder_interval_minutes: f64,
-    /// Stop animation after this many minutes. 0 = off.
+    /// Stop animation after this many minutes. 0 = off
     pub auto_stop_minutes: f64,
 
     // ── State ─────────────────────────────────────────────────────────────────
     pub is_animating: bool,
-    /// Pause holds the animation on the current frame without resetting position.
+    /// Pause holds the animation on the current frame without resetting position
     pub is_paused: bool,
 
     // ── Window frame (persisted so each window reopens where you left it) ──
@@ -69,12 +69,12 @@ pub struct Settings {
     // monitor still has visible real estate rather than restoring to
     // off-screen coordinates.  Both windows use the same shape, see
     // [`WindowPlacement`] / [`Settings::settings_window_placement`] /
-    // [`Settings::animation_window_placement`].
+    // [`Settings::animation_window_placement`]
     //
     // The settings window has a fixed width; only its height is
     // persisted (`settings_window_width` doesn't exist).  The animation
     // window persists both dimensions because the user can resize it
-    // freely.
+    // freely
     #[serde(default)]
     pub settings_window_x: Option<i32>,
     #[serde(default)]
@@ -127,9 +127,9 @@ pub const KBD_MOD_META:  u8 = 1 << 3;
 /// bumps that might re-number the underlying enum
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KeyboardShortcut {
-    /// Bitmask of `KBD_MOD_*`.
+    /// Bitmask of `KBD_MOD_*`
     pub modifiers: u8,
-    /// `keyboard_types::Code` variant name.
+    /// `keyboard_types::Code` variant name
     pub code:      String,
 }
 
@@ -147,12 +147,11 @@ impl KeyboardShortcut {
     pub fn has_alt(&self)   -> bool { self.modifiers & KBD_MOD_ALT   != 0 }
     pub fn has_meta(&self)  -> bool { self.modifiers & KBD_MOD_META  != 0 }
 
-    /// Human-readable rendering for tooltips and capture prompts.
-    /// macOS users see the standard glyph triad (`⌃⇧⌥⌘`); other
-    /// platforms get textual `Ctrl+Shift+...` so the string remains
-    /// legible in any font.  The trailing key strips the `Key` /
-    /// `Digit` prefixes that come from `keyboard_types::Code`'s
-    /// variant names
+    /// Human-readable rendering for tooltips and capture prompts. macOS
+    /// users see the standard glyph triad (`⌃⇧⌥⌘`); other platforms get
+    /// textual `Ctrl+Shift+...` so the string remains legible in any
+    /// font.  The trailing key strips the `Key` / `Digit` prefixes that
+    /// come from `keyboard_types::Code`'s variant names
     pub fn display(&self) -> String {
         #[cfg(target_os = "macos")]
         let (ctrl, shift, alt, meta) = ("\u{2303}", "\u{21E7}", "\u{2325}", "\u{2318}");
@@ -201,13 +200,13 @@ fn human_key(code: &str) -> String {
 }
 
 /// Per-action global-hotkey defaults.  Only Preferences ships with
-/// a binding (Ctrl+Shift+, — the conventional "open preferences"
-/// combo across desktop platforms).  Every other action defaults
-/// to `None` so we ship without any global hotkey that could
-/// silently conflict with the user's other apps; users opt into
-/// bindings via right-click → Change Shortcut on the matching
-/// settings-window button.  Avoids the long support tail of
-/// "Ctrl+Shift+A doesn't work on my mac" reports — anything we
+/// a binding (Ctrl+Shift+, which is the conventional "open
+/// preferences" combo across desktop platforms).  Every other
+/// action defaults to `None` so we ship without any global hotkey
+/// that could silently conflict with the user's other apps; users
+/// opt into bindings via right-click -> Change Shortcut on the
+/// matching settings-window button.  Avoids the long support tail
+/// of "Ctrl+Shift+A doesn't work on my mac" reports: anything we
 /// pre-register is anything we'd have to justify
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KeyboardShortcuts {
@@ -306,7 +305,7 @@ impl KeyboardShortcuts {
 /// shared shape between [`Settings::settings_window_placement`] /
 /// [`Settings::animation_window_placement`] so the apply-on-create
 /// and capture-on-move logic in `exhale-app::placement` is a single
-/// helper used by both windows.  Not directly serialized — the flat
+/// helper used by both windows.  Not directly serialized: the flat
 /// `*_window_*` fields above are the on-disk format, kept flat for
 /// backward compatibility with existing settings.toml files
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -332,22 +331,22 @@ impl Default for Settings {
             animation_mode:      AnimationMode::Sinusoidal,
             hold_ripple_mode:    HoldRippleMode::Gradient,
             // Show both the menu-bar / tray icon AND the Dock / taskbar
-            // entry by default — users new to the app are more likely to
+            // entry by default; users new to the app are more likely to
             // notice it in the Dock, and discovering the tray-only mode
-            // via Preferences once is easy.
+            // via Preferences once is easy
             app_visibility:      AppVisibility::Both,
 
-            // 5 / 0 / 5 / 0, six breaths a minute, no holds.
+            // 5 / 0 / 5 / 0, six breaths a minute, no holds
             //
             // Inside the 5-to-7 band `you2023-respiratory-frequency` tested
             // directly, and the condition that won the four-way head-to-head in
             // `marchant2025-square-478-six`. The previous default was 5 / 0 / 10 / 0,
-            // four a minute, which nobody has measured; it is still one click away
-            // as a preset.
+            // four a minute, which nobody has measured; it's still one click away
+            // as a preset
             //
             // These fields carry no `#[serde(default)]`, so a settings.toml that
             // predates this change keeps every value it already has. The move
-            // reaches fresh installs and Reset to Defaults, and nobody else.
+            // reaches fresh installs and Reset to Defaults, and nobody else
             inhale_duration:           5.0,
             post_inhale_hold_duration: 0.0,
             exhale_duration:           5.0,
@@ -395,7 +394,7 @@ impl Settings {
     }
 
     /// Write the persisted placement of the settings window.  Width
-    /// is ignored because the settings window is fixed-width.
+    /// is ignored because the settings window is fixed-width
     pub fn set_settings_window_placement(&mut self, p: WindowPlacement) {
         self.settings_window_x      = p.x;
         self.settings_window_y      = p.y;
@@ -418,7 +417,7 @@ impl Settings {
         }
     }
 
-    /// Write the persisted placement of the animation window.
+    /// Write the persisted placement of the animation window
     pub fn set_animation_window_placement(&mut self, p: WindowPlacement) {
         self.animation_window_x      = p.x;
         self.animation_window_y      = p.y;
@@ -430,11 +429,11 @@ impl Settings {
 
 /// Categorised diff between two `Settings` snapshots.  Adding a new
 /// setting is a one-line edit to the relevant `*_changed` computation
-/// here rather than coordinated edits across `main.rs`.
+/// here rather than coordinated edits across `main.rs`
 ///
 /// All `*_changed` fields are inclusive: they're `true` whenever ANY
 /// field in their category differs.  Categories match the downstream
-/// actions:
+/// actions
 ///
 ///   - `animating_changed`: drives tray-state refresh + auto-stop reschedule
 ///   - `paused_changed`: drives overlay redraw
@@ -459,7 +458,7 @@ pub struct SettingsDiff {
 impl SettingsDiff {
     /// Compute the diff between `before` (snapshot taken pre-render)
     /// and `after` (settings as mutated by the egui frame).  All
-    /// float comparisons use an epsilon — 1e-9 for timing values
+    /// float comparisons use an epsilon: 1e-9 for timing values
     /// (seconds) and 1e-4 for the `[0,1]` overlay opacity, both well
     /// below user-perceptible differences
     pub fn from(before: &Settings, after: &Settings) -> Self {
@@ -497,14 +496,14 @@ impl SettingsDiff {
         }
     }
 
-    /// Any setting that should trigger an overlay redraw.
+    /// Any setting that should trigger an overlay redraw
     pub fn should_redraw_overlay(&self) -> bool {
         self.paused_changed || self.animating_changed || self.visual_changed || self.timing_changed
     }
 
     /// Any setting that, per Swift's `triggerAnimationReset()`,
     /// should restart the animation from inhale phase 0 (only when
-    /// the animation is actively running and not paused).
+    /// the animation is actively running and not paused)
     pub fn should_restart_animation(&self, current: &Settings) -> bool {
         self.animating_started
             || ((self.visual_changed || self.timing_changed)
@@ -538,19 +537,19 @@ impl Settings {
     //
     // These exist so the settings window can state what the current
     // configuration actually does without storing a number that can go
-    // stale. Nothing here is a claim about the literature; it is
+    // stale. Nothing here is a claim about the literature; it's
     // division. That distinction is the reason the app can say it at
-    // all: an arithmetic statement cannot be retracted, so it carries
+    // all: an arithmetic statement can't be retracted, so it carries
     // none of the review risk that a health claim in a store-reviewed
-    // binary would.
+    // binary would
     //
     // Deliberately computed from live `Settings` rather than attached
     // to a preset. A rate cached alongside a preset is wrong the
     // moment the user nudges one stepper, and wrong from the first
-    // cycle whenever `drift` is on.
+    // cycle whenever `drift` is on
 
     /// Seconds in one full breath cycle at the current settings,
-    /// before any drift is applied.
+    /// before any drift is applied
     ///
     /// Ignores the randomisation sliders: they perturb individual
     /// phases around these values without changing the mean, so the
@@ -562,9 +561,9 @@ impl Settings {
             + self.post_exhale_hold_duration
     }
 
-    /// Breaths per minute at the start of a session.
+    /// Breaths per minute at the start of a session
     ///
-    /// `None` when all four phases are zero, which is not a rate of
+    /// `None` when all four phases are zero, which isn't a rate of
     /// anything. Callers render nothing rather than an infinity
     pub fn breaths_per_min(&self) -> Option<f64> {
         let cycle = self.cycle_secs();
@@ -572,7 +571,7 @@ impl Settings {
     }
 
     /// Breaths per minute after `minutes` of continuous running, with
-    /// `drift` compounding.
+    /// `drift` compounding
     ///
     /// The closed form is exact at cycle boundaries and worth the
     /// comment, because the obvious implementation is a loop. Cycle
@@ -580,7 +579,7 @@ impl Settings {
     /// geometric sum `S = c·(dᵏ − 1)/(d − 1)`. Substituting the
     /// current cycle length `D = c·dᵏ` gives `S = (D − c)/(d − 1)`,
     /// and solving for `D` at `S = 60·minutes` collapses the whole
-    /// thing to a line with no `powi` and no logarithm:
+    /// thing to a line with no `powi` and no logarithm
     ///
     /// ```text
     /// D = c + 60 · minutes · (d − 1)
@@ -588,12 +587,12 @@ impl Settings {
     ///
     /// The compounding is real; its *effect on elapsed wall time* is
     /// simply linear. `d == 1` falls out as `D == c` with no special
-    /// case.
+    /// case
     ///
     /// `None` when the cycle is zero-length, and also when a drift
     /// below 1.0 has shortened the projected cycle to nothing. Drift
-    /// cannot be set below 1.0 through the UI, but a hand-edited
-    /// settings file can, and a negative rate is not a thing to show
+    /// can't be set below 1.0 through the UI, but a hand-edited
+    /// settings file can, and a negative rate isn't a thing to show
     /// a user
     pub fn breaths_per_min_after(&self, minutes: f64) -> Option<f64> {
         let cycle = self.cycle_secs();
@@ -604,7 +603,7 @@ impl Settings {
         (projected > 0.0).then(|| 60.0 / projected)
     }
 
-    /// True when `drift` is doing anything at all.
+    /// True when `drift` is doing anything at all
     ///
     /// Uses the same `1e-9` epsilon `SettingsDiff::from` uses on this
     /// field, so "the UI shows a drift line" and "a drift change marks
@@ -622,23 +621,23 @@ impl Settings {
             .all(|(a, b)| (a - b).abs() < 0.001)
     }
 
-    /// Background colour stripped of its own alpha — used as the shape background.
+    /// Background colour stripped of its own alpha, used as the shape background
     pub fn background_color_rgb(&self) -> [f32; 4] {
         let [r, g, b, _a] = self.background_color;
         [r, g, b, 1.0]
     }
 
-    /// The alpha component of background_color, clamped to overlay_opacity.
+    /// The alpha component of background_color, clamped to overlay_opacity
     pub fn background_opacity(&self) -> f32 {
         self.background_color[3].min(self.overlay_opacity)
     }
 
-    /// Rectangle scale factor: 2× when gradient is `On` (extends the fill above 100 %).
+    /// Rectangle scale factor: 2× when gradient is `On` (extends the fill above 100 %)
     pub fn rectangle_scale(&self) -> f32 {
         if self.color_fill_gradient == ColorFillGradient::On { 2.0 } else { 1.0 }
     }
 
-    /// Circle gradient scale: same factor as rectangle.
+    /// Circle gradient scale: same factor as rectangle
     pub fn circle_gradient_scale(&self) -> f32 {
         if self.color_fill_gradient == ColorFillGradient::On { 2.0 } else { 1.0 }
     }
@@ -847,7 +846,7 @@ mod tests {
         let d = SettingsDiff::from(&before, &after);
         assert!(d.animating_started);
         assert!(d.animating_changed);
-        // Stopping should not register as `started`.
+        // Stopping should not register as `started`
         let d_rev = SettingsDiff::from(&after, &before);
         assert!(!d_rev.animating_started);
         assert!(d_rev.animating_changed);
@@ -906,13 +905,13 @@ mod tests {
         let d = SettingsDiff::from(&before, &after);
         assert!(d.should_restart_animation(&after));
 
-        // Paused: no restart even though visual changed.
+        // Paused: no restart even though visual changed
         let mut after_paused = after.clone();
         after_paused.is_paused = true;
         let d2 = SettingsDiff::from(&before, &after_paused);
         assert!(!d2.should_restart_animation(&after_paused));
 
-        // Not animating: no restart.
+        // Not animating: no restart
         let mut after_stopped = after.clone();
         after_stopped.is_animating = false;
         let d3 = SettingsDiff::from(&before, &after_stopped);
@@ -925,7 +924,7 @@ mod tests {
         before.is_animating = false;
         let mut after = before.clone();
         after.is_animating = true;
-        // Even with no visual or timing change, `started` triggers a restart.
+        // Even with no visual or timing change, `started` triggers a restart
         let d = SettingsDiff::from(&before, &after);
         assert!(d.should_restart_animation(&after));
     }

--- a/rust/crates/exhale-core/src/settings_manager.rs
+++ b/rust/crates/exhale-core/src/settings_manager.rs
@@ -11,15 +11,15 @@ use log::{info, warn};
 use crate::poison::RwLockPoisonExt;
 use crate::settings::Settings;
 
-/// Manages loading, saving, and sharing of [`Settings`].
+/// Manages loading, saving, and sharing of [`Settings`]
 ///
-/// Settings are stored as TOML in the platform config directory:
+/// Settings are stored as TOML in the platform config directory
 /// - macOS:   `~/Library/Application Support/exhale/settings.toml`
 /// - Windows: `%APPDATA%\exhale\settings.toml`
 /// - Linux:   `~/.config/exhale/settings.toml`
 ///
 /// Writes are coalesced: a background thread waits 500 ms of silence before
-/// flushing to disk, matching UserDefaults coalescing behaviour.
+/// flushing to disk, matching UserDefaults coalescing behaviour
 pub struct SettingsManager {
     pub settings: Arc<RwLock<Settings>>,
     config_path:  PathBuf,
@@ -29,7 +29,7 @@ pub struct SettingsManager {
 
 impl SettingsManager {
     /// Load settings from disk (or use defaults if no file exists) and start
-    /// the coalescing write-back thread.
+    /// the coalescing write-back thread
     pub fn new() -> Result<Self> {
         let config_path = config_file_path()?;
         let settings = load_or_default(&config_path);
@@ -56,23 +56,23 @@ impl SettingsManager {
         })
     }
 
-    /// Mark settings as dirty; will be flushed within ~500 ms.
+    /// Mark settings as dirty; will be flushed within ~500 ms
     pub fn mark_dirty(&self) {
         let _ = self.dirty_tx.send(());
     }
 
-    /// Path where the settings file is stored.
+    /// Path where the settings file is stored
     pub fn config_path(&self) -> &PathBuf {
         &self.config_path
     }
 
-    /// Synchronously flush settings to disk right now.
-    /// Useful on shutdown to avoid losing the last write.
+    /// Synchronously flush settings to disk right now. Useful on
+    /// shutdown to avoid losing the last write
     pub fn flush_sync(&self) -> Result<()> {
         let s = self.settings.read_or_recover().clone();
         // Cloning before persisting means the lock is released for the
         // duration of the (potentially slow) disk write; readers and
-        // writers from other threads aren't blocked on I/O.
+        // writers from other threads aren't blocked on I/O
         save_settings(&s, &self.config_path)
     }
 }
@@ -81,7 +81,7 @@ impl SettingsManager {
 
 fn config_file_path() -> Result<PathBuf> {
     let dirs = ProjectDirs::from("com", "peterklingelhofer", "exhale")
-        .context("could not determine config directory")?;
+        .context("couldn't determine config directory")?;
     let dir = dirs.config_dir();
     std::fs::create_dir_all(dir)
         .with_context(|| format!("create config dir {}", dir.display()))?;
@@ -102,9 +102,10 @@ fn load_or_default(path: &PathBuf) -> Settings {
             Settings::default()
         }
     };
-    // Always start animating on launch; never restore a stopped or paused state.
-    // Matches Swift SettingsModel.init() which hardcodes isAnimating = true
-    // and never loads isAnimating/isPaused back from UserDefaults.
+    // Always start animating on launch; never restore a stopped or
+    // paused state. Matches Swift SettingsModel.init() which hardcodes
+    // isAnimating = true and never loads isAnimating/isPaused back
+    // from UserDefaults
     s.is_animating = true;
     s.is_paused    = false;
     s
@@ -113,12 +114,12 @@ fn load_or_default(path: &PathBuf) -> Settings {
 fn save_settings(settings: &Settings, path: &PathBuf) -> Result<()> {
     let contents = toml::to_string_pretty(settings)
         .context("serialise settings")?;
-    // Write to a temp file then rename — atomic on POSIX, best-effort on Windows.
+    // Write to a temp file then rename: atomic on POSIX, best-effort on Windows
     let tmp = path.with_extension("toml.tmp");
     std::fs::write(&tmp, &contents)
         .with_context(|| format!("write {}", tmp.display()))?;
     std::fs::rename(&tmp, path)
-        .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
     Ok(())
 }
 
@@ -128,12 +129,12 @@ fn write_back_loop(
     rx:       std::sync::mpsc::Receiver<()>,
 ) {
     // Drain the channel with a 500 ms timeout; flush once there are no more
-    // events for that window (coalescing).
+    // events for that window (coalescing)
     loop {
         match rx.recv() {
-            Err(_) => break, // sender dropped → manager is gone
+            Err(_) => break, // sender dropped -> manager is gone
             Ok(()) => {
-                // Drain further events within the coalesce window.
+                // Drain further events within the coalesce window
                 let deadline = std::time::Instant::now() + Duration::from_millis(500);
                 loop {
                     let remaining = deadline.saturating_duration_since(std::time::Instant::now());

--- a/rust/crates/exhale-core/src/types.rs
+++ b/rust/crates/exhale-core/src/types.rs
@@ -1,56 +1,56 @@
 use serde::{Deserialize, Serialize};
 
-/// Breathing animation shape shown on the overlay.
+/// Breathing animation shape shown on the overlay
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnimationShape {
-    /// Solid fill covering the entire screen.
+    /// Solid fill covering the entire screen
     Fullscreen,
-    /// Rectangle that scales up from the bottom of the screen.
+    /// Rectangle that scales up from the bottom of the screen
     Rectangle,
-    /// Circle that scales from the center outward.
+    /// Circle that scales from the center outward
     Circle,
 }
 
-/// Color fill / gradient style applied to the animated shape.
+/// Color fill / gradient style applied to the animated shape
 ///
 /// Shader encoding: Off=0, Inner=1, On=2
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ColorFillGradient {
-    /// Solid color, no gradient.
+    /// Solid color, no gradient
     Off,
-    /// Gradient from background at the base to shape color at the top/edge.
+    /// Gradient from background at the base to shape color at the top/edge
     Inner,
-    /// Gradient that peaks at the midpoint and fades back to background (full cycle).
+    /// Gradient that peaks at the midpoint and fades back to background (full cycle)
     On,
 }
 
-/// Style of the perimeter glow shown during hold phases.
+/// Style of the perimeter glow shown during hold phases
 ///
 /// Shader encoding: Off=0, Stark=1, Gradient=2
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HoldRippleMode {
-    /// No ripple effect during holds.
+    /// No ripple effect during holds
     Off,
-    /// Hard-edged band sweeping the screen perimeter.
+    /// Hard-edged band sweeping the screen perimeter
     Stark,
-    /// Soft Gaussian glow sweeping the screen perimeter.
+    /// Soft Gaussian glow sweeping the screen perimeter
     Gradient,
 }
 
-/// Easing curve applied to each inhale/exhale transition.
+/// Easing curve applied to each inhale/exhale transition
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnimationMode {
-    /// No easing — progress advances at a constant rate.
+    /// No easing: progress advances at a constant rate
     Linear,
-    /// CSS cubic-bezier(0.42, 0, 0.58, 1) — ease-in-out.
+    /// CSS cubic-bezier(0.42, 0, 0.58, 1): ease-in-out
     Sinusoidal,
 }
 
-/// Controls how the app appears in the macOS UI chrome.
+/// Controls how the app appears in the macOS UI chrome
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AppVisibility {
@@ -60,7 +60,7 @@ pub enum AppVisibility {
 }
 
 
-/// The four phases of a single breath cycle.
+/// The four phases of a single breath cycle
 ///
 /// Shader phase encoding: Inhale=0, HoldAfterInhale=1, Exhale=2, HoldAfterExhale=3
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -72,7 +72,7 @@ pub enum BreathingPhase {
 }
 
 impl BreathingPhase {
-    /// Integer encoding sent to the fragment shader.
+    /// Integer encoding sent to the fragment shader
     pub fn shader_value(self) -> u32 {
         match self {
             Self::Inhale         => 0,
@@ -82,7 +82,7 @@ impl BreathingPhase {
         }
     }
 
-    /// Returns true for the two hold phases.
+    /// Returns true for the two hold phases
     pub fn is_hold(self) -> bool {
         matches!(self, Self::HoldAfterInhale | Self::HoldAfterExhale)
     }
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn serde_round_trip() {
-        // TOML requires a table at the top level, so wrap in a struct.
+        // TOML requires a table at the top level, so wrap in a struct
         #[derive(serde::Serialize, serde::Deserialize)]
         struct W { shape: AnimationShape, ripple: HoldRippleMode }
         let w = W { shape: AnimationShape::Circle, ripple: HoldRippleMode::Gradient };

--- a/rust/crates/exhale-render/examples/cpu_bench.rs
+++ b/rust/crates/exhale-render/examples/cpu_bench.rs
@@ -1,21 +1,20 @@
-//! Headless CPU benchmark — mirrors the Swift `measureCPU` suite.
+//! Headless CPU benchmark, mirrors the Swift `measureCPU` suite
 //!
 //! Runs the real `BreathingController` driving a `HeadlessRenderer` that
-//! draws into an offscreen 1920×1080 Bgra8Unorm texture.  This is not a
-//! like-for-like replacement for the live-process sampler — there is no
-//! window, no compositor, no swapchain present — but it isolates the
-//! controller + render cost of the Rust port and gives a stable number
-//! that is directly comparable between local runs.
+//! draws into an offscreen 1920×1080 Bgra8Unorm texture, distinct from
+//! the live-process sampler: no window, no compositor, no swapchain
+//! present. It isolates the controller + render cost of the Rust port
+//! and gives a stable number that's directly comparable between local runs
 //!
-//! Methodology (matches `exhale/swift/exhaleTests.swift::measureCPU`):
-//!   1. Warm up 0.5 s.
+//! Methodology (matches `exhale/swift/exhaleTests.swift::measureCPU`)
+//!   1. Warm up 0.5 s
 //!   2. Baseline phase: `is_animating = false`, 5 × 1 s samples via
-//!      `getrusage(RUSAGE_SELF)`, averaged.
-//!   3. Animation phase: `is_animating = true`, another 5 × 1 s samples.
-//!   4. Delta = max(0, animation − baselineAvg) for each sample.
-//!   5. Print per-variant peak + avg delta.
+//!      `getrusage(RUSAGE_SELF)`, averaged
+//!   3. Animation phase: `is_animating = true`, another 5 × 1 s samples
+//!   4. Delta = max(0, animation − baselineAvg) for each sample
+//!   5. Print per-variant peak + avg delta
 //!
-//! Usage:
+//! Usage
 //!   cargo run --release --example cpu_bench -p exhale-render
 //!   cargo run --release --example cpu_bench -p exhale-render -- only=circle_ripple
 
@@ -44,7 +43,7 @@ fn get_cpu_seconds() -> f64 {
     u + s
 }
 
-/// Sleep for `dur` and return CPU% used by *this whole process* during the sleep.
+/// Sleep for `dur` and return CPU% used by *this whole process* during the sleep
 fn sample_cpu(dur: Duration) -> f64 {
     let cpu_before  = get_cpu_seconds();
     let wall_before = Instant::now();
@@ -76,10 +75,10 @@ fn variants() -> Vec<Variant> {
 
 #[allow(clippy::field_reassign_with_default)]
 fn run_variant(v: &Variant) {
-    // Build settings with animation ON — matches the real-app default.
-    // Baseline phase intentionally does NOT spawn the controller, so the
+    // Build settings with animation ON, matches the real-app default. Baseline
+    // phase intentionally does NOT spawn the controller, so the
     // baseline measures pure process idle (no controller thread, no GPU
-    // work).  Delta = animation + render cost above that floor.
+    // work).  Delta = animation + render cost above that floor
     let mut s = Settings::default();
     s.shape                = v.shape;
     s.color_fill_gradient  = v.gradient;
@@ -111,7 +110,7 @@ fn run_variant(v: &Variant) {
     let baseline_avg = baseline.iter().sum::<f64>() / baseline.len() as f64;
 
     // ── Phase 2: start controller + measure animation ────────────────────────
-    // Weak-ref slot breaks the controller-callback reference cycle.
+    // Weak-ref slot breaks the controller-callback reference cycle
     let ctrl_slot: Arc<RwLock<Option<std::sync::Weak<BreathingController>>>> =
         Arc::new(RwLock::new(None));
 
@@ -153,9 +152,9 @@ fn run_variant(v: &Variant) {
     let anim_elap  = anim_start.elapsed().as_secs_f64();
     let fps_effect = frame_end as f64 / anim_elap;
 
-    // Drop the last strong Arc → controller's Drop runs stop() + joins thread.
-    // Clear the slot so the Weak inside the callback is released as the thread
-    // shuts down.
+    // Drop the last strong Arc -> controller's Drop runs stop() + joins
+    // thread. Clear the slot so the Weak inside the callback is released
+    // as the thread shuts down
     *ctrl_slot.write().unwrap() = None;
     drop(ctrl);
 
@@ -184,7 +183,7 @@ fn main() {
         .find_map(|a| a.strip_prefix("only=").map(|s| s.to_string()));
 
     println!(
-        "exhale-render headless CPU bench — {w}×{h}, {n}×{s:.1}s samples, warmup {wu:.1}s",
+        "exhale-render headless CPU bench: {w}×{h}, {n}×{s:.1}s samples, warmup {wu:.1}s",
         w = WIDTH, h = HEIGHT, n = SAMPLE_COUNT, s = SAMPLE_SECONDS, wu = WARMUP_SECONDS,
     );
     println!("{}\n", "─".repeat(72));
@@ -197,7 +196,7 @@ fn main() {
     }
 
     println!(
-        "Done.  Baseline measures idle process overhead (controller parked, no \
-         render).  Delta approximates animation + render cost."
+        "Baseline measures idle process overhead (controller parked, no render); \
+         delta approximates animation + render cost."
     );
 }

--- a/rust/crates/exhale-render/src/gpu_context.rs
+++ b/rust/crates/exhale-render/src/gpu_context.rs
@@ -3,41 +3,41 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use log::info;
 
-/// Shared wgpu instance + adapter + a default device/queue.
+/// Shared wgpu instance + adapter + a default device/queue
 ///
-/// The instance + adapter are shared across the whole app — they're stateless
+/// The instance + adapter are shared across the whole app, they're stateless
 /// "this is the GPU you're using" handles.  The default device + queue stay
 /// for headless / benchmarking code that doesn't need its own isolated
-/// command queue.
+/// command queue
 ///
 /// **Per-window renderers should call [`GpuContext::new_render_device`] to
 /// mint their own (`Device`, `Queue`) pair** instead of using the default
 /// one.  Each `wgpu::Device` maps to a separate `ID3D12CommandQueue` (or
 /// Metal/Vulkan queue) under the hood; modern GPUs schedule those
-/// concurrently, but commands submitted to the *same* queue serialize.
-/// Sharing the default device across the overlay and settings windows
-/// meant every hover-driven settings repaint blocked the overlay's next
-/// present on the shared queue — visible as breath-animation stutter on
-/// Windows.  Per-window devices remove that contention entirely.
+/// concurrently, but commands submitted to the *same* queue serialize. Sharing
+/// the default device across the overlay and settings windows meant every
+/// hover-driven settings repaint blocked the overlay's next present on the
+/// shared queue, visible as breath-animation stutter on Windows.  Per-window
+/// devices remove that contention entirely
 pub struct GpuContext {
-    /// Used to create additional surfaces for new windows.
+    /// Used to create additional surfaces for new windows
     pub instance: wgpu::Instance,
     /// The physical adapter every device is requested from.  Exposed so
     /// per-window renderers can mint their own devices via
     /// `new_render_device()`, and so each window can query surface
-    /// capabilities for its own surface.
+    /// capabilities for its own surface
     pub adapter:  Arc<wgpu::Adapter>,
-    /// Default device — convenient for headless / one-off rendering.
-    /// Per-window renderers should NOT use this directly; call
-    /// `new_render_device()` instead so each window gets its own queue.
+    /// Default device, convenient for headless / one-off rendering. Per-window
+    /// renderers should NOT use this directly; call `new_render_device()`
+    /// instead so each window gets its own queue
     pub device:   Arc<wgpu::Device>,
-    /// Default queue (see `device`).
+    /// Default queue (see `device`)
     pub queue:    Arc<wgpu::Queue>,
 }
 
 impl GpuContext {
-    /// Initialise a shared GPU context compatible with the given surface.
-    /// Call once on startup; clone the returned `Arc` for each renderer.
+    /// Initialise a shared GPU context compatible with the given surface. Call
+    /// once on startup; clone the returned `Arc` for each renderer
     pub fn new_for_surface(
         instance: wgpu::Instance,
         surface:  &wgpu::Surface<'_>,
@@ -46,16 +46,16 @@ impl GpuContext {
     }
 
     /// Initialise a shared GPU context with no surface (for headless rendering,
-    /// e.g. CPU benchmarks that render to an offscreen texture).
+    /// e.g. CPU benchmarks that render to an offscreen texture)
     pub fn new_headless() -> Result<Arc<Self>> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
         pollster::block_on(Self::new_async(instance, None))
     }
 
-    /// Mint a fresh (`Device`, `Queue`) pair from the shared adapter.
-    /// Each window's renderer calls this once at construction and keeps
+    /// Mint a fresh (`Device`, `Queue`) pair from the shared adapter. Each
+    /// window's renderer calls this once at construction and keeps
     /// the pair for all its GPU work, so its command submissions don't
-    /// serialize behind other windows' on a single shared queue.
+    /// serialize behind other windows' on a single shared queue
     pub fn new_render_device(&self) -> Result<(Arc<wgpu::Device>, Arc<wgpu::Queue>)> {
         pollster::block_on(async {
             let (device, queue) = self.adapter
@@ -96,7 +96,7 @@ impl GpuContext {
         // `downlevel_defaults` caps `max_texture_dimension_2d` at 2048, which
         // rejects surface configuration on any ≥4K display.  Request the
         // adapter's actual limits so the overlay can span real hardware
-        // resolutions on modern GPUs (Metal/DX12/Vulkan all report ≥8192).
+        // resolutions on modern GPUs (Metal/DX12/Vulkan all report ≥8192)
         let (device, queue) = adapter
             .request_device(
                 &wgpu::DeviceDescriptor {

--- a/rust/crates/exhale-render/src/headless.rs
+++ b/rust/crates/exhale-render/src/headless.rs
@@ -6,14 +6,14 @@ use exhale_core::{controller::BreathingState, settings::Settings};
 
 use crate::{gpu_context::GpuContext, renderer::build_pipeline, uniforms::OverlayUniforms};
 
-/// wgpu renderer that draws into an offscreen texture (no `wgpu::Surface`).
+/// wgpu renderer that draws into an offscreen texture (no `wgpu::Surface`)
 ///
 /// Used by the CPU benchmark to measure render cost without the presentation
 /// path (swapchain acquire + present + compositor work).  The pipeline mirrors
-/// [`crate::OverlayRenderer`] exactly so the work-per-frame is comparable.
+/// [`crate::OverlayRenderer`] exactly so the work-per-frame is comparable
 pub struct HeadlessRenderer {
     gpu:            Arc<GpuContext>,
-    /// Owned to keep the render target alive — `view` borrows it internally.
+    /// Owned to keep the render target alive: `view` borrows it internally
     #[allow(dead_code)]
     texture:        wgpu::Texture,
     view:           wgpu::TextureView,
@@ -27,7 +27,7 @@ pub struct HeadlessRenderer {
 
 impl HeadlessRenderer {
     pub fn new(gpu: Arc<GpuContext>, width: u32, height: u32) -> Result<Self> {
-        // Match the format used by the real overlay on macOS/Windows.
+        // Match the format used by the real overlay on macOS/Windows
         let format = wgpu::TextureFormat::Bgra8Unorm;
 
         let texture = gpu.device.create_texture(&wgpu::TextureDescriptor {
@@ -80,7 +80,7 @@ impl HeadlessRenderer {
             pass.draw(0..3, 0..1);
         }
         self.gpu.queue.submit(std::iter::once(enc.finish()));
-        // No present — the texture is the render target.
+        // No present: the texture is the render target
         Ok(())
     }
 

--- a/rust/crates/exhale-render/src/renderer.rs
+++ b/rust/crates/exhale-render/src/renderer.rs
@@ -12,17 +12,17 @@ const SHADER_SRC: &str = include_str!("shaders/overlay.wgsl");
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
-/// wgpu renderer for a single breathing overlay window.
+/// wgpu renderer for a single breathing overlay window
 ///
 /// Each screen gets its own `OverlayRenderer` with its own **isolated
 /// `wgpu::Device` + `wgpu::Queue`** minted from the shared
-/// [`GpuContext`]'s adapter — so the overlay's command submissions
-/// don't serialize behind the settings window's on a shared queue.
-/// See `GpuContext::new_render_device` for the rationale.
+/// [`GpuContext`]'s adapter, so the overlay's command submissions
+/// don't serialize behind the settings window's on a shared queue. See
+/// `GpuContext::new_render_device` for the rationale
 pub struct OverlayRenderer {
-    /// Per-window device — owns its own `ID3D12CommandQueue` /
+    /// Per-window device, owns its own `ID3D12CommandQueue` /
     /// Metal queue / Vulkan queue.  Independent of any other
-    /// window's renderer.
+    /// window's renderer
     device:         Arc<wgpu::Device>,
     queue:          Arc<wgpu::Queue>,
     surface:        wgpu::Surface<'static>,
@@ -36,7 +36,7 @@ impl OverlayRenderer {
     /// Create a renderer for an existing surface.  Takes the shared
     /// `GpuContext` to access the adapter + instance, then mints its
     /// own (`Device`, `Queue`) pair so it doesn't share a command
-    /// queue with other windows' renderers.
+    /// queue with other windows' renderers
     pub fn new(
         gpu:    Arc<GpuContext>,
         surface: wgpu::Surface<'static>,
@@ -45,13 +45,13 @@ impl OverlayRenderer {
     ) -> Result<Self> {
         // Mint a fresh device + queue for this window.  Independent of
         // the settings window's device, so settings repaints don't
-        // block this overlay's presents on a shared queue.
+        // block this overlay's presents on a shared queue
         let (device, queue) = gpu.new_render_device()
             .context("overlay per-window device")?;
 
         // Re-use the shared adapter to query surface caps.  Adapters
-        // are stateless — caps depend on the (adapter, surface) pair,
-        // not the device, so this is correct.
+        // are stateless, caps depend on the (adapter, surface) pair,
+        // not the device, so this is correct
         let surface_caps   = surface.get_capabilities(&gpu.adapter);
 
         let surface_format = prefer_format(&surface_caps);
@@ -60,11 +60,11 @@ impl OverlayRenderer {
         // Diagnostic: log every alpha mode the surface advertises and
         // the one we picked.  On Windows (especially under WARP / VMs
         // without GPU passthrough) the surface can be limited to
-        // `Opaque` only — in which case alpha is ignored regardless of
+        // `Opaque` only, in which case alpha is ignored regardless of
         // window flags or shader output, and the overlay renders as
         // solid black.  Surfacing this in the log lets us tell apart
         // "code wrong" from "platform doesn't support per-pixel alpha
-        // here" without a debugger.
+        // here" without a debugger
         log::info!(
             "overlay surface alpha_modes={:?}, picked={:?}",
             surface_caps.alpha_modes, alpha_mode,
@@ -106,7 +106,7 @@ impl OverlayRenderer {
             Ok(t)  => t,
             Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
                 self.surface.configure(&self.device, &self.config);
-                warn!("overlay surface lost — reconfigured");
+                warn!("overlay surface lost; reconfigured");
                 return Ok(());
             }
             Err(e) => return Err(e).context("overlay get_current_texture"),
@@ -152,11 +152,11 @@ impl OverlayRenderer {
 
     /// `true` when the swap chain advertises a per-pixel-alpha mode
     /// (`PreMultiplied`, `PostMultiplied`, or `Inherit`).  `false` when
-    /// it could only do `Opaque` — typical for VM environments running
+    /// it could only do `Opaque`, typical for VM environments running
     /// the Microsoft Basic Render Driver (WARP), where the emulated
     /// DXGI surface doesn't expose alpha modes.  Callers can use this
     /// to hide the overlay window in those environments instead of
-    /// painting full-screen opaque black on top of everything.
+    /// painting full-screen opaque black on top of everything
     pub fn alpha_capable(&self) -> bool {
         !matches!(self.config.alpha_mode, wgpu::CompositeAlphaMode::Opaque)
     }
@@ -253,10 +253,10 @@ pub(crate) fn build_pipeline(
 // ─── Surface helpers ──────────────────────────────────────────────────────────
 
 /// Prefer non-sRGB (linear byte) formats so color values fed into the shader
-/// land in the framebuffer 1:1 — matching Swift's `MTKView.colorPixelFormat =
-/// .bgra8Unorm`.  With a `*UnormSrgb` surface wgpu would gamma-encode the
-/// shader output (linear → sRGB) and mid-tone blends would render noticeably
-/// brighter than the Swift reference.
+/// land in the framebuffer 1:1, matching Swift's `MTKView.colorPixelFormat =
+/// .bgra8Unorm`. With a `*UnormSrgb` surface wgpu would gamma-encode the
+/// shader output (linear -> sRGB) and mid-tone blends would render noticeably
+/// brighter than the Swift reference
 fn prefer_format(caps: &wgpu::SurfaceCapabilities) -> wgpu::TextureFormat {
     for &f in &[
         wgpu::TextureFormat::Bgra8Unorm,
@@ -267,8 +267,8 @@ fn prefer_format(caps: &wgpu::SurfaceCapabilities) -> wgpu::TextureFormat {
         if caps.formats.contains(&f) { return f; }
     }
     // Driver bug guard: wgpu specifies `formats` as non-empty, but a
-    // misbehaving driver could in principle return an empty list.
-    // Falling back to a hard-coded `Bgra8Unorm` keeps us from indexing
+    // misbehaving driver could in principle return an empty list. Falling
+    // back to a hard-coded `Bgra8Unorm` keeps us from indexing
     // `formats[0]` past the end and crashing the renderer
     caps.formats.first().copied().unwrap_or(wgpu::TextureFormat::Bgra8Unorm)
 }

--- a/rust/crates/exhale-render/src/shaders/overlay.wgsl
+++ b/rust/crates/exhale-render/src/shaders/overlay.wgsl
@@ -1,10 +1,10 @@
-// overlay.wgsl — full port of OverlayShaders.metal
+// overlay.wgsl: full port of OverlayShaders.metal
 //
-// Uniform struct layout (112 bytes).
-// WGSL auto-pads 12 bytes between ripple_enabled and background_color so that
-// background_color sits at offset 64 (vec4<f32> alignment = 16).  The Rust
-// OverlayUniforms struct adds the same 12 bytes as explicit _pad0/1/2 fields
-// so both sides agree exactly.
+// Uniform struct layout (112 bytes). WGSL auto-pads 12 bytes between
+// ripple_enabled and background_color so that background_color sits at
+// offset 64 (vec4<f32> alignment = 16).  The Rust OverlayUniforms struct
+// adds the same 12 bytes as explicit _pad0/1/2 fields so both sides
+// agree exactly
 
 struct OverlayUniforms {
     viewport_size:         vec2<f32>,  // offset  0
@@ -21,7 +21,7 @@ struct OverlayUniforms {
     ripple_enabled:        u32,        // offset 48
     display_mode:          u32,        // offset 52  0=normal 1=paused 2=stopped
     // WGSL inserts 8 bytes of implicit padding here (offsets 56–63)
-    // so that the vec4 below lands at offset 64.
+    // so that the vec4 below lands at offset 64
     background_color:      vec4<f32>,  // offset 64
     inhale_color:          vec4<f32>,  // offset 80
     exhale_color:          vec4<f32>,  // offset 96
@@ -37,8 +37,8 @@ struct VertexOutput {
     @location(0)       ndc:      vec2<f32>,
 }
 
-/// Fullscreen triangle — no vertex buffer required.
-/// Three vertices cover the entire clip-space quad.
+/// Fullscreen triangle, no vertex buffer required. Three vertices cover
+/// the entire clip-space quad
 @vertex
 fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
     var positions = array<vec2<f32>, 3>(
@@ -68,8 +68,8 @@ fn pixel_from_ndc(ndc: vec2<f32>) -> vec2<f32> {
     return uv * u.viewport_size;
 }
 
-/// Premultiply alpha and apply overlay opacity in one step.
-/// Matches Metal's `applyOverlayOpacityPremultiplied`.
+/// Premultiply alpha and apply overlay opacity in one step. Matches
+/// Metal's `applyOverlayOpacityPremultiplied`
 fn apply_premultiplied(color: vec4<f32>) -> vec4<f32> {
     let a = color.a * u.overlay_opacity;
     return vec4<f32>(color.rgb * a, a);
@@ -77,12 +77,12 @@ fn apply_premultiplied(color: vec4<f32>) -> vec4<f32> {
 
 // ─── Phase color ──────────────────────────────────────────────────────────────
 
-/// Return the flat phase color — inhale_color during inhale/holdAfterInhale,
-/// exhale_color during exhale/holdAfterExhale.
+/// Return the flat phase color: inhale_color during inhale/holdAfterInhale,
+/// exhale_color during exhale/holdAfterExhale
 ///
 /// Matches Swift ContentView's `colorTransitionFill` which uses `lastColor` =
 /// a flat phase color.  The color switches INSTANTLY at phase boundaries;
-/// only the shape size/progress animates.
+/// only the shape size/progress animates
 fn phase_color() -> vec4<f32> {
     if u.phase == 0u || u.phase == 1u {
         return u.inhale_color;
@@ -90,28 +90,28 @@ fn phase_color() -> vec4<f32> {
     return u.exhale_color;
 }
 
-/// Color used for the screen-edge ripple.
+/// Color used for the screen-edge ripple
 ///
 /// Picks the color of the NEXT phase so the ripple stands out against
-/// whatever the current fill is painting:
+/// whatever the current fill is painting
 ///   • HoldAfterInhale (phase 1): screen is currently filled with
 ///     `inhale_color` (e.g. red).  Ripple uses `exhale_color` (blue)
 ///     so it reads against the red fill and previews where the next
-///     phase is heading.
+///     phase is heading
 ///   • HoldAfterExhale (phase 3): screen is empty / background-only
-///     from the exhale's shrink.  Ripple uses `inhale_color` (red) —
+///     from the exhale's shrink.  Ripple uses `inhale_color` (red),
 ///     same "next phase's color" rule, and red against the dark/
-///     background-tinted backdrop is highly visible.
+///     background-tinted backdrop is highly visible
 ///
 /// Cross-phase fade-out (the first 10 % of the next phase, where
-/// `rippleOpacity` fades from 1 → 0): the ripple keeps the colour
+/// `rippleOpacity` fades from 1 -> 0): the ripple keeps the colour
 /// it had during the hold it's fading FROM, so the transition reads
-/// as a single continuous animation rather than a colour swap.  That
-/// translates to:
+/// as a single continuous animation rather than a colour swap. That
+/// translates to
 ///   • Exhale (phase 2): fading out the HoldAfterInhale ripple
-///     (which was `exhale_color`) — so still `exhale_color`.
+///     (which was `exhale_color`), so still `exhale_color`
 ///   • Inhale (phase 0): fading out the HoldAfterExhale ripple
-///     (which was `inhale_color`) — so still `inhale_color`.
+///     (which was `inhale_color`), so still `inhale_color`
 fn ripple_color() -> vec4<f32> {
     if u.phase == 1u || u.phase == 2u {
         return u.exhale_color;
@@ -134,7 +134,7 @@ fn gradient_circle(base: vec4<f32>, pixel: vec2<f32>, _bg: vec4<f32>) -> vec4<f3
     // constant and fade only alpha so transparent zones at the gradient's
     // endpoints don't reveal a dark wallpaper as a perceived "ring."
     // Smoothstep softens the visual falloff
-    if u.gradient_mode == 1u { // Inner: center invisible → outer edge fully base
+    if u.gradient_mode == 1u { // Inner: center invisible -> outer edge fully base
         let t = smoothstep(0.0, 1.0, clamp01(dist / radius));
         return vec4<f32>(base.rgb, base.a * t);
     }
@@ -158,7 +158,7 @@ fn gradient_rectangle(base: vec4<f32>, pixel: vec2<f32>, rect_h: f32, _bg: vec4<
     // and fading only alpha keeps any wallpaper bleed-through harmonious
     // with the base hue. Smoothstep softens the falloff so the transition
     // isn't a perceptual band even on darker wallpapers
-    if u.gradient_mode == 1u { // Inner: bottom invisible → top fully base
+    if u.gradient_mode == 1u { // Inner: bottom invisible -> top fully base
         let t = smoothstep(0.0, 1.0, y01);
         return vec4<f32>(base.rgb, base.a * t);
     }
@@ -171,13 +171,13 @@ fn gradient_rectangle(base: vec4<f32>, pixel: vec2<f32>, rect_h: f32, _bg: vec4<
 
 // ─── Screen-edge ripple ───────────────────────────────────────────────────────
 
-/// Gaussian band sweeping the screen perimeter during hold phases.
-/// Returns a scalar [0, 1] brightness contribution.
+/// Gaussian band sweeping the screen perimeter during hold phases. Returns
+/// a scalar [0, 1] brightness contribution
 ///
-/// Perimeter parameterisation (same as Metal):
+/// Perimeter parameterisation (same as Metal)
 ///   0 = bottom-center, 0.5 = top-center (mirrored left/right)
-///   HoldAfterInhale: front sweeps 0 → 1
-///   HoldAfterExhale: front sweeps 1 → 0
+///   HoldAfterInhale: front sweeps 0 -> 1
+///   HoldAfterExhale: front sweeps 1 -> 0
 fn screen_edge_ripple(pixel: vec2<f32>) -> f32 {
     let W = u.viewport_size.x;
     let H = u.viewport_size.y;
@@ -191,8 +191,8 @@ fn screen_edge_ripple(pixel: vec2<f32>) -> f32 {
     // Swift: borderUnit = min(w, h) * 0.04
     let border_unit  = min(W, H) * 0.04;
 
-    // Stroke + blur half-extents. Stark: 2× borderUnit stroke, no blur.
-    // Gradient: 3× borderUnit stroke + 2× borderUnit blur.
+    // Stroke + blur half-extents: stark gets 2× borderUnit stroke and no blur;
+    // gradient gets 3× borderUnit stroke and 2× borderUnit blur
     let use_gradient = u.ripple_enabled == 2u;
     let stroke_half  = select(border_unit, border_unit * 1.5, use_gradient);
     let blur_radius  = select(0.0, border_unit * 2.0, use_gradient);
@@ -221,11 +221,11 @@ fn screen_edge_ripple(pixel: vec2<f32>) -> f32 {
 
     let perim = clamp(perim_param / half_perim, 0.0, 1.0);
 
-    // Swift's holdProgress per phase:
-    //   HoldAfterInhale (phase 1): 0 → 1
-    //   HoldAfterExhale (phase 3): 1 → 0
+    // Swift's holdProgress per phase
+    //   HoldAfterInhale (phase 1): 0 -> 1
+    //   HoldAfterExhale (phase 3): 1 -> 0
     //   Exhale (phase 2), cross-phase fade: frozen at 1 (end of inhale-hold)
-    //   Inhale (phase 0), cross-phase fade: frozen at 0 (end of exhale-hold —
+    //   Inhale (phase 0), cross-phase fade: frozen at 0 (end of exhale-hold,
     //     but trail/band collapse to [0,0] so nothing draws; Swift quirk preserved)
     var hp: f32;
     if u.phase == 1u {
@@ -238,9 +238,9 @@ fn screen_edge_ripple(pixel: vec2<f32>) -> f32 {
         hp = 0.0;
     }
 
-    // Swift's isExhale is true only during HoldAfterExhale (phase 3).
-    // During inhale/exhale, isExhale is false because holdProgress is 0 in that
-    // branch. Trail/band formulas below follow Swift exactly.
+    // Swift's isExhale is true only during HoldAfterExhale (phase 3). During
+    // inhale/exhale, isExhale is false because holdProgress is 0 in that
+    // branch. Trail/band formulas below follow Swift exactly
     let is_exhale_hold = u.phase == 3u;
 
     var trail_from: f32;
@@ -259,25 +259,25 @@ fn screen_edge_ripple(pixel: vec2<f32>) -> f32 {
         band_to    = hp;
     }
 
-    // Along-path edge softening: blur radius in pixels → perim-param units.
+    // Along-path edge softening: blur radius in pixels -> perim-param units
     let along_b  = max(blur_radius / max(half_perim, 1.0), 1e-4);
     let in_trail = smoothstep(trail_from - along_b, trail_from + along_b, perim)
                  * (1.0 - smoothstep(trail_to - along_b, trail_to + along_b, perim));
     let in_band  = smoothstep(band_from - along_b, band_from + along_b, perim)
                  * (1.0 - smoothstep(band_to - along_b, band_to + along_b, perim));
 
-    // Perpendicular stroke — crisp for stark, blur-softened edge for gradient.
+    // Perpendicular stroke: crisp for stark, blur-softened edge for gradient
     let perp_b = max(blur_radius, 1e-4);
     let perp   = 1.0 - smoothstep(stroke_half - perp_b, stroke_half + perp_b, min_dist);
 
     // Swift trail opacity = 0.25, band opacity = 0.8. Take the max so the band
-    // rides on top of the trail rather than double-counting.
+    // rides on top of the trail rather than double-counting
     let intensity = max(in_trail * 0.25, in_band * 0.80) * perp;
 
     // rippleOpacity: Swift holds it at 1 during the hold phase, then fades it
-    // 1→0 over the first 10% of the following inhale/exhale. hold_time carries
+    // 1 -> 0 over the first 10% of the following inhale/exhale. hold_time carries
     // the LINEAR phase progress (not eased) so 10% of hold_time == 10% of the
-    // wall-clock phase, matching Swift's `.linear(duration: duration * 0.1)`.
+    // wall-clock phase, matching Swift's `.linear(duration: duration * 0.1)`
     var ripple_opacity: f32 = 1.0;
     if u.phase == 0u || u.phase == 2u {
         ripple_opacity = 1.0 - smoothstep(0.0, 0.10, u.hold_time);
@@ -289,14 +289,14 @@ fn screen_edge_ripple(pixel: vec2<f32>) -> f32 {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    // Stopped (display_mode == 2): overlay is completely transparent — matches
-    // Swift ContentView `Color.clear` when `!isAnimating && !isPaused`.
+    // Stopped (display_mode == 2): overlay is completely transparent, matches
+    // Swift ContentView `Color.clear` when `!isAnimating && !isPaused`
     if u.display_mode == 2u || u.overlay_opacity <= 0.0001 {
         return vec4<f32>(0.0, 0.0, 0.0, 0.0);
     }
 
-    // Paused (display_mode == 1): flat background-colour tint, no animation shape —
-    // matches Swift ContentView showing `backgroundColorWithoutAlpha.opacity(overlayOpacity)`.
+    // Paused (display_mode == 1): flat background-colour tint, no animation shape,
+    // matches Swift ContentView showing `backgroundColorWithoutAlpha.opacity(overlayOpacity)`
     if u.display_mode == 1u {
         let a = u.overlay_opacity;
         return vec4<f32>(u.background_color.rgb * a, a);   // premultiplied
@@ -304,9 +304,10 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     let pixel = pixel_from_ndc(in.ndc);
 
-    // background_opacity = min(bg.a, overlay_opacity) — the final background alpha,
-    // matching Swift's .opacity(min(bgAlpha, overlayOpacity)) on the background layer.
-    // Background pixels must NOT have overlay_opacity applied again; only shape pixels do.
+    // background_opacity = min(bg.a, overlay_opacity), the final background
+    // alpha, matching Swift's .opacity(min(bgAlpha, overlayOpacity)) on the
+    // background layer. Background pixels must NOT have overlay_opacity
+    // applied again; only shape pixels do
     var bg = vec4<f32>(u.background_color.rgb, u.background_opacity);
 
     let pc        = phase_color();
@@ -314,15 +315,15 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // ripple_enabled is toggled on by from_state for hold phases AND during the
     // first 10% of the following inhale/exhale (cross-phase fade). The shader
     // itself applies the fade envelope; this gate just avoids paying the cost
-    // outside those windows.
+    // outside those windows
     let do_ripple = u.ripple_enabled != 0u;
 
     // ── Fullscreen (shape == 0) ───────────────────────────────────────────────
     // Flat inhale/exhale color with no progress-based transition, matching
     // Swift ContentView which switches immediately at phase boundaries. The
-    // ripple sits on top in the ripple_color — invisible when it matches the
+    // ripple sits on top in the ripple_color, invisible when it matches the
     // fill color (phases 0/1/3) and a visible cross-phase fade during phase 2
-    // where fill=exhale but ripple=inhale.
+    // where fill=exhale but ripple=inhale
     if u.shape == 0u {
         var out = pc;
         if do_ripple {
@@ -340,16 +341,16 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let rect_h      = height * scaled_prog;
 
         if pixel.y <= rect_h {
-            // Inside shape: apply overlay_opacity via apply_premultiplied.
+            // Inside shape: apply overlay_opacity via apply_premultiplied
             var sc = pc;
             if u.gradient_mode != 0u {
                 sc = gradient_rectangle(pc, pixel, rect_h, bg);
             }
             if do_ripple {
                 // Swift band alpha = 0.8, trail = 0.25; screen_edge_ripple returns
-                // intensity in [0, 0.8] so lerp factor is the intensity directly.
-                // Target color is ripple_color (inhale except during HoldAfterExhale),
-                // not the shape fill color — see Swift's `phaseColor = isExhale ? ...`.
+                // intensity in [0, 0.8] so lerp factor is the intensity directly. Target
+                // color is ripple_color (inhale except during HoldAfterExhale), not the
+                // shape fill color, see Swift's `phaseColor = isExhale ? ...`
                 let r = screen_edge_ripple(pixel);
                 sc = lerp_color(sc, rpc, r);
             }
@@ -359,8 +360,9 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
             let r = screen_edge_ripple(pixel);
             return apply_premultiplied(lerp_color(bg, rpc, r));
         }
-        // Background-only pixel: alpha is already background_opacity = min(bg.a, overlay_opacity).
-        // Do NOT multiply by overlay_opacity again — matches Swift's separate background layer.
+        // Background-only pixel: alpha is already background_opacity =
+        // min(bg.a, overlay_opacity). Do NOT multiply by overlay_opacity again,
+        // matches Swift's separate background layer
         return vec4<f32>(bg.rgb * bg.a, bg.a);
     }
 
@@ -374,15 +376,15 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     let min_dim   = min(u.viewport_size.x, u.viewport_size.y);
     let prog_sq   = u.progress * u.progress;
     let inner_r   = max((min_dim * prog_sq * u.max_circle_scale) * 0.5, 0.0);
-    // "On" gradient doubles the visible circle radius (matches Swift gradientScale=2 * bakedSize).
+    // "On" gradient doubles the visible circle radius (matches Swift gradientScale=2 * bakedSize)
     let visible_r = inner_r * max(u.circle_gradient_scale, 1.0);
 
     if length(pixel - center) <= visible_r {
-        // Inside shape: apply overlay_opacity via apply_premultiplied.
-        // Ripple target is `rpc` (next-phase colour), matching the
-        // rectangle path above — passing `pc` here was an older
-        // bug that made the circle's ripple always match the fill
-        // colour and disappear visually during HoldAfterInhale.
+        // Inside shape: apply overlay_opacity via apply_premultiplied. Ripple
+        // target is `rpc` (next-phase colour), matching the rectangle path
+        // above: passing `pc` here was an older bug that made the circle's
+        // ripple always match the fill colour and disappear visually during
+        // HoldAfterInhale
         if do_ripple {
             let r = screen_edge_ripple(pixel);
             sc = lerp_color(sc, rpc, r);
@@ -393,6 +395,6 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         let r = screen_edge_ripple(pixel);
         return apply_premultiplied(lerp_color(bg, rpc, r));
     }
-    // Background-only pixel — same fix as rectangle above.
+    // Background-only pixel, same fix as rectangle above
     return vec4<f32>(bg.rgb * bg.a, bg.a);
 }

--- a/rust/crates/exhale-render/src/uniforms.rs
+++ b/rust/crates/exhale-render/src/uniforms.rs
@@ -5,9 +5,9 @@ use exhale_core::{
     types::HoldRippleMode,
 };
 
-/// GPU-side uniform buffer matching the WGSL `OverlayUniforms` struct.
+/// GPU-side uniform buffer matching the WGSL `OverlayUniforms` struct
 ///
-/// Memory layout (112 bytes, repr(C)):
+/// Memory layout (112 bytes, repr(C))
 ///
 /// | offset | size | field                |
 /// |--------|------|----------------------|
@@ -29,9 +29,9 @@ use exhale_core::{
 /// |     80 |   16 | inhale_color         |
 /// |     96 |   16 | exhale_color         |
 ///
-/// WGSL naturally pads from offset 52→64 (`vec4<f32>` alignment = 16).
-/// Rust's repr(C) does not, so two explicit `u32` padding fields are needed
-/// after display_mode.
+/// WGSL naturally pads from offset 52 -> 64 (`vec4<f32>` alignment = 16). Rust's
+/// repr(C) doesn't, so two explicit `u32` padding fields are needed after
+/// display_mode
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct OverlayUniforms {
@@ -56,7 +56,7 @@ pub struct OverlayUniforms {
 }
 // Total: 112 bytes
 
-/// `display_mode` values for the shader.
+/// `display_mode` values for the shader
 pub mod display_mode {
     pub const NORMAL:  u32 = 0;
     pub const PAUSED:  u32 = 1;
@@ -64,11 +64,11 @@ pub mod display_mode {
 }
 
 impl OverlayUniforms {
-    /// Build a uniform buffer from the current breathing state and user settings.
+    /// Build a uniform buffer from the current breathing state and user settings
     ///
     /// `max_circle_scale` is passed in (rather than derived from the viewport)
     /// so all monitors can share the primary-monitor scale, matching Swift's
-    /// `getMaxCircleScale()` which snapshots `NSScreen.main` once at onAppear.
+    /// `getMaxCircleScale()` which snapshots `NSScreen.main` once at onAppear
     pub fn from_state(
         state: &BreathingState,
         settings: &Settings,
@@ -81,13 +81,13 @@ impl OverlayUniforms {
 
         // Match Swift: ripple is active during a hold phase with duration > 0,
         // and also stays active during the first 10% of the following inhale/
-        // exhale so the shader can fade rippleOpacity 1 → 0 the way Swift does
-        // (`withAnimation(.linear(duration: duration * 0.1)) { rippleOpacity = 0 }`).
+        // exhale so the shader can fade rippleOpacity 1 -> 0 the way Swift does
+        // (`withAnimation(.linear(duration: duration * 0.1)) { rippleOpacity = 0 }`)
         use exhale_core::types::BreathingPhase;
         let ripple_active = match state.phase {
             BreathingPhase::HoldAfterInhale => settings.post_inhale_hold_duration > 0.0,
             BreathingPhase::HoldAfterExhale => settings.post_exhale_hold_duration > 0.0,
-            // Cross-phase fade windows (preceding hold must have had duration > 0).
+            // Cross-phase fade windows (preceding hold must have had duration > 0)
             BreathingPhase::Exhale => settings.post_inhale_hold_duration > 0.0,
             BreathingPhase::Inhale => settings.post_exhale_hold_duration > 0.0,
         };
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn background_color_at_offset_64() {
-        // This is the critical alignment check: vec4<f32> must be at offset 64.
+        // This is the critical alignment check: vec4<f32> must be at offset 64
         assert_eq!(offset_of!(OverlayUniforms, background_color), 64);
     }
 
@@ -241,14 +241,14 @@ mod tests {
         assert_eq!(u.viewport_size, [1920.0, 1080.0]);
         assert_eq!(u.phase, BreathingPhase::Inhale.shader_value());
         assert!((u.progress - 0.5).abs() < 1e-6);
-        // Default shape is Rectangle → shader value 1
+        // Default shape is Rectangle -> shader value 1
         assert_eq!(u.shape, 1);
-        // Default hold durations are 0 → ripple disabled regardless of phase
+        // Default hold durations are 0 -> ripple disabled regardless of phase
         assert_eq!(u.ripple_enabled, 0);
         // Padding must be zero
         assert_eq!(u._pad1, 0);
         assert_eq!(u._pad2, 0);
-        // max_circle_scale is whatever the caller provided.
+        // max_circle_scale is whatever the caller provided
         assert!((u.max_circle_scale - expected_scale).abs() < 1e-4,
             "max_circle_scale={} expected {expected_scale}", u.max_circle_scale);
     }
@@ -257,7 +257,7 @@ mod tests {
     fn max_circle_scale_passthrough() {
         use exhale_core::types::BreathingPhase;
         let state = BreathingState { phase: BreathingPhase::Inhale, progress: 0.0, hold_time: 0.0 };
-        // Caller supplies the scale — verify it rides through to the uniform.
+        // Caller supplies the scale: verify it rides through to the uniform
         let u = OverlayUniforms::from_state(&state, &Settings::default(), 1000, 1000, 2.5);
         assert!((u.max_circle_scale - 2.5).abs() < 1e-6);
     }
@@ -290,7 +290,7 @@ mod tests {
         let settings = Settings::default();
         let original = OverlayUniforms::from_state(&state, &settings, 800, 600, 4.0 / 3.0);
 
-        // Cast to bytes and back — bytemuck roundtrip.
+        // Cast to bytes and back: bytemuck roundtrip
         let bytes: &[u8] = bytemuck::bytes_of(&original);
         assert_eq!(bytes.len(), 112);
         let restored: OverlayUniforms = *bytemuck::from_bytes(bytes);

--- a/rust/packaging/windows/AppxManifest.xml
+++ b/rust/packaging/windows/AppxManifest.xml
@@ -8,7 +8,7 @@
   Store submission rejects with "publisher does not match".
 
   Version must increase monotonically per Store submission (A.B.C.D; keep
-  D=0 and bump the short version in Cargo.toml — the bundle-msix.ps1
+  D=0 and bump the short version in Cargo.toml; the bundle-msix.ps1
   script derives A.B.C from there).
 
   Reference:
@@ -72,7 +72,7 @@
   <Capabilities>
     <!-- The app is a traditional Win32 desktop binary wrapped in MSIX,
          so it needs `runFullTrust` to run outside the UWP sandbox.
-         No network, no filesystem, no location — matches macOS. -->
+         No network, no filesystem, no location, matching macOS -->
     <rescap:Capability Name="runFullTrust" />
   </Capabilities>
 </Package>

--- a/rust/packaging/windows/store-listing.md
+++ b/rust/packaging/windows/store-listing.md
@@ -1,7 +1,7 @@
 # Microsoft Store listing copy
 
 The Partner Center form field values for the exhale listing (Store ID `9P79Z1NJMZB3`). Build and
-upload mechanics are in [DEPLOYMENT.md](../../../DEPLOYMENT.md#windows--microsoft-store).
+upload mechanics are in [DEPLOYMENT.md](../../../DEPLOYMENT.md#windows-microsoft-store).
 
 ---
 
@@ -12,14 +12,14 @@ A minimal cross-platform breathing overlay: a friendly indicator and reminder to
 
 The overlay is a translucent always-on-top window that gently expands on inhale and contracts on exhale. Inhale, post-inhale hold, exhale, and post-exhale hold durations are all configurable. A good place to start is 5 seconds in and 5 seconds out, which is 6 breaths a minute. Rates from 5 to 7 a minute are the ones that have been tested directly. Box breathing (4 / 4 / 4 / 4) is also supported.
 
-Every claim above is sourced, alongside a ledger of what the research does not support, at https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md
+Every claim above is sourced, alongside a ledger of what the research doesn't support, at https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md
 
 Every action (Start, Stop, Reset, Quit, Preferences) is rebindable to a global keyboard shortcut. Fully keyboard-navigable Preferences panel. Runs as a menu-bar / system-tray app; the overlay itself is click-through so it never interrupts whatever you're doing.
 
-Take breaks if intense feelings arise; it's important not to overdo it.
+Take breaks if intense feelings arise; don't overdo it.
 
 ---
-Disclaimer: The information and guidance provided by this app are intended for general informational purposes only and are not medical advice. The creator is not a medical professional. Always seek the advice of a qualified healthcare provider with any questions about your health, and do not disregard or delay professional medical advice because of this app. Use is at your own risk.
+Disclaimer: The information and guidance provided by this app are intended for general informational purposes only and aren't medical advice. The creator isn't a medical professional. Always seek the advice of a qualified healthcare provider with any questions about your health, and don't disregard or delay professional medical advice because of this app. Use is at your own risk.
 ```
 
 ## Short description (150 char max)
@@ -36,7 +36,7 @@ breathing, mindfulness, focus, breath, reminder, meditation, productivity, calm,
 
 ## What's new in this version
 
-Per-release, so it is **not** pinned here. Take it from the release notes for the tag being
+Per-release, so it's **not** pinned here. Take it from the release notes for the tag being
 submitted. The v2.0.21 text, kept as a shape reference:
 
 ```

--- a/rust/scripts/bundle-appimage.sh
+++ b/rust/scripts/bundle-appimage.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 #
-# Package the Rust exhale binary as a portable Linux AppImage.
+# Package the Rust exhale binary as a portable Linux AppImage
 #
-# Produces (under `rust/target/appimage/`):
-#   exhale-${VERSION}-x86_64.AppImage   — single-file portable Linux app
+# Produces (under `rust/target/appimage/`)
+#   exhale-${VERSION}-x86_64.AppImage: single-file portable Linux app
 #
-# Requirements:
-#   - Linux host (appimagetool is Linux-only; macOS users should let CI run this).
-#   - Rust toolchain with `x86_64-unknown-linux-gnu` target.
+# Requirements
+#   - Linux host (appimagetool is Linux-only; macOS users should let CI run this)
+#   - Rust toolchain with `x86_64-unknown-linux-gnu` target
 #   - System libraries listed in snapcraft.yaml (libx11-dev, libxkbcommon-dev,
 #     libwayland-dev, libglib2.0-dev, libgtk-3-dev, libayatana-appindicator3-dev,
-#     libvulkan-dev, pkg-config).
-#   - `appimagetool` — auto-downloaded into rust/target/appimage/bin if missing.
+#     libvulkan-dev, pkg-config)
+#   - `appimagetool`, auto-downloaded into rust/target/appimage/bin if missing
 #
-# Usage:
+# Usage
 #   rust/scripts/bundle-appimage.sh                    # VERSION from crate
 #   VERSION=2.0.8 rust/scripts/bundle-appimage.sh
 #
@@ -80,7 +80,7 @@ install -m 644 "$RUST_ROOT/packaging/linux/icons/256x256/exhale.png" \
 install -m 644 "$RUST_ROOT/packaging/linux/icons/512x512/exhale.png" \
                                                                 "$APPDIR/usr/share/icons/hicolor/512x512/apps/exhale.png"
 
-# AppImage convention: exhale.desktop + exhale.png + AppRun all at the AppDir root.
+# AppImage convention: exhale.desktop + exhale.png + AppRun all at the AppDir root
 install -m 644 "$RUST_ROOT/packaging/linux/exhale.desktop"      "$APPDIR/exhale.desktop"
 install -m 644 "$PKG_DIR/exhale.png"                            "$APPDIR/exhale.png"
 
@@ -94,7 +94,7 @@ SH
 chmod +x "$APPDIR/AppRun"
 
 # ── 4. Pack AppImage ─────────────────────────────────────────────────────────
-log "appimagetool $APPDIR → $OUT_APPIMAGE"
+log "appimagetool $APPDIR -> $OUT_APPIMAGE"
 ARCH=x86_64 "$APPIMAGETOOL" --no-appstream "$APPDIR" "$OUT_APPIMAGE"
 
 log "success"

--- a/rust/scripts/bundle-mas.sh
+++ b/rust/scripts/bundle-mas.sh
@@ -1,38 +1,38 @@
 #!/usr/bin/env bash
 #
 # Build + sign + package the Rust exhale binary into a Mac App Store
-# submission (.pkg), ready for Transporter upload.
+# submission (.pkg), ready for Transporter upload
 #
-# Produces (under `rust/target/mas/`):
-#   exhale.app          — signed .app bundle (for local TestFlight/install QA)
-#   exhale.pkg          — signed installer package (upload via Transporter)
+# Produces (under `rust/target/mas/`)
+#   exhale.app          : signed .app bundle (for local TestFlight/install QA)
+#   exhale.pkg          : signed installer package (upload via Transporter)
 #
-# Requirements:
+# Requirements
 #   - macOS with Xcode command-line tools (codesign, productbuild, iconutil,
-#     sips, lipo, plutil).
-#   - rustup targets: aarch64-apple-darwin, x86_64-apple-darwin.
-#     Installed automatically on first run.
+#     sips, lipo, plutil)
+#   - rustup targets: aarch64-apple-darwin, x86_64-apple-darwin. Installed
+#     automatically on first run
 #   - Two signing identities in the login keychain (from Apple Developer
-#     → "Certificates, IDs & Profiles"):
-#         "Apple Distribution: …"                    — signs the .app
-#         "3rd Party Mac Developer Installer: …"     — signs the .pkg
-#     Check with: `security find-identity -v -p basic`.
+# -> "Certificates, IDs & Profiles")
+#         "Apple Distribution: …"                    : signs the .app
+#         "3rd Party Mac Developer Installer: …"     : signs the .pkg
+#     Check with: `security find-identity -v -p basic`
 #     ("Apple Distribution" is the modern unified iOS+macOS App Store cert;
 #      the legacy "3rd Party Mac Developer Application" still works but
-#      Apple no longer issues it — select "Apple Distribution" in the
+#      Apple no longer issues it, select "Apple Distribution" in the
 #      portal when creating new certs.)
 #   - A Mac App Store provisioning profile for bundle ID
 #     `peterklingelhofer.exhale`, download from developer.apple.com and
 #     save as `rust/signing/exhale.provisionprofile`  (or point
-#     `PROVISION_PROFILE` env var at any path).
+#     `PROVISION_PROFILE` env var at any path)
 #
-# Usage:
+# Usage
 #   rust/scripts/bundle-mas.sh                           # default version
 #   VERSION=2.0.8 BUILD=208 rust/scripts/bundle-mas.sh   # override version
 #   PROVISION_PROFILE=/path/to/exhale.provisionprofile \
 #       rust/scripts/bundle-mas.sh                       # override profile
 #
-# Environment overrides:
+# Environment overrides
 #   APP_IDENT       default: "Apple Distribution: …VZCHHV7VNW…"
 #   INSTALLER_IDENT default: "3rd Party Mac Developer Installer: …VZCHHV7VNW…"
 #   VERSION         default: cargo version from Cargo.toml (bumped manually)
@@ -40,8 +40,8 @@
 #                            uploads to MAS; survives resubmissions)
 #   PROVISION_PROFILE default: rust/signing/exhale.provisionprofile
 #   DRY_RUN=1       skip identity checks, profile requirement, and signing;
-#                   emit an unsigned exhale.app for local validation.  Useful
-#                   before the MAS distribution certs are installed.
+#                   emit an unsigned exhale.app for local validation. Useful
+#                   before the MAS distribution certs are installed
 
 set -euo pipefail
 
@@ -70,13 +70,13 @@ INSTALLER_IDENT="${INSTALLER_IDENT:-3rd Party Mac Developer Installer: Peter Kli
 PROVISION_PROFILE="${PROVISION_PROFILE:-$RUST_ROOT/signing/exhale.provisionprofile}"
 
 # Read version from crate Cargo.toml unless overridden.  The crate currently
-# reads 0.1.0, so users will almost always want to override — but we match the
-# Swift 2.0.7 → 2.0.8 expectation by default so a fresh run produces a
-# submission one higher than the current MAS listing.
+# reads 0.1.0, so users will almost always want to override, but we match the
+# Swift 2.0.7 -> 2.0.8 expectation by default so a fresh run produces a
+# submission one higher than the current MAS listing
 VERSION="${VERSION:-2.0.22}"
 # CFBundleVersion. Apple requires this to be monotonically increasing
 # across all uploads (rejected ones count too), so derive from git commit
-# count rather than VERSION — see release.sh for the full story
+# count rather than VERSION, see release.sh for the full story
 BUILD="${BUILD:-$(( $(git -C "$REPO_ROOT" rev-list --count HEAD 2>/dev/null || echo 0) + 10000 ))}"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -88,7 +88,7 @@ for t in cargo codesign productbuild iconutil sips lipo plutil rustup; do need "
 
 DRY_RUN="${DRY_RUN:-0}"
 
-# SKIP_PKG=1 — skip productbuild, emit a signed `.app.zip` instead. Set in CI
+# SKIP_PKG=1: skip productbuild, emit a signed `.app.zip` instead. Set in CI
 # because productbuild deterministically hangs on macos-latest runners (likely
 # OCSP / CRL revocation check on an unreachable endpoint that the codesign
 # code path doesn't trigger). Local devs leave it off so they keep getting a
@@ -100,8 +100,8 @@ SKIP_PKG="${SKIP_PKG:-0}"
 
 if [[ "$DRY_RUN" != "1" ]]; then
     [[ -f "$PROVISION_PROFILE" ]] || die "provisioning profile missing: $PROVISION_PROFILE
-  → download from developer.apple.com → Certificates → Profiles, save as that path
-  → or export PROVISION_PROFILE=/path/to/file.provisionprofile before re-running"
+ -> download from developer.apple.com -> Certificates -> Profiles, save as that path
+ -> or export PROVISION_PROFILE=/path/to/file.provisionprofile before re-running"
 
     security find-identity -v -p basic | grep -q "$APP_IDENT"       || die "signing identity not found: $APP_IDENT"
     security find-identity -v -p basic | grep -q "$INSTALLER_IDENT" || die "installer identity not found: $INSTALLER_IDENT"
@@ -133,7 +133,7 @@ mkdir -p "$BUILD_DIR"
 
 ICONSET="$BUILD_DIR/AppIcon.iconset"
 mkdir -p "$ICONSET"
-# iconutil expects these exact names; each pair is (N×N, N×N@2x = 2N).
+# iconutil expects these exact names; each pair is (N×N, N×N@2x = 2N)
 for pair in "16:32" "32:64" "128:256" "256:512" "512:1024"; do
     one="${pair%:*}"; two="${pair#*:}"
     sips -z "$one" "$one" "$MASTER_ICON" --out "$ICONSET/icon_${one}x${one}.png"     >/dev/null
@@ -147,15 +147,15 @@ rm -rf "$APP_BUNDLE"
 CONTENTS="$APP_BUNDLE/Contents"
 mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Resources"
 
-# Universal binary.
+# Universal binary
 lipo -create "$BIN_ARM" "$BIN_X86" -output "$CONTENTS/MacOS/$EXECUTABLE"
 chmod +x "$CONTENTS/MacOS/$EXECUTABLE"
 
-# Icon.
+# Icon
 cp "$BUILD_DIR/AppIcon.icns" "$CONTENTS/Resources/AppIcon.icns"
 
 # Info.plist.  Use plutil to emit a canonical binary plist; Apple accepts both
-# XML and binary, but binary avoids whitespace diffs between runs.
+# XML and binary, but binary avoids whitespace diffs between runs
 cat > "$CONTENTS/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -184,18 +184,18 @@ cat > "$CONTENTS/Info.plist" <<PLIST
 PLIST
 plutil -lint "$CONTENTS/Info.plist" >/dev/null || die "Info.plist failed plutil lint"
 
-# Entitlements — mirror the Swift app exactly (sandbox + user-selected
+# Entitlements: mirror the Swift app exactly (sandbox + user-selected
 # read-only).  No network, no camera, no hotkey entitlement (we ship the
-# MAS build with `--no-default-features`, which drops the hotkey crate).
+# MAS build with `--no-default-features`, which drops the hotkey crate)
 #
 # `application-identifier` + `team-identifier` MUST be present in the
 # binary's code signature and must match the embedded provisioning profile
 # exactly, or App Store Connect rejects with error 90886.  Derive both
-# from the profile itself so renames/team-changes propagate automatically.
-# Use PlistBuddy instead of `plutil -extract`: plutil's key-path syntax
+# from the profile itself so renames/team-changes propagate automatically. Use
+# PlistBuddy instead of `plutil -extract`: plutil's key-path syntax
 # uses `.` as the separator, which collides with the dotted key names
 # (`com.apple.application-identifier` etc.) that the entitlements plist
-# actually uses.  PlistBuddy uses `:` and handles the real key names.
+# actually uses.  PlistBuddy uses `:` and handles the real key names
 PROF_PLIST=$(mktemp)
 trap 'rm -f "$PROF_PLIST"' EXIT
 security cms -D -i "$PROVISION_PROFILE" > "$PROF_PLIST" \
@@ -219,14 +219,14 @@ cat > "$BUILD_DIR/exhale.entitlements" <<ENT
 ENT
 
 # Embedded provisioning profile.  Apple's installer checks that the embedded
-# profile's entitlements are a superset of the binary's entitlements.
+# profile's entitlements are a superset of the binary's entitlements
 if [[ "$DRY_RUN" != "1" ]]; then
     cp "$PROVISION_PROFILE" "$CONTENTS/embedded.provisionprofile"
     # App Store Connect rejects bundles containing `com.apple.quarantine`
     # (set automatically by browsers on downloaded files like the
     # provisioning profile) with error 91109.  Wipe every xattr from the
-    # whole bundle before signing — any attribute Apple doesn't explicitly
-    # strip is treated as a package-contents violation.
+    # whole bundle before signing: any attribute Apple doesn't explicitly
+    # strip is treated as a package-contents violation
     xattr -cr "$APP_BUNDLE"
 fi
 
@@ -282,7 +282,7 @@ retry_signing() {
 }
 
 if [[ "$DRY_RUN" != "1" ]]; then
-    # Single-binary bundle: no nested executables to sign individually.
+    # Single-binary bundle: no nested executables to sign individually
     retry_signing "codesign --sign" 300 \
         codesign --force --timestamp \
             --entitlements "$BUILD_DIR/exhale.entitlements" \
@@ -294,14 +294,14 @@ if [[ "$DRY_RUN" != "1" ]]; then
 
     if [[ "$SKIP_PKG" != "1" ]]; then
         # ── 6. Signed .pkg for Transporter / App Store Connect ───────────────
-        retry_signing "productbuild → $OUT_PKG" 300 \
+        retry_signing "productbuild -> $OUT_PKG" 300 \
             productbuild --component "$APP_BUNDLE" /Applications \
                 --sign "$INSTALLER_IDENT" \
                 "$OUT_PKG"
     else
-        # SKIP_PKG=1 (CI only): stop after codesign. No .pkg, no .zip.
-        # An Apple-Distribution-signed .app zipped and downloaded directly
-        # cannot launch on a user's Mac — the embedded provisioning profile
+        # SKIP_PKG=1 (CI only): stop after codesign. No .pkg, no .zip. An
+        # Apple-Distribution-signed .app zipped and downloaded directly
+        # can't launch on a user's Mac; the embedded provisioning profile
         # + sandbox entitlements only validate when the package is delivered
         # via the App Store. So shipping a CI-produced .zip just creates a
         # broken download. Mac users go through the App Store badge in the
@@ -313,10 +313,10 @@ fi
 
 # ── 7. Done ──────────────────────────────────────────────────────────────────
 if [[ "$DRY_RUN" == "1" ]]; then
-    log "DRY_RUN complete — unsigned bundle ready for local validation"
+    log "DRY_RUN complete: unsigned bundle ready for local validation"
     printf '\n  %s\n\n' "$APP_BUNDLE"
     echo "to test the unsigned bundle:  open \"$APP_BUNDLE\""
-    echo "(Gatekeeper will warn on first launch — right-click → Open to bypass)"
+    echo "(Gatekeeper will warn on first launch; right-click -> Open to bypass)"
 else
     log "success"
     if [[ "$SKIP_PKG" != "1" ]]; then
@@ -327,14 +327,14 @@ else
         echo "     (xcrun altool was removed in Xcode 15; use Transporter,"
         echo "      xcrun iTMSTransporter, or the App Store Connect REST API.)"
         echo "  2. After processing, test in real sandbox via TestFlight."
-        echo "     (Do not 'sudo installer -pkg …' an MAS-signed .pkg locally —"
+        echo "     (Do not 'sudo installer -pkg …' an MAS-signed .pkg locally:"
         echo "      macOS silently refuses to write the .app since the embedded"
         echo "      provisioning profile is only valid via the App Store /"
         echo "      TestFlight delivery path. Receipt registers anyway, making"
         echo "      it look broken when nothing is wrong.)"
     else
         printf '\n  %s\n\n' "$APP_BUNDLE"
-        echo "SKIP_PKG=1 mode — build smoke test only, no .pkg or .zip."
+        echo "SKIP_PKG=1 mode: build smoke test only, no .pkg or .zip."
         echo "For a real MAS submission, unset SKIP_PKG and re-run locally."
     fi
 fi

--- a/rust/scripts/bundle-msix.ps1
+++ b/rust/scripts/bundle-msix.ps1
@@ -1,29 +1,29 @@
 #
 # Build + sign the Rust exhale binary into an MSIX package for Microsoft
-# Store submission (and sideload testing).
+# Store submission (and sideload testing)
 #
-# Produces (under `rust\target\msix\`):
-#   exhale.msix          — signed MSIX (upload via Partner Center)
+# Produces (under `rust\target\msix\`)
+#   exhale.msix          : signed MSIX (upload via Partner Center)
 #
-# Requirements:
-#   - Windows 10 SDK (10.0.17763 or newer) — provides makeappx.exe + signtool.exe
+# Requirements
+#   - Windows 10 SDK (10.0.17763 or newer), provides makeappx.exe + signtool.exe
 #     Install from: https://developer.microsoft.com/windows/downloads/windows-sdk
 #   - Rust toolchain with x86_64-pc-windows-msvc target
 #   - (Partner-Center upload only) Publisher + Identity Name reserved at
 #     https://partner.microsoft.com/dashboard/windows/overview and pasted into
 #     rust\packaging\windows\AppxManifest.xml before running
-#   - (Signing only) A code-signing cert in PFX form.
+#   - (Signing only) A code-signing cert in PFX form
 #
-# Usage (PowerShell):
+# Usage (PowerShell)
 #   rust\scripts\bundle-msix.ps1                                   # default version
 #   rust\scripts\bundle-msix.ps1 -Version 2.0.8 -Build 208         # override
 #   rust\scripts\bundle-msix.ps1 -CertPath C:\certs\self.pfx `
 #                                -CertPassword (ConvertTo-SecureString "pw" -AsPlainText -Force)
 #   rust\scripts\bundle-msix.ps1 -DryRun                           # skip signing
 #
-# For the Microsoft Store, signing is *optional* here — Partner Center
+# For the Microsoft Store, signing is *optional* here: Partner Center
 # re-signs the submitted MSIX with the Store's own cert.  For sideload /
-# CI smoke tests, pass -CertPath + -CertPassword to self-sign.
+# CI smoke tests, pass -CertPath + -CertPassword to self-sign
 #
 
 [CmdletBinding()]
@@ -53,7 +53,7 @@ function Write-Log($msg)  { Write-Host "[msix] $msg" -ForegroundColor Cyan }
 function Write-Fail($msg) { Write-Host "[msix] error: $msg" -ForegroundColor Red; exit 1 }
 
 function Find-SdkTool($name) {
-    # Walk every installed Windows 10/11 SDK, pick the newest bin\*\x64\$name.
+    # Walk every installed Windows 10/11 SDK, pick the newest bin\*\x64\$name
     $roots = @(
         "${Env:ProgramFiles(x86)}\Windows Kits\10\bin",
         "${Env:ProgramFiles}\Windows Kits\10\bin"
@@ -73,9 +73,9 @@ function Find-SdkTool($name) {
 $MakeAppx = Find-SdkTool "makeappx.exe"
 $SignTool = Find-SdkTool "signtool.exe"
 
-if (-not $MakeAppx) { Write-Fail "makeappx.exe not found — install Windows 10 SDK" }
+if (-not $MakeAppx) { Write-Fail "makeappx.exe not found: install Windows 10 SDK" }
 if (-not $DryRun -and $CertPath -and -not $SignTool) {
-    Write-Fail "signtool.exe not found — install Windows 10 SDK"
+    Write-Fail "signtool.exe not found: install Windows 10 SDK"
 }
 
 # ── 1. Build the Rust binary (release, no-default-features for MAS parity) ──
@@ -107,17 +107,17 @@ $ManifestDst = Join-Path $StageDir "AppxManifest.xml"
 
 # Read via .NET so a BOM on the source file is stripped during decode, and
 # write back with an explicit no-BOM encoder so makeappx doesn't reject the
-# manifest with "Incorrect xml declaration syntax" on Line 1 Col 14.
+# manifest with "Incorrect xml declaration syntax" on Line 1 Col 14
 $manifestText = [System.IO.File]::ReadAllText($ManifestSrc)
 # Coerce any pre-release suffix (e.g. "2.0.8-rc.1") down to the numeric
-# triple MSIX requires; D must be 0 (Microsoft Store rule).
+# triple MSIX requires; D must be 0 (Microsoft Store rule)
 $numericVersion = ($Version -split '-')[0]
 # Case-sensitive replace (-creplace) so we only hit the <Identity Version="…">
 # attribute and leave the lowercase XML declaration `<?xml version="1.0"?>`
 # untouched.  Negative-lookbehind `(?<!\w)` prevents matching inside
-# `MinVersion="…"` or `MaxVersionTested="…"` on the TargetDeviceFamily —
+# `MinVersion="…"` or `MaxVersionTested="…"` on the TargetDeviceFamily,
 # otherwise Partner Center rejects the MSIX with "targets Windows MinVersion
-# <= 10.0.17134.0" because MinVersion got clobbered to the app version.
+# <= 10.0.17134.0" because MinVersion got clobbered to the app version
 $manifestText = $manifestText -creplace '(?<!\w)Version="[^"]+"', "Version=`"$numericVersion.0`""
 [System.IO.File]::WriteAllText($ManifestDst, $manifestText, [System.Text.UTF8Encoding]::new($false))
 
@@ -125,7 +125,7 @@ $manifestText = $manifestText -creplace '(?<!\w)Version="[^"]+"', "Version=`"$nu
 if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out-Null }
 if (Test-Path $OutMsix) { Remove-Item -Force $OutMsix }
 
-Write-Log "makeappx pack → $OutMsix"
+Write-Log "makeappx pack -> $OutMsix"
 & $MakeAppx pack /d $StageDir /p $OutMsix /o
 if ($LASTEXITCODE -ne 0) { Write-Fail "makeappx pack failed" }
 
@@ -139,7 +139,7 @@ if ($DryRun) {
     $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($CertPassword)
     $plainPw = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
     try {
-        Write-Log "signtool sign → $OutMsix"
+        Write-Log "signtool sign -> $OutMsix"
         & $SignTool sign `
             /fd SHA256 `
             /a `
@@ -151,7 +151,7 @@ if ($DryRun) {
         [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
     }
 } else {
-    Write-Log "no -CertPath supplied — MSIX is unsigned"
+    Write-Log "no -CertPath supplied: MSIX is unsigned"
     Write-Log "Microsoft Store will re-sign on submission; for sideload testing"
     Write-Log "pass -CertPath + -CertPassword with a self-signed PFX."
 }

--- a/rust/scripts/cpu_bench.sh
+++ b/rust/scripts/cpu_bench.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 #
-# Live-process CPU bench — samples the real Rust app while it runs.
+# Live-process CPU bench: samples the real Rust app while it runs
 #
-# Methodology mirrors the Swift `measureCPU` helper:
-#   - Phase 1 (baseline):  launch with `is_animating = false` in settings.toml.
-#                          Sample process CPU% 5 × 1 s. Kill.
-#   - Phase 2 (animating): launch with `is_animating = true`.  Sample 5 × 1 s.
-#   - Report delta = max(0, animating − baseline_avg).
+# Methodology mirrors the Swift `measureCPU` helper
+#   - Phase 1 (baseline):  launch with `is_animating = false` in
+#                          settings.toml.  Sample process CPU% 5 × 1 s. Kill
+#   - Phase 2 (animating): launch with `is_animating = true`.  Sample 5 × 1 s
+#   - Report delta = max(0, animating − baseline_avg)
 #
-# Runs all six variants that the Swift PerformanceTests suite covers.
+# Runs all six variants that the Swift PerformanceTests suite covers
 #
 # The script backs up your existing settings.toml, writes a stripped one for
-# each phase, and restores the original on exit (even on ^C).
+# each phase, and restores the original on exit (even on ^C)
 #
-# Usage:
+# Usage
 #   rust/scripts/cpu_bench.sh             # run all 6 variants
 #   rust/scripts/cpu_bench.sh rect_ripple # just one variant (tag match)
 #
-# Requires: macOS, cargo, bash ≥ 4, python3.
+# Requires: macOS, cargo, bash ≥ 4, python3
 
 set -euo pipefail
 
@@ -48,7 +48,7 @@ VARIANTS=(
 # ── Helpers ───────────────────────────────────────────────────────────────────
 log() { printf '\033[2m[bench]\033[0m %s\n' "$*" >&2; }
 
-# Convert ps's MM:SS.ss or HH:MM:SS.ss cpu time string → seconds.
+# Convert ps's MM:SS.ss or HH:MM:SS.ss cpu time string -> seconds
 parse_cputime() {
     python3 - <<PY
 t = "$1".strip()
@@ -132,7 +132,7 @@ run_phase() {
 
     write_settings "$animating" "$shape" "$gradient" "$hold" "$ripple"
 
-    # `RUST_LOG=warn` keeps wgpu from firehosing INFO-level messages.
+    # `RUST_LOG=warn` keeps wgpu from firehosing INFO-level messages
     RUST_LOG=warn "$BIN" >/dev/null 2>&1 &
     APP_PID=$!
     sleep "$WARMUP_SECONDS"
@@ -164,7 +164,7 @@ BIN="$RUST_ROOT/target/release/exhale"
 mkdir -p "$CONFIG_DIR"
 if [[ -f "$CONFIG_FILE" ]]; then
     cp "$CONFIG_FILE" "$BACKUP_FILE"
-    log "backed up settings.toml → $BACKUP_FILE"
+    log "backed up settings.toml -> $BACKUP_FILE"
 fi
 
 # ── Header ────────────────────────────────────────────────────────────────────
@@ -179,9 +179,9 @@ for entry in "${VARIANTS[@]}"; do
         continue
     fi
 
-    log "→ [$tag] baseline"
+    log " -> [$tag] baseline"
     BASELINE=$(run_phase false "$shape" "$gradient" "$hold" "$ripple")
-    log "→ [$tag] animating"
+    log " -> [$tag] animating"
     ANIMATING=$(run_phase true "$shape" "$gradient" "$hold" "$ripple")
 
     python3 - "$tag" "$label" "$BASELINE" "$ANIMATING" <<'PY'
@@ -205,6 +205,6 @@ print()
 PY
 done
 
-echo "Done.  Baseline includes full idle app (tray + event loop + static"
-echo "overlay repainting at compositor cadence).  Delta isolates the"
-echo "controller + state-update cost above that floor."
+echo "Baseline includes full idle app (tray + event loop + static overlay"
+echo "repainting at compositor cadence); delta isolates the controller +"
+echo "state-update cost above that floor."

--- a/rust/scripts/release.sh
+++ b/rust/scripts/release.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # Bump exhale's version string across every place it's pinned, and
-# optionally commit, tag, and push the release.
+# optionally commit, tag, and push the release
 #
-# Files touched:
+# Files touched
 #   rust/crates/exhale-app/Cargo.toml          version = "X.Y.Z"
 #   snap/snapcraft.yaml                        version: 'X.Y.Z'
 #   rust/packaging/windows/AppxManifest.xml    Version="X.Y.Z.0"
@@ -13,14 +13,14 @@
 #   .github/workflows/release.yml              V="X.Y.Z" fallback
 #   rust/Cargo.lock                            via `cargo update -p exhale-app`
 #
-# Usage:
+# Usage
 #   rust/scripts/release.sh 2.0.16              # bump files only
 #   rust/scripts/release.sh 2.0.16 --dry-run    # show diffs, no writes
 #   rust/scripts/release.sh 2.0.16 --tag        # bump + commit + tag + push tag
 #
 # --tag mode: stages only the files above (so unrelated dirty files are safe),
 # commits as "release: vX.Y.Z", pushes the current branch, creates tag
-# vX.Y.Z, and pushes the tag (which triggers the release workflow).
+# vX.Y.Z, and pushes the tag (which triggers the release workflow)
 #
 
 set -euo pipefail
@@ -46,8 +46,8 @@ case "$MODE" in ""|--dry-run|--tag) ;; *)
 # 2021 as v2.0.20 resubmissions, then v2.0.21's default 2021 collided
 # with App Store Connect rejection ID 8a9458f3-...). Using commit count
 # instead gives a monotonic value that doesn't depend on VERSION, plus a
-# 10000 offset to clear the historical 2020–2022 range we already burned.
-# Matches the computation in release.yml + bundle-mas.sh
+# 10000 offset to clear the historical 2020–2022 range we already burned. Matches
+# the computation in release.yml + bundle-mas.sh
 BUILD="$(( $(git rev-list --count HEAD) + 10000 ))"
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -71,8 +71,8 @@ sed_inplace() {
     esac
 }
 
-printf 'bumping exhale → %s (build %s)\n' "$VERSION" "$BUILD"
-[[ "$MODE" == "--dry-run" ]] && echo "(dry run — no files will be modified)"
+printf 'bumping exhale -> %s (build %s)\n' "$VERSION" "$BUILD"
+[[ "$MODE" == "--dry-run" ]] && echo "(dry run, no files will be modified)"
 
 sed_inplace 's/(^version[[:space:]]+=[[:space:]]+")[^"]+(")/\1'"$VERSION"'\2/' \
     rust/crates/exhale-app/Cargo.toml
@@ -80,8 +80,9 @@ sed_inplace 's/(^version[[:space:]]+=[[:space:]]+")[^"]+(")/\1'"$VERSION"'\2/' \
 sed_inplace "s/(^version: ')[^']+(')/\\1${VERSION}\\2/" \
     snap/snapcraft.yaml
 
-# Anchor to line-start whitespace so we only match the <Identity Version="…">
-# attribute, not the <TargetDeviceFamily Min/MaxVersion="…"> siblings.
+# Anchor to line-start whitespace so only the <Identity Version="…">
+# attribute is touched, leaving the <TargetDeviceFamily Min/MaxVersion="…">
+# siblings alone
 sed_inplace 's/(^[[:space:]]+Version=")[0-9]+\.[0-9]+\.[0-9]+\.0(")/\1'"${VERSION}"'.0\2/' \
     rust/packaging/windows/AppxManifest.xml
 
@@ -130,7 +131,7 @@ if [[ "$MODE" != "--tag" ]]; then
 fi
 
 if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-    echo "error: tag v$VERSION already exists — pick a new version" >&2
+    echo "error: tag v$VERSION already exists; pick a new version" >&2
     exit 1
 fi
 

--- a/scripts/generate-citations.py
+++ b/scripts/generate-citations.py
@@ -80,7 +80,7 @@ def load_corpus() -> list[dict]:
             issued = (rec.get("issued", {}).get("date-parts") or [[None]])[0][0]
             if keyed and issued and keyed.group(1) != str(issued):
                 problems.append(
-                    f"{rid}: citekey year {keyed.group(1)} does not match issued year {issued}"
+                    f"{rid}: citekey year {keyed.group(1)} doesn't match issued year {issued}"
                 )
         if rid in seen:
             problems.append(f"{rid}: duplicate id")
@@ -113,7 +113,7 @@ def load_corpus() -> list[dict]:
             problems.append(f"{rid}: openCopy must be an https URL")
         # Absent means citable; only an explicit `false` blocks a record
         # from backing something the binary ships. Written as an opt-OUT so
-        # the corpus does not need touching for the common case, and so the
+        # the corpus doesn't need touching for the common case, and so the
         # blocklist is greppable as four lines rather than inferred from
         # forty-four omissions
         if custom.get("inAppCitable", False) not in (True, False):
@@ -123,7 +123,7 @@ def load_corpus() -> list[dict]:
         if not isinstance(claims, list) or not claims:
             problems.append(f"{rid}: backsClaims must be a non-empty list")
 
-        # A record with no DOI cannot honestly call itself Crossref-verified
+        # A record with no DOI can't call itself Crossref-verified
         if custom.get("verification") == "crossref-verified" and not rec.get("DOI"):
             problems.append(f"{rid}: crossref-verified but carries no DOI")
 
@@ -152,24 +152,24 @@ def check_cross_references(records: list[dict]) -> None:
         raise CorpusError("\n".join("  - " + p for p in problems))
 
 
-# Claims the corpus does not support, kept out of the surfaces that assert them.
+# Claims the corpus doesn't support, kept out of the surfaces that assert them
 #
 # Scope is deliberate. Only surfaces that ASSERT are scanned: store listings and
 # anything compiled into the binary. `docs/` and `README.md` are exempt, because
 # the gaps ledger has to be able to name a claim in order to explain what the
-# evidence actually says about it.
+# evidence actually says about it
 #
-# This is not hypothetical. `snapcraft.yaml` went on shipping the parasympathetic
+# This isn't hypothetical. `snapcraft.yaml` went on shipping the parasympathetic
 # claim to the Snap Store for two days after the README had stopped making it,
 # because a store listing is edited in a different place from a README and
 # nothing connected the two
 UNSUPPORTED_PHRASES: list[tuple[str, str]] = [
     ("engage the parasympathetic nervous system", "gaps ledger 4: the cardiac evidence splits 2-for / 1-against / 1-null"),
     ("engages the parasympathetic nervous system", "gaps ledger 4: the cardiac evidence splits 2-for / 1-against / 1-null"),
-    ("breathe more shallowly", "gaps ledger 1: the measured finding is faster and chest-high, not shallower"),
+    ("breathe more shallowly", "gaps ledger 1: the measured finding is faster and chest-high; no study measured shallower breathing"),
     ("screen apnea", "gaps ledger 1: no peer-reviewed source; the measured effect points the other way"),
     ("email apnea", "gaps ledger 1: no peer-reviewed source; the measured effect points the other way"),
-    ("higher in the chest", "gaps ledger 1: the diaphragmatic-to-thoracic shift is theorised, not measured in screen users"),
+    ("higher in the chest", "gaps ledger 1: the diaphragmatic-to-thoracic shift is theorised; no study has measured it in screen users"),
     ("countermeasure with the most evidence", "no source compares countermeasures, and gaps ledger 5 says slow pacing can add to over-breathing"),
     ("hardware buys nothing", "laborde2021-spb-6cpm-biofeedback reports a valence advantage for biofeedback"),
 ]
@@ -214,7 +214,7 @@ def check_note_links(records: list[dict], text: str, where: str) -> None:
 
     Both the gaps ledger and the README deep-link into the corpus by citekey.
     A rename silently breaks every one of them, and the README is the project's
-    front door, so it is checked on exactly the same footing as the notes
+    front door, so it's checked on exactly the same footing as the notes
     """
     known = {r["id"] for r in records}
     # Only anchors shaped like a citekey are entry references; the rest are
@@ -234,15 +234,15 @@ def check_preset_citekeys(records: list[dict]) -> None:
 
     The preset list is the one place the binary makes a *selection* from the
     literature rather than a statement about it, and a selection is an
-    argument whether or not it is worded as one. Offering five patterns says
+    argument whether or not it's worded as one. Offering five patterns says
     these five are worth a click, so each carries a citekey that never reaches
     the screen and exists only to fail this check.
 
     Four conditions, and the third and fourth are the ones that earn their
-    keep. A record downgraded to tier E is lineage-only and cannot license a
+    keep. A record downgraded to tier E is lineage-only and can't license a
     default. A record marked `inAppCitable: false` is one the design review
     blocklisted from a store-reviewed binary, which is a different judgement
-    from whether it is good evidence: `fincham2023` is the strongest warrant
+    from whether it's good evidence: `fincham2023` is the strongest warrant
     in the corpus and is on that list
     """
     if not PRESETS.exists():
@@ -291,13 +291,13 @@ def check_readme_counts(records: list[dict], text: str) -> None:
     README advertised 42 sources verified 40 / 2 while the corpus held 48
     verified 45 / 2 / 1. Nothing caught it, because a number in prose looks
     exactly like a number in prose. Undercounting is the harmless direction and
-    it is still the project's front door claiming a provenance figure it had
-    not checked, which is the specific failure this whole apparatus exists to
+    it's still the project's front door claiming a provenance figure it
+    hadn't checked, which is the specific failure this whole apparatus exists to
     prevent
     """
     counts = collections.Counter(r["custom"]["verification"] for r in records)
     # Each phrase is matched wherever it appears, so the lede and the research
-    # section cannot drift apart from each other either
+    # section can't drift apart from each other either
     expected = [
         (r"(\d+)\s+sources", len(records), "total sources"),
         (r"(\d+)\s+verified against the Crossref REST API", counts["crossref-verified"], "Crossref"),
@@ -320,7 +320,7 @@ def check_readme_counts(records: list[dict], text: str) -> None:
 def slugify(heading: str) -> str:
     """GitHub's heading-anchor rule, reduced to what these headings use.
 
-    Lowercase, drop everything that is not a word character, space or hyphen,
+    Lowercase, drop everything that isn't a word character, space or hyphen,
     then spaces to hyphens. The corpus headings are plain prose, so the full
     GitHub algorithm (duplicate suffixes, emoji, HTML) buys nothing here
     """
@@ -336,7 +336,7 @@ def check_binary_deep_link(rendered: str) -> None:
     stale. This one is compiled into a binary that stays installed for months,
     so a renamed heading strands a user on the top of a 48-entry list at the
     exact moment they went looking for the limits. Renaming the heading is
-    allowed; renaming it silently is not
+    allowed; renaming it silently isn't
 
     The menu may point either at the file on GitHub or at docs/citations.html,
     which fetches that same file from `main` and renders it. Both are the
@@ -379,7 +379,7 @@ def year(rec: dict) -> str:
 
 
 def locator(rec: dict) -> str:
-    """Volume(issue): pages, omitting whatever the record does not have."""
+    """Volume(issue): pages, omitting whatever the record doesn't have."""
     bits = ""
     if rec.get("volume"):
         bits += str(rec["volume"])
@@ -396,7 +396,7 @@ def render_entry(rec: dict) -> list[str]:
     c = rec["custom"]
     lines = [f'#### `{rec["id"]}`', ""]
 
-    # Titles that already end in their own punctuation should not collect a second period
+    # Titles that already end in their own punctuation shouldn't collect a second period
     tail = "" if rec["title"].rstrip().endswith(("?", "!", ".")) else "."
     # Books name the edition the ISBN resolves to, so the reader can find the same one
     if rec.get("edition"):

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,14 +14,14 @@ description: |
 
   The overlay is a translucent, always-on-top, click-through window that
   gently expands on inhale and contracts on exhale, so it never interrupts
-  whatever you are doing. Inhale, post-inhale hold, exhale, and post-exhale
+  whatever you're doing. Inhale, post-inhale hold, exhale, and post-exhale
   hold durations are all configurable. A good place to start is 5 seconds in
   and 5 seconds out, which is 6 breaths a minute. Rates from 5 to 7 a minute
   are the ones that have been tested directly. Box breathing
   (4 / 4 / 4 / 4) is also supported.
 
-  Every claim above is sourced, alongside a ledger of what the research does
-  not support, at
+  Every claim above is sourced, alongside a ledger of what the research
+  doesn't support, at
   https://github.com/peterklingelhofer/exhale/blob/main/docs/CITATIONS.md
 
   Features:
@@ -34,12 +34,12 @@ description: |
     defaults, open preferences
   - Optional reminder notifications
 
-  Take breaks if intense feelings arise; it is important not to overdo it.
+  Take breaks if intense feelings arise; don't overdo it.
 
   Disclaimer: The information and guidance provided by this app are for
-  general informational purposes only and are not medical advice. The creator
-  is not a medical professional. Always seek the advice of a qualified
-  healthcare provider with any questions about your health, and do not
+  general informational purposes only and aren't medical advice. The creator
+  isn't a medical professional. Always seek the advice of a qualified
+  healthcare provider with any questions about your health, and don't
   disregard or delay professional medical advice because of this app. Use is
   at your own risk.
 
@@ -66,13 +66,13 @@ apps:
 parts:
   # The `rust` plugin can build workspace members directly, but we lean on
   # `override-build` so the invocation mirrors `cargo-deb` / CI exactly and
-  # so we can pin to `--no-default-features` (global-hotkeys off — matches
+  # so we can pin to `--no-default-features` (global-hotkeys off: matches
   # the Mac App Store policy; snap confinement wouldn't grant global-hotkey
-  # access anyway).
+  # access anyway)
   exhale:
     plugin: nil
     # snapcraft.yaml lives at snap/snapcraft.yaml so the project dir is the
-    # repo root; source the whole tree so `override-build` can `cd rust`.
+    # repo root; source the whole tree so `override-build` can `cd rust`
     source: .
     source-type: local
     build-packages:
@@ -90,10 +90,10 @@ parts:
       - libayatana-appindicator3-dev
       - libvulkan-dev
       - libxdo-dev
-    # Keep this list minimal — the `gnome` extension brings in gtk/glib and
+    # Keep this list minimal: the `gnome` extension brings in gtk/glib and
     # most display stack runtimes.  Extra packages here balloon the built
     # snap and have been linked to LXD "Failed to execute pack in instance"
-    # failures on CI. Drop mesa-vulkan-drivers (wgpu falls back to GL).
+    # failures on CI. Drop mesa-vulkan-drivers (wgpu falls back to GL)
     stage-packages:
       - libayatana-appindicator3-1
       - libxdo3
@@ -102,7 +102,7 @@ parts:
 
       # Install a pinned stable rustup toolchain into the build container.
       # snapcraft's build hosts don't ship rust; this mirrors what
-      # `.github/workflows/release.yml` does for the Linux snap job.
+      # `.github/workflows/release.yml` does for the Linux snap job
       if ! command -v cargo >/dev/null 2>&1; then
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
           | sh -s -- -y --default-toolchain stable --profile minimal

--- a/swift/exhale/ContentView.swift
+++ b/swift/exhale/ContentView.swift
@@ -73,7 +73,7 @@ extension Shape {
     }
 }
 
-// Traces half the screen perimeter: bottom-center → corner → side → top-center.
+// Traces half the screen perimeter: bottom-center -> corner -> side -> top-center.
 // Used for the hold-phase ripple effect. `rightSide: true` goes clockwise (right),
 // `rightSide: false` goes counter-clockwise (left).
 struct HalfPerimeterShape: Shape {

--- a/swift/exhale/OverlayShaders.metal
+++ b/swift/exhale/OverlayShaders.metal
@@ -131,13 +131,13 @@ static inline float4 applyGradientRectangle(
 
 // Screen-edge ripple during hold phases.
 // A glowing band sweeps around the screen perimeter.
-// Inhale hold: bottom-center → both sides → top-center (holdTime 0→1)
-// Exhale hold: top-center → both sides → bottom-center (reversed)
+// Inhale hold: bottom-center -> both sides -> top-center (holdTime 0 -> 1)
+// Exhale hold: top-center -> both sides -> bottom-center (reversed)
 //
 // Perimeter parameterization (0 = bottom center, 1 = top center):
-//   Segment 1: bottom edge half  (bottom-center → corner)  length W/2
-//   Segment 2: side edge         (bottom-corner → top-corner) length H
-//   Segment 3: top edge half     (top-corner → top-center)   length W/2
+//   Segment 1: bottom edge half  (bottom-center -> corner)  length W/2
+//   Segment 2: side edge         (bottom-corner -> top-corner) length H
+//   Segment 3: top edge half     (top-corner -> top-center)   length W/2
 //   Half-perimeter = W + H
 // Both left and right halves are mirrored (same param).
 static inline float screenEdgeRipple(float2 pixel, float2 viewportSize, float holdTime, uint phase) {
@@ -152,7 +152,7 @@ static inline float screenEdgeRipple(float2 pixel, float2 viewportSize, float ho
 
     float minDist = min(min(dB, dT), min(dL, dR));
 
-    // Border glow depth — how far inward from the edge the glow reaches
+    // Border glow depth: how far inward from the edge the glow reaches
     float borderDepth = min(W, H) * 0.035f;
 
     // Early exit for pixels far from any edge
@@ -186,7 +186,7 @@ static inline float screenEdgeRipple(float2 pixel, float2 viewportSize, float ho
 
     perimParam = clamp(perimParam / halfPerim, 0.0f, 1.0f);
 
-    // Ripple front: inhale hold sweeps 0→1, exhale hold sweeps 1→0
+    // Ripple front: inhale hold sweeps 0 -> 1, exhale hold sweeps 1 -> 0
     float front = (phase == 3u) ? (1.0f - holdTime) : holdTime;
 
     // Gaussian-shaped glowing band centered on the front

--- a/swift/exhale/SettingsView.swift
+++ b/swift/exhale/SettingsView.swift
@@ -62,7 +62,7 @@ struct SettingsView: View {
 
     var body: some View {
         VStack(spacing: sectionSpacing) {
-            // Controls — pinned at top
+            // Controls, pinned at top
             SectionCard {
                 HStack(spacing: 8) {
                     ControlButton(

--- a/swift/exhaleTests/exhaleTests.swift
+++ b/swift/exhaleTests/exhaleTests.swift
@@ -430,7 +430,7 @@ class MetalBreathingControllerTests: XCTestCase {
         let controller = MetalBreathingController(settingsModel: model)
         controller.startIfNeeded()
 
-        // Should be running (not stopped) — verify by getting state
+        // Should be running; verify by getting state
         let state = controller.getCurrentState()
         XCTAssertNotNil(state)
 
@@ -444,7 +444,7 @@ class MetalBreathingControllerTests: XCTestCase {
         let controller = MetalBreathingController(settingsModel: model)
         controller.startIfNeeded()
 
-        // Controller should be stopped — no crash getting state though
+        // Controller should be stopped, and getting state shouldn't crash
         // (getCurrentState accesses internal queue synchronously)
         let state = controller.getCurrentState()
         XCTAssertNotNil(state)
@@ -557,7 +557,7 @@ class GradientBackgroundOpacityTests: XCTestCase {
         let model = SettingsModel()
         model.backgroundColor = Color.clear
 
-        // cachedBackgroundColorWithoutAlpha strips alpha → alpha=1
+        // cachedBackgroundColorWithoutAlpha strips alpha -> alpha=1
         // This is the value that was incorrectly used in the gradient, causing the dark outline
         XCTAssertEqual(model.cachedBackgroundColorWithoutAlpha.alphaComponent(), 1.0, accuracy: 0.001)
 
@@ -584,17 +584,17 @@ class GradientBackgroundOpacityTests: XCTestCase {
         let model = SettingsModel()
         model.overlayOpacity = 0.25
 
-        // Case 1: transparent background → backgroundOpacity should be 0
+        // Case 1: transparent background -> backgroundOpacity should be 0
         model.backgroundColor = Color.clear
         let bgOpacity1 = min(model.cachedBackgroundAlphaComponent, model.overlayOpacity)
         XCTAssertEqual(bgOpacity1, 0.0, accuracy: 0.001)
 
-        // Case 2: opaque background → backgroundOpacity capped at overlayOpacity
+        // Case 2: opaque background -> backgroundOpacity capped at overlayOpacity
         model.backgroundColor = Color.red
         let bgOpacity2 = min(model.cachedBackgroundAlphaComponent, model.overlayOpacity)
         XCTAssertEqual(bgOpacity2, 0.25, accuracy: 0.001)
 
-        // Case 3: semi-transparent background below overlay → uses bg alpha
+        // Case 3: semi-transparent background below overlay -> uses bg alpha
         model.backgroundColor = Color(red: 1, green: 0, blue: 0, opacity: 0.1)
         let bgOpacity3 = min(model.cachedBackgroundAlphaComponent, model.overlayOpacity)
         XCTAssertEqual(bgOpacity3, 0.1, accuracy: 0.01)
@@ -631,7 +631,7 @@ class SameColorFullscreenTests: XCTestCase {
         model.inhaleColor = color
         model.exhaleColor = color
 
-        // Colors match, but shape is not fullscreen — the optimization only applies to fullscreen
+        // Colors match but the shape isn't fullscreen, so the optimization doesn't apply
         XCTAssertTrue(model.inhaleAndExhaleColorsMatch)
         XCTAssertNotEqual(model.shape, .fullscreen)
     }
@@ -651,7 +651,7 @@ class OverlayUniformsLayoutTests: XCTestCase {
         //   float4 (16) + float4 (16) + float4 (16) = 48
         //   Total = 112
         XCTAssertEqual(MemoryLayout<OverlayUniforms>.stride, 112,
-                        "OverlayUniforms stride changed — update both Swift and Metal struct definitions")
+                        "OverlayUniforms stride changed; update both Swift and Metal struct definitions")
     }
 
     func testStructAlignment() {
@@ -769,7 +769,7 @@ class EasingTableTests: XCTestCase {
     }
 
     func testEasingTableSize() {
-        // Controller uses 1024 samples — verify table generation doesn't crash or truncate
+        // Controller uses 1024 samples; verify table generation doesn't crash or truncate
         let table = (0..<1024).map { i -> Float in
             let t = Double(i) / 1023.0
             return Float(CubicBezierEaseInOut.getValue(t: t, x1: 0.42, y1: 0.0, x2: 0.58, y2: 1.0))
@@ -1515,7 +1515,7 @@ class PerformanceTests: XCTestCase {
         window.contentView = hostingView
         window.orderFront(nil)
 
-        // Warm up — let SwiftUI set up its render pipeline
+        // Warm up: let SwiftUI set up its render pipeline
         RunLoop.main.run(until: Date().addingTimeInterval(0.5))
 
         let sampleCount = 5
@@ -1578,7 +1578,7 @@ class PerformanceTests: XCTestCase {
         //
         // Detect CI via multiple env vars.  Plain `xcodebuild test`
         // does NOT propagate the shell's `CI=true` to the spawned
-        // xctest process — the workflow forwards it via Xcode's
+        // xctest process; the workflow forwards it via Xcode's
         // documented `TEST_RUNNER_<NAME>` build-setting pass-through
         // (see `.github/workflows/test.yml`).  Reading both the
         // forwarded names and the runner-set ones gives multiple
@@ -1592,7 +1592,7 @@ class PerformanceTests: XCTestCase {
         let hasRipple = holdRipple != .off
         // CI thresholds: 15% peak / 10% avg for ripple, 12% / 8% no-ripple.
         // Local thresholds widened from previous (10/8 ripple, 8/6 no-ripple)
-        // to (12/10 ripple, 10/8 no-ripple) — leaves headroom for
+        // to (12/10 ripple, 10/8 no-ripple), which leaves headroom for
         // thermal throttling and other-app interference on dev
         // machines without losing regression sensitivity.  Real
         // regressions land >2x over these numbers anyway.
@@ -1607,11 +1607,11 @@ class PerformanceTests: XCTestCase {
         // Circle gradient is inherently noisier than rectangle because its RadialGradient
         // endRadius changes every frame, making it more sensitive to system load variance.
         XCTAssertLessThan(peakDelta, peakThreshold,
-            "\(label) peak animation CPU \(String(format: "%.1f", peakDelta))% exceeded \(String(format: "%.0f", peakThreshold))% — delta: [\(deltaStr)]",
+            "\(label) peak animation CPU \(String(format: "%.1f", peakDelta))% exceeded \(String(format: "%.0f", peakThreshold))%; delta: [\(deltaStr)]",
             file: file, line: line
         )
         XCTAssertLessThan(avgDelta, avgThreshold,
-            "\(label) average animation CPU \(String(format: "%.1f", avgDelta))% exceeded \(String(format: "%.0f", avgThreshold))% — delta: [\(deltaStr)]",
+            "\(label) average animation CPU \(String(format: "%.1f", avgDelta))% exceeded \(String(format: "%.0f", avgThreshold))%; delta: [\(deltaStr)]",
             file: file, line: line
         )
     }


### PR DESCRIPTION
Removes generated-writing tells from every prose surface: README, DEPLOYMENT, LEARNING, the citation corpus and gaps ledger, the store listings, the published citations page, code comments across the Rust crates, scripts and workflows, and the settings-panel copy.

- No em dashes or arrows; contrasts restated as positives; contractions throughout; no comment ends in a period.
- Every number, citekey, link target and validated README phrase is unchanged, checked by script; the corpus generator check and the core tests pass.
- One settings-panel line changed wording: the drift projection now reads "After an hour the cycle is 46 s, up from 10 s."